### PR TITLE
feat: multi-stage Dockerfile — node:22-alpine + alpine:3.23.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# =============================================================================
+# ssh-access-manager — Dockerfile multi-stage
+# Stage 1 : node:22-alpine  → build Vue.js 3 / Vite
+# Stage 2 : alpine:3.23.4   → image finale container unique
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# STAGE 1 — Build de l'interface Vue.js 3
+# -----------------------------------------------------------------------------
+FROM node:22-alpine AS ui-builder
+
+WORKDIR /ui
+
+COPY ui/package*.json ./
+RUN npm ci
+
+COPY ui/ ./
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# STAGE 2 — Image finale Alpine 3.23.4
+# -----------------------------------------------------------------------------
+FROM alpine:3.23.4
+
+RUN apk update && apk add --no-cache \
+    postgresql18 \
+    postgresql18-client \
+    python3 \
+    py3-pip \
+    py3-setuptools \
+    supervisor \
+    nginx \
+    msmtp \
+    openssh-client \
+    busybox-extras \
+    wget \
+    tzdata && \
+    pip install --no-cache-dir \
+        flask \
+        click \
+        paramiko \
+        psycopg2-binary \
+        pyyaml \
+        --break-system-packages
+
+COPY --from=ui-builder /ui/dist /app/static
+
+COPY app/            /app/app/
+COPY sql/            /app/sql/
+COPY supervisord.conf          /etc/supervisord.conf
+COPY bootstrap.sh              /app/bootstrap.sh
+COPY nginx.conf.template       /app/nginx.conf.template
+COPY msmtp.conf.template       /app/msmtp.conf.template
+COPY crontab                   /etc/crontabs/root
+COPY provision-host.sh         /app/provision-host.sh
+
+RUN chmod +x /app/bootstrap.sh
+
+ENTRYPOINT ["/app/bootstrap.sh"]


### PR DESCRIPTION
Closes #2

- Stage 1 : node:22-alpine → build Vue.js
- Stage 2 : alpine:3.23.4 → image finale
- apk --no-cache : postgresql18, python3, supervisor, nginx, msmtp
- pip : flask, click, paramiko, psycopg2-binary, pyyaml
- ENTRYPOINT bootstrap.sh