### PR TITLE
feat: alerts.py — envoi email msmtp + niveaux CRITIQUE/WARNING/INFO

### DIFF
--- a/app/alerts.py
+++ b/app/alerts.py
@@ -1,21 +1,59 @@
 """
 alerts.py — envoi d'emails via msmtp.
-Stub minimal — implementation complete dans Issue #11.
+
+Niveaux :
+  CRITICAL  → email immediat
+  WARNING   → email immediat (anti-spam 24h gere par actions.py)
+  INFO      → log uniquement, pas d'email
 """
+import logging
 import os
 import subprocess
-
 
 SMTP_TO = os.environ.get("SMTP_TO", "admin@example.com")
 SMTP_FROM = os.environ.get("SMTP_FROM", "ssh-manager@example.com")
 
+_EMAIL_LEVELS = {"CRITICAL", "WARNING"}
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+
+def _build_message(level: str, subject: str, body: str) -> str:
+    priority = "1 (Highest)" if level == "CRITICAL" else "3 (Normal)"
+    return (
+        f"From: {SMTP_FROM}\n"
+        f"To: {SMTP_TO}\n"
+        f"Subject: [{level}] {subject}\n"
+        f"X-Priority: {priority}\n"
+        f"\n"
+        f"{body}\n"
+        f"\n--\nssh-access-manager\n"
+    )
+
 
 def send_alert(level: str, subject: str, body: str) -> None:
-    """Send an email alert via msmtp. level: CRITICAL | WARNING | INFO."""
-    message = f"From: {SMTP_FROM}\nTo: {SMTP_TO}\nSubject: {subject}\n\n{body}\n"
-    subprocess.run(
-        ["msmtp", "--", SMTP_TO],
-        input=message,
-        text=True,
-        capture_output=True,
-    )
+    """
+    Send an alert at the given level.
+    CRITICAL/WARNING → email via msmtp.
+    INFO             → log only, no email.
+    """
+    log.info("[%s] %s", level, subject)
+
+    if level not in _EMAIL_LEVELS:
+        return
+
+    message = _build_message(level, subject, body)
+    try:
+        result = subprocess.run(
+            ["msmtp", "--", SMTP_TO],
+            input=message,
+            text=True,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            log.error("msmtp failed (rc=%d): %s", result.returncode, result.stderr)
+    except FileNotFoundError:
+        log.error("msmtp not found — alert not sent: %s", subject)
+    except Exception as exc:
+        log.error("Failed to send alert: %s", exc)

--- a/app/tests/test_alerts.py
+++ b/app/tests/test_alerts.py
@@ -1,0 +1,98 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import alerts
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL — envoie un email via msmtp
+# ---------------------------------------------------------------------------
+
+def test_alerts_critical_sends_email(mock_smtp):
+    alerts.send_alert("CRITICAL", "Cle inconnue detectee", "Fingerprint: SHA256:abc")
+    mock_smtp.assert_called_once()
+    args = mock_smtp.call_args[0][0]
+    assert "msmtp" in args
+
+
+def test_alerts_critical_uses_correct_recipient(mock_smtp):
+    with patch.dict(os.environ, {"SMTP_TO": "admin@example.com"}):
+        import importlib
+        importlib.reload(alerts)
+        alerts.send_alert("CRITICAL", "Subject", "Body")
+    args = mock_smtp.call_args[0][0]
+    assert "admin@example.com" in args
+
+
+def test_alerts_critical_message_contains_level(mock_smtp):
+    alerts.send_alert("CRITICAL", "Test subject", "Test body")
+    msg = mock_smtp.call_args[1]["input"]
+    assert "CRITICAL" in msg
+    assert "Test subject" in msg
+    assert "Test body" in msg
+
+
+def test_alerts_critical_sets_high_priority(mock_smtp):
+    alerts.send_alert("CRITICAL", "Urgent", "Body")
+    msg = mock_smtp.call_args[1]["input"]
+    assert "X-Priority: 1" in msg
+
+
+# ---------------------------------------------------------------------------
+# WARNING — envoie un email via msmtp
+# ---------------------------------------------------------------------------
+
+def test_alerts_warning_sends_email(mock_smtp):
+    alerts.send_alert("WARNING", "Cle expirant bientot", "Expires dans 2 jours")
+    mock_smtp.assert_called_once()
+
+
+def test_alerts_warning_message_contains_level(mock_smtp):
+    alerts.send_alert("WARNING", "Expiry warning", "Details")
+    msg = mock_smtp.call_args[1]["input"]
+    assert "WARNING" in msg
+
+
+def test_alerts_warning_sets_normal_priority(mock_smtp):
+    alerts.send_alert("WARNING", "Warn", "Body")
+    msg = mock_smtp.call_args[1]["input"]
+    assert "X-Priority: 3" in msg
+
+
+# ---------------------------------------------------------------------------
+# INFO — log uniquement, pas d'email
+# ---------------------------------------------------------------------------
+
+def test_alerts_info_does_not_send_email(mock_smtp):
+    alerts.send_alert("INFO", "Scan completed", "3 keys scanned")
+    mock_smtp.assert_not_called()
+
+
+def test_alerts_info_unknown_level_does_not_send_email(mock_smtp):
+    alerts.send_alert("DEBUG", "Debug message", "details")
+    mock_smtp.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Robustesse — msmtp manquant ou erreur
+# ---------------------------------------------------------------------------
+
+def test_alerts_msmtp_not_found_does_not_raise():
+    with patch("subprocess.run", side_effect=FileNotFoundError("msmtp not found")):
+        alerts.send_alert("CRITICAL", "Test", "Body")  # must not raise
+
+
+def test_alerts_msmtp_nonzero_exit_does_not_raise(mock_smtp):
+    mock_smtp.return_value = MagicMock(returncode=1, stderr="connection refused", stdout="")
+    alerts.send_alert("CRITICAL", "Test", "Body")  # must not raise
+
+
+def test_alerts_message_contains_footer(mock_smtp):
+    alerts.send_alert("CRITICAL", "Subject", "Body")
+    msg = mock_smtp.call_args[1]["input"]
+    assert "ssh-access-manager" in msg


### PR DESCRIPTION
Closes #11

- CRITICAL/WARNING → email msmtp immédiat
- INFO → log uniquement, pas d'email
- X-Priority 1 pour CRITICAL, 3 pour WARNING
- Gestion FileNotFoundError et rc!=0 sans raise
- SMTP_TO + SMTP_FROM depuis ENV
- Remplace le stub créé à l'issue #8
- 12 tests unitaires passent