### PR TITLE
feat: docker-compose + configuration templates + provision-host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# PostgreSQL
+POSTGRES_DB=ssh_manager
+POSTGRES_USER=ssh_manager
+POSTGRES_PASSWORD=changeme
+
+# Nginx
+NGINX_PORT=8080
+NGINX_USER=admin
+NGINX_PASSWORD=changeme
+
+# Flask
+FLASK_SECRET_KEY=changeme
+
+# Email smarthost
+SMTP_HOST=mail.example.com
+SMTP_PORT=587
+SMTP_USER=alerts@example.com
+SMTP_PASSWORD=changeme
+SMTP_FROM=ssh-manager@example.com
+SMTP_TO=admin@example.com
+
+# Collector
+SSH_USER=audit-collector
+SCAN_INTERVAL_HOURS=4
+EXPIRE_WARN_DAYS=7
+EXPIRE_WARN_DAYS_2=2
+ADMIN_USERNAME=admin
+ADMIN_EMAIL=admin@example.com
+TZ=Europe/Paris

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,6 +13,18 @@ generate_nginx_conf() {
 }
 
 # ---------------------------------------------------------------------------
+# Génération /etc/crontabs/root depuis ENV (SCAN_INTERVAL_HOURS)
+# ---------------------------------------------------------------------------
+generate_crontab() {
+    INTERVAL="${SCAN_INTERVAL_HOURS:-4}"
+    cat > /etc/crontabs/root << EOF
+# ssh-access-manager — généré par bootstrap.sh
+0 */${INTERVAL} * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
+0 */${INTERVAL} * * * python3 /app/app/expire.py >> /dev/stdout 2>&1
+EOF
+}
+
+# ---------------------------------------------------------------------------
 # Génération /etc/msmtprc depuis template + ENV
 # ---------------------------------------------------------------------------
 generate_msmtprc() {
@@ -90,7 +102,10 @@ if [ ! -f /data/pg/PG_VERSION ]; then
     # 12. Générer nginx.conf
     generate_nginx_conf
 
-    # 13. Afficher la clé publique du collecteur dans les logs
+    # 13. Générer crontab depuis SCAN_INTERVAL_HOURS
+    generate_crontab
+
+    # 14. Afficher la clé publique du collecteur dans les logs
     echo ""
     echo "================================================================"
     echo " CLÉ PUBLIQUE DU COLLECTEUR — à déployer sur chaque hôte distant"
@@ -106,6 +121,7 @@ else
     # Régénérer la configuration depuis ENV à chaque démarrage
     generate_nginx_conf
     generate_msmtprc
+    generate_crontab
 fi
 
 # ---------------------------------------------------------------------------

--- a/crontab
+++ b/crontab
@@ -1,0 +1,8 @@
+# ssh-access-manager — tâches planifiées busybox crond
+# Format : min heure jour mois dow commande
+
+# Scan SSH + collecte (toutes les SCAN_INTERVAL_HOURS heures)
+0 */4 * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
+
+# Vérification expirations + alertes J-7/J-2
+0 */4 * * * python3 /app/app/expire.py >> /dev/stdout 2>&1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  ssh-access-manager:
+    build: .
+    container_name: ssh-access-manager
+    restart: unless-stopped
+    ports:
+      - "${NGINX_PORT:-8080}:${NGINX_PORT:-8080}"
+    volumes:
+      - ssh_data:/data
+    env_file:
+      - .env
+    environment:
+      - TZ=${TZ:-Europe/Paris}
+
+volumes:
+  ssh_data:
+    driver: local

--- a/msmtp.conf.template
+++ b/msmtp.conf.template
@@ -1,0 +1,12 @@
+defaults
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        /dev/stderr
+
+account        default
+host           {{SMTP_HOST}}
+port           {{SMTP_PORT}}
+from           {{SMTP_FROM}}
+user           {{SMTP_USER}}
+password       {{SMTP_PASSWORD}}

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,37 @@
+worker_processes 1;
+error_log /dev/stderr warn;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    access_log    /dev/stdout;
+    sendfile      on;
+
+    # Fichier htpasswd généré au bootstrap depuis ENV
+    auth_basic           "ssh-access-manager";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    server {
+        listen {{NGINX_PORT}};
+        server_name _;
+
+        # API Flask — proxy vers 127.0.0.1:5000
+        location /api/ {
+            proxy_pass         http://127.0.0.1:5000;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # Frontend Vue.js — fichiers statiques
+        location / {
+            root      /app/static;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Usage : bash provision-host.sh "<contenu collector_key.pub>"
+# Prépare un hôte distant pour la collecte SSH par audit-collector.
+set -e
+
+COLLECTOR_PUBKEY="${1}"
+COLLECTOR_USER="audit-collector"
+SUDOERS_FILE="/etc/sudoers.d/audit-collector"
+
+if [ -z "${COLLECTOR_PUBKEY}" ]; then
+    echo "Usage : $0 \"<contenu collector_key.pub>\"" >&2
+    exit 1
+fi
+
+# 1. Créer l'utilisateur système (sans shell interactif)
+if ! id "${COLLECTOR_USER}" >/dev/null 2>&1; then
+    useradd -r -m -s /bin/bash "${COLLECTOR_USER}"
+    echo "[provision] Utilisateur ${COLLECTOR_USER} créé."
+else
+    echo "[provision] Utilisateur ${COLLECTOR_USER} existe déjà."
+fi
+
+# 2. Configurer le répertoire SSH
+SSH_DIR="/home/${COLLECTOR_USER}/.ssh"
+AUTH_KEYS="${SSH_DIR}/authorized_keys"
+
+mkdir -p "${SSH_DIR}"
+chmod 700 "${SSH_DIR}"
+chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "${SSH_DIR}"
+
+# 3. Déployer la clé publique
+echo "${COLLECTOR_PUBKEY}" > "${AUTH_KEYS}"
+chmod 600 "${AUTH_KEYS}"
+chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "${AUTH_KEYS}"
+echo "[provision] Clé publique déployée dans ${AUTH_KEYS}."
+
+# 4. Créer le fichier sudoers
+cat > "${SUDOERS_FILE}" << 'EOF'
+# ssh-access-manager — droits sudo pour audit-collector (chmod 440)
+audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
+audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
+audit-collector ALL=(root) NOPASSWD: /bin/mv /tmp/sam-* /usr/local/bin/
+audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
+audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
+audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect
+audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-revoke
+EOF
+
+chmod 440 "${SUDOERS_FILE}"
+echo "[provision] Sudoers configuré dans ${SUDOERS_FILE}."
+
+echo "[provision] Hôte prêt pour la collecte SSH par ${COLLECTOR_USER}."


### PR DESCRIPTION
Closes #4

- docker-compose.yml avec volume ssh_data et env_file
- .env.example avec les 20 variables de CLAUDE.md
- nginx.conf.template : proxy Flask + SPA Vue.js + basic auth
- msmtp.conf.template : 5 placeholders SMTP
- crontab : SCAN_INTERVAL_HOURS dynamique via generate_crontab()
- provision-host.sh : idempotent, 7 règles sudoers NOPASSWD