### PR TITLE
feat: ssh.py — paramiko + RejectPolicy + ensure_scripts + SAM_COLLECT/SAM_REVOKE

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,0 +1,195 @@
+import hashlib
+import io
+import os
+
+import paramiko
+
+import db
+
+KNOWN_HOSTS = os.environ.get("KNOWN_HOSTS", "/data/keys/known_hosts")
+COLLECTOR_KEY = os.environ.get("COLLECTOR_KEY", "/data/keys/collector_key")
+SSH_USER = os.environ.get("SSH_USER", "audit-collector")
+
+SAM_COLLECT_PATH = "/usr/local/bin/sam-collect"
+SAM_REVOKE_PATH = "/usr/local/bin/sam-revoke"
+
+# ---------------------------------------------------------------------------
+# Remote scripts — versioned as Python constants.
+# Deployed via SFTP if absent or if SHA256 hash differs.
+# ---------------------------------------------------------------------------
+
+SAM_COLLECT = b"""#!/bin/sh
+# sam-collect - list all authorized_keys on the system
+set -e
+
+getent passwd | while IFS=: read user _ _ _ _ home _; do
+    keyfile="${home}/.ssh/authorized_keys"
+    [ -f "$keyfile" ] || continue
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -z "$line" ] && continue
+        case "$line" in '#'*) continue ;; esac
+        printf '%s\\t%s\\n' "$user" "$line"
+    done < "$keyfile"
+done
+
+rootkeys="/root/.ssh/authorized_keys"
+if [ -f "$rootkeys" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        [ -z "$line" ] && continue
+        case "$line" in '#'*) continue ;; esac
+        printf 'root\\t%s\\n' "$line"
+    done < "$rootkeys"
+fi
+"""
+
+SAM_REVOKE = b"""#!/bin/sh
+# sam-revoke <fingerprint> - revoke a key by SHA256 fingerprint
+# fingerprint format: SHA256:<base64>
+set -e
+
+TARGET_FP="${1}"
+if [ -z "$TARGET_FP" ]; then
+    echo "Usage: sam-revoke <SHA256:base64>" >&2
+    exit 1
+fi
+
+revoke_from_file() {
+    keyfile="$1"
+    [ -f "$keyfile" ] || return 0
+    tmp=$(mktemp /tmp/sam-XXXXXX)
+    changed=0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            ''|'#'*) printf '%s\\n' "$line" >> "$tmp"; continue ;;
+        esac
+        ktmp=$(mktemp /tmp/sam-XXXXXX)
+        printf '%s\\n' "$line" > "$ktmp"
+        fp=$(ssh-keygen -l -E sha256 -f "$ktmp" 2>/dev/null | awk '{print $2}')
+        rm -f "$ktmp"
+        if [ "$fp" = "$TARGET_FP" ]; then
+            changed=1
+        else
+            printf '%s\\n' "$line" >> "$tmp"
+        fi
+    done < "$keyfile"
+    if [ "$changed" -eq 1 ]; then
+        chmod 600 "$tmp"
+        mv "$tmp" "$keyfile"
+    else
+        rm -f "$tmp"
+    fi
+}
+
+getent passwd | while IFS=: read user _ _ _ _ home _; do
+    revoke_from_file "${home}/.ssh/authorized_keys"
+done
+revoke_from_file "/root/.ssh/authorized_keys"
+"""
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _connect(hostname: str) -> paramiko.SSHClient:
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
+    client.load_host_keys(KNOWN_HOSTS)
+    client.connect(
+        hostname=hostname,
+        username=SSH_USER,
+        key_filename=COLLECTOR_KEY,
+        timeout=15,
+    )
+    return client
+
+
+def _run(client: paramiko.SSHClient, cmd: str) -> tuple[str, str, int]:
+    _, stdout, stderr = client.exec_command(cmd)
+    out = stdout.read().decode()
+    err = stderr.read().decode()
+    rc = stdout.channel.recv_exit_status()
+    return out, err, rc
+
+
+def _remote_sha256(client: paramiko.SSHClient, remote_path: str) -> str | None:
+    out, _, rc = _run(client, f"sha256sum {remote_path} 2>/dev/null")
+    if rc != 0 or not out.strip():
+        return None
+    return out.split()[0]
+
+
+def _deploy_script(
+    client: paramiko.SSHClient,
+    sftp: paramiko.SFTPClient,
+    content: bytes,
+    remote_path: str,
+    tmp_path: str,
+) -> None:
+    sftp.putfo(io.BytesIO(content), tmp_path)
+    name = os.path.basename(remote_path)
+    _run(client, f"sudo /bin/mv {tmp_path} {remote_path}")
+    _run(client, f"sudo /bin/chown root:root {remote_path}")
+    _run(client, f"sudo /bin/chmod 755 {remote_path}")
+
+
+def ensure_scripts(hostname: str, server_id: str) -> None:
+    """
+    Deploy SAM_COLLECT and SAM_REVOKE on the remote host if absent or outdated.
+    Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
+    """
+    client = _connect(hostname)
+    try:
+        sftp = client.open_sftp()
+        for content, remote_path in (
+            (SAM_COLLECT, SAM_COLLECT_PATH),
+            (SAM_REVOKE, SAM_REVOKE_PATH),
+        ):
+            local_hash = _sha256(content)
+            remote_hash = _remote_sha256(client, remote_path)
+            if remote_hash == local_hash:
+                continue
+            name = os.path.basename(remote_path)
+            tmp_path = f"/tmp/{name}"
+            _deploy_script(client, sftp, content, remote_path, tmp_path)
+            db.execute(
+                """
+                INSERT INTO audit_log (action, target_server, details)
+                VALUES (%s, %s, %s::jsonb)
+                """,
+                (
+                    "SCRIPT_DEPLOYED",
+                    server_id,
+                    f'{{"script": "{name}", "hostname": "{hostname}"}}',
+                ),
+            )
+        sftp.close()
+    finally:
+        client.close()
+
+
+def revoke_on_server(hostname: str, fingerprint: str) -> None:
+    """Run sam-revoke on the remote host to remove the key with given fingerprint."""
+    client = _connect(hostname)
+    try:
+        _, err, rc = _run(
+            client, f"sudo {SAM_REVOKE_PATH} '{fingerprint}'"
+        )
+        if rc != 0:
+            raise RuntimeError(
+                f"sam-revoke failed on {hostname} (rc={rc}): {err}"
+            )
+    finally:
+        client.close()
+
+
+def collect_keys(hostname: str) -> list[str]:
+    """Run sam-collect on the remote host and return raw output lines."""
+    client = _connect(hostname)
+    try:
+        out, _, rc = _run(client, f"sudo {SAM_COLLECT_PATH}")
+        if rc != 0:
+            raise RuntimeError(f"sam-collect failed on {hostname}")
+        return [line for line in out.splitlines() if line.strip()]
+    finally:
+        client.close()

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -1,0 +1,191 @@
+import hashlib
+import io
+import os
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import ssh
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(stdout_data=b"", stderr_data=b"", exit_status=0, sha_out=None):
+    """Build a mock paramiko SSHClient."""
+    client = MagicMock()
+    stdout = MagicMock()
+    stderr = MagicMock()
+    stdout.read.return_value = stdout_data
+    stderr.read.return_value = stderr_data
+    stdout.channel.recv_exit_status.return_value = exit_status
+
+    if sha_out is not None:
+        sha_stdout = MagicMock()
+        sha_stdout.read.return_value = sha_out
+        sha_stdout.channel.recv_exit_status.return_value = 0
+        client.exec_command.side_effect = [
+            (MagicMock(), sha_stdout, MagicMock(read=MagicMock(return_value=b""))),
+            (MagicMock(), stdout, stderr),
+            (MagicMock(), stdout, stderr),
+            (MagicMock(), stdout, stderr),
+        ]
+    else:
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+    sftp = MagicMock()
+    client.open_sftp.return_value = sftp
+    return client, sftp
+
+
+# ---------------------------------------------------------------------------
+# RejectPolicy présent sur chaque connexion
+# ---------------------------------------------------------------------------
+
+def test_ssh_connect_uses_reject_policy():
+    with patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy") as mock_policy:
+        client_instance = MagicMock()
+        mock_cls.return_value = client_instance
+        client_instance.connect.side_effect = Exception("stop")
+        try:
+            ssh._connect("host")
+        except Exception:
+            pass
+        client_instance.set_missing_host_key_policy.assert_called_once_with(
+            mock_policy.return_value
+        )
+
+
+def test_ssh_connect_never_uses_auto_add_policy():
+    with patch("ssh.paramiko.SSHClient") as mock_cls:
+        client_instance = MagicMock()
+        mock_cls.return_value = client_instance
+        client_instance.connect.side_effect = Exception("stop")
+        try:
+            ssh._connect("host")
+        except Exception:
+            pass
+        for c in client_instance.set_missing_host_key_policy.call_args_list:
+            assert not isinstance(c[0][0], type), "AutoAddPolicy should never be used"
+
+
+# ---------------------------------------------------------------------------
+# ensure_scripts — déploie si hash différent
+# ---------------------------------------------------------------------------
+
+def test_ssh_ensure_scripts_deploys_when_hash_differs(sample_server):
+    wrong_hash = "0" * 64
+    with patch("ssh._connect") as mock_connect, \
+         patch("ssh.db") as mock_db:
+        client = MagicMock()
+        sftp = MagicMock()
+        mock_connect.return_value = client
+        client.open_sftp.return_value = sftp
+
+        # sha256sum returns wrong hash → triggers deploy
+        stdout_wrong = MagicMock()
+        stdout_wrong.read.return_value = f"{wrong_hash}  /usr/local/bin/sam-collect\n".encode()
+        stdout_wrong.channel.recv_exit_status.return_value = 0
+
+        stdout_ok = MagicMock()
+        stdout_ok.read.return_value = b""
+        stdout_ok.channel.recv_exit_status.return_value = 0
+
+        client.exec_command.return_value = (MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b"")))
+
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"])
+
+        assert sftp.putfo.called
+        assert mock_db.execute.called
+        assert mock_db.execute.call_args[0][1][0] == "SCRIPT_DEPLOYED"
+
+
+def test_ssh_ensure_scripts_skips_when_hash_identical(sample_server):
+    local_hash_collect = ssh._sha256(ssh.SAM_COLLECT)
+    local_hash_revoke = ssh._sha256(ssh.SAM_REVOKE)
+
+    with patch("ssh._connect") as mock_connect, \
+         patch("ssh.db") as mock_db:
+        client = MagicMock()
+        sftp = MagicMock()
+        mock_connect.return_value = client
+        client.open_sftp.return_value = sftp
+
+        call_count = [0]
+        hashes = [local_hash_collect, local_hash_revoke]
+
+        def exec_side_effect(cmd):
+            stdout = MagicMock()
+            h = hashes[call_count[0] % 2]
+            stdout.read.return_value = f"{h}  path\n".encode()
+            stdout.channel.recv_exit_status.return_value = 0
+            call_count[0] += 1
+            return (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
+
+        client.exec_command.side_effect = exec_side_effect
+
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"])
+
+        sftp.putfo.assert_not_called()
+        mock_db.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# revoke_on_server — appelle sam-revoke avec le bon fingerprint
+# ---------------------------------------------------------------------------
+
+def test_ssh_revoke_on_server_calls_sam_revoke_with_fingerprint(sample_key):
+    with patch("ssh._connect") as mock_connect:
+        client = MagicMock()
+        mock_connect.return_value = client
+
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 0
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+        ssh.revoke_on_server("server-test-01", sample_key["fingerprint"])
+
+        cmd = client.exec_command.call_args[0][0]
+        assert "sam-revoke" in cmd
+        assert sample_key["fingerprint"] in cmd
+
+
+def test_ssh_revoke_on_server_raises_on_nonzero_exit(sample_key):
+    with patch("ssh._connect") as mock_connect:
+        client = MagicMock()
+        mock_connect.return_value = client
+
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 1
+        stderr = MagicMock()
+        stderr.read.return_value = b"error"
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+        with pytest.raises(RuntimeError):
+            ssh.revoke_on_server("server-test-01", sample_key["fingerprint"])
+
+
+# ---------------------------------------------------------------------------
+# SAM_COLLECT et SAM_REVOKE — vérifications de contenu
+# ---------------------------------------------------------------------------
+
+def test_ssh_sam_collect_is_bytes():
+    assert isinstance(ssh.SAM_COLLECT, bytes)
+    assert b"authorized_keys" in ssh.SAM_COLLECT
+    assert b"#!/bin/sh" in ssh.SAM_COLLECT
+
+
+def test_ssh_sam_revoke_is_bytes():
+    assert isinstance(ssh.SAM_REVOKE, bytes)
+    assert b"TARGET_FP" in ssh.SAM_REVOKE
+    assert b"mktemp" in ssh.SAM_REVOKE
+    assert b"mv" in ssh.SAM_REVOKE


### PR DESCRIPTION
Closes #7

- RejectPolicy sur toutes les connexions (jamais AutoAddPolicy)
- SAM_COLLECT et SAM_REVOKE versionnés comme constantes bytes
- ensure_scripts() SFTP + hash SHA256 + déploie si différent
- revoke_on_server() via sudo sam-revoke
- collect_keys() via sudo sam-collect
- 8 tests unitaires passent