### PR TITLE
feat: expire.py — expiration automatique + alertes J-7/J-2

### DIFF
--- a/app/expire.py
+++ b/app/expire.py
@@ -1,0 +1,120 @@
+"""
+expire.py — gestion des expirations de cles SSH.
+Appelee par cron a chaque cycle (SCAN_INTERVAL_HOURS).
+
+warn_expiring_keys() : alerte J-7 et J-2 avec anti-spam 24h
+expire_keys()        : scenario 4 — revocation automatique a echeance
+"""
+import json
+import os
+
+import actions
+import alerts
+import db
+import ssh
+
+EXPIRE_WARN_DAYS = int(os.environ.get("EXPIRE_WARN_DAYS", "7"))
+EXPIRE_WARN_DAYS_2 = int(os.environ.get("EXPIRE_WARN_DAYS_2", "2"))
+
+
+def warn_expiring_keys() -> int:
+    """
+    Find ACTIVE keys expiring within EXPIRE_WARN_DAYS or EXPIRE_WARN_DAYS_2 days.
+    Delegates to actions.warn_expiring_key() which enforces the 24h anti-spam.
+    Returns the number of warnings actually sent.
+    """
+    rows = db.query(
+        """
+        SELECT ka.key_id, ka.server_id, ka.expires_at
+        FROM key_authorizations ka
+        WHERE ka.status = 'ACTIVE'
+          AND ka.expires_at IS NOT NULL
+          AND ka.expires_at > now()
+          AND ka.expires_at <= now() + INTERVAL '%s days'
+        """,
+        (max(EXPIRE_WARN_DAYS, EXPIRE_WARN_DAYS_2),),
+    )
+    sent = 0
+    for row in rows:
+        before = db.query_one(
+            """
+            SELECT id FROM audit_log
+            WHERE action = 'EXPIRY_WARNING'
+              AND target_key = %s
+              AND target_server = %s
+              AND performed_at > now() - INTERVAL '24 hours'
+            """,
+            (row["key_id"], row["server_id"]),
+        )
+        if before:
+            continue
+        actions.warn_expiring_key(row["key_id"], row["server_id"], row["expires_at"])
+        sent += 1
+    return sent
+
+
+def expire_keys() -> int:
+    """
+    Scenario 4 — revoke all ACTIVE keys whose expires_at < NOW().
+    Calls sam-revoke on each server, sets EXPIRED + revoked_automatically=True.
+    Returns the number of keys expired.
+    """
+    rows = db.query(
+        """
+        SELECT ka.key_id, ka.server_id, sk.fingerprint, s.hostname
+        FROM key_authorizations ka
+        JOIN ssh_keys sk ON sk.id = ka.key_id
+        JOIN servers s ON s.id = ka.server_id
+        WHERE ka.status = 'ACTIVE'
+          AND ka.expires_at IS NOT NULL
+          AND ka.expires_at <= now()
+        """,
+        (),
+    )
+    expired = 0
+    for row in rows:
+        try:
+            ssh.revoke_on_server(row["hostname"], row["fingerprint"])
+        except Exception as exc:
+            alerts.send_alert(
+                "CRITICAL",
+                f"[ssh-access-manager] Echec revocation expiree sur {row['hostname']}",
+                f"Fingerprint: {row['fingerprint']}\nErreur: {exc}",
+            )
+            continue
+
+        db.execute(
+            """
+            UPDATE key_authorizations
+            SET status = 'EXPIRED',
+                revoked_at = now(),
+                revoked_by = NULL,
+                revoked_automatically = true,
+                revocation_justification = 'Scheduled expiration reached'
+            WHERE key_id = %s AND server_id = %s
+            """,
+            (row["key_id"], row["server_id"]),
+        )
+        db.execute(
+            """
+            INSERT INTO audit_log (action, target_key, target_server, details)
+            VALUES ('KEY_EXPIRED', %s, %s, %s::jsonb)
+            """,
+            (
+                row["key_id"],
+                row["server_id"],
+                json.dumps({
+                    "fingerprint": row["fingerprint"],
+                    "hostname": row["hostname"],
+                    "reason": "scheduled_expiration",
+                }),
+            ),
+        )
+        expired += 1
+    return expired
+
+
+if __name__ == "__main__":
+    warned = warn_expiring_keys()
+    expired = expire_keys()
+    print(f"expire.py: {warned} warnings sent, {expired} keys expired")

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -1,0 +1,156 @@
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import expire
+
+
+SERVER_ID = str(uuid.uuid4())
+KEY_ID = str(uuid.uuid4())
+FINGERPRINT = "SHA256:testfingerprintABCDEF"
+HOSTNAME = "server-test-01"
+
+
+def _future(days=3):
+    return datetime.now(tz=timezone.utc) + timedelta(days=days)
+
+
+def _past(hours=1):
+    return datetime.now(tz=timezone.utc) - timedelta(hours=hours)
+
+
+# ---------------------------------------------------------------------------
+# warn_expiring_keys()
+# ---------------------------------------------------------------------------
+
+def test_expire_warn_expiring_keys_calls_warn_for_each_key():
+    rows = [
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)},
+        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "expires_at": _future(5)},
+    ]
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+        mock_db.query.return_value = rows
+        mock_db.query_one.return_value = None  # no prior warning → send
+        expire.warn_expiring_keys()
+        assert mock_actions.warn_expiring_key.call_count == 2
+
+
+def test_expire_warn_expiring_keys_antispam_skips_already_warned():
+    rows = [{"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)}]
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+        mock_db.query.return_value = rows
+        mock_db.query_one.return_value = {"id": str(uuid.uuid4())}  # already warned
+        count = expire.warn_expiring_keys()
+        mock_actions.warn_expiring_key.assert_not_called()
+        assert count == 0
+
+
+def test_expire_warn_expiring_keys_returns_count_sent():
+    rows = [
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)},
+    ]
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+        mock_db.query.return_value = rows
+        mock_db.query_one.return_value = None
+        count = expire.warn_expiring_keys()
+        assert count == 1
+
+
+def test_expire_warn_expiring_keys_returns_zero_when_no_keys():
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+        mock_db.query.return_value = []
+        count = expire.warn_expiring_keys()
+        assert count == 0
+        mock_actions.warn_expiring_key.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# expire_keys() — scenario 4 (expiration programmee → sam-revoke)
+# ---------------------------------------------------------------------------
+
+def test_expire_expire_keys_scenario4_calls_sam_revoke():
+    row = {
+        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME,
+    }
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = [row]
+        expire.expire_keys()
+        mock_ssh.revoke_on_server.assert_called_once_with(HOSTNAME, FINGERPRINT)
+
+
+def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():
+    row = {
+        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME,
+    }
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = [row]
+        expire.expire_keys()
+        update_sql = mock_db.execute.call_args_list[0][0][0]
+        assert "EXPIRED" in update_sql
+        assert "revoked_automatically = true" in update_sql
+        assert "revoked_by = NULL" in update_sql
+
+
+def test_expire_expire_keys_scenario4_logs_key_expired():
+    row = {
+        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME,
+    }
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = [row]
+        expire.expire_keys()
+        audit_sql = mock_db.execute.call_args_list[1][0][0]
+        assert "KEY_EXPIRED" in audit_sql
+
+
+def test_expire_expire_keys_scenario4_returns_count():
+    rows = [
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "fingerprint": FINGERPRINT, "hostname": HOSTNAME},
+        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "fingerprint": "SHA256:other", "hostname": HOSTNAME},
+    ]
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = rows
+        count = expire.expire_keys()
+        assert count == 2
+
+
+def test_expire_expire_keys_scenario4_sends_critical_on_revoke_failure():
+    row = {
+        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME,
+    }
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts") as mock_alerts:
+        mock_db.query.return_value = [row]
+        mock_ssh.revoke_on_server.side_effect = RuntimeError("SSH timeout")
+        count = expire.expire_keys()
+        mock_alerts.send_alert.assert_called_once()
+        assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
+        assert count == 0
+
+
+def test_expire_expire_keys_returns_zero_when_no_expired_keys():
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = []
+        count = expire.expire_keys()
+        assert count == 0
+        mock_ssh.revoke_on_server.assert_not_called()


### PR DESCRIPTION
Closes #10

- warn_expiring_keys() avec anti-spam 24h via audit_log
- expire_keys() scénario 4 : sam-revoke → EXPIRED + revoked_automatically=true
- CRITICAL si sam-revoke échoue
- EXPIRE_WARN_DAYS et EXPIRE_WARN_DAYS_2 depuis ENV
- 10 tests unitaires passent