### PR TITLE
feat: Vue.js 3 + Vite — setup, router, App.vue, 6 stubs

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ssh-access-manager</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ssh-access-manager-ui",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@vue/test-utils": "^2.4.0",
+    "jsdom": "^24.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
+  }
+}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,0 +1,90 @@
+<template>
+  <div id="app">
+    <nav class="navbar">
+      <span class="brand">ssh-access-manager</span>
+      <router-link to="/">Dashboard</router-link>
+      <router-link to="/anomalies">Anomalies</router-link>
+      <router-link to="/access">Accès</router-link>
+      <router-link to="/audit">Audit</router-link>
+      <router-link to="/admins">Admins</router-link>
+    </nav>
+    <main class="content">
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup>
+</script>
+
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: system-ui, sans-serif;
+  background: #f5f5f5;
+  color: #222;
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: #1a1a2e;
+  color: #fff;
+}
+
+.brand {
+  font-weight: bold;
+  font-size: 1.1rem;
+  margin-right: auto;
+}
+
+.navbar a {
+  color: #ccc;
+  text-decoration: none;
+  font-size: 0.9rem;
+}
+
+.navbar a.router-link-active {
+  color: #fff;
+  font-weight: bold;
+}
+
+.content {
+  padding: 1.5rem;
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+table { width: 100%; border-collapse: collapse; background: #fff; }
+th, td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid #e0e0e0; }
+th { background: #f0f0f0; font-size: 0.8rem; text-transform: uppercase; }
+tr:hover { background: #fafafa; }
+
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: bold;
+}
+.badge-active    { background: #d4edda; color: #155724; }
+.badge-pending   { background: #fff3cd; color: #856404; }
+.badge-revoked   { background: #f8d7da; color: #721c24; }
+.badge-expired   { background: #e2e3e5; color: #383d41; }
+.badge-critical  { background: #f8d7da; color: #721c24; }
+
+button {
+  padding: 0.3rem 0.75rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.btn-primary  { background: #0d6efd; color: #fff; }
+.btn-danger   { background: #dc3545; color: #fff; }
+.btn-success  { background: #198754; color: #fff; }
+.btn-warning  { background: #ffc107; color: #000; }
+</style>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(router).mount('#app')

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -1,0 +1,22 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+import Dashboard from '../views/Dashboard.vue'
+import ServerDetail from '../views/ServerDetail.vue'
+import Anomalies from '../views/Anomalies.vue'
+import AccessRequests from '../views/AccessRequests.vue'
+import Audit from '../views/Audit.vue'
+import Admins from '../views/Admins.vue'
+
+const routes = [
+  { path: '/',              name: 'Dashboard',      component: Dashboard },
+  { path: '/servers/:hostname', name: 'ServerDetail', component: ServerDetail },
+  { path: '/anomalies',    name: 'Anomalies',      component: Anomalies },
+  { path: '/access',       name: 'AccessRequests', component: AccessRequests },
+  { path: '/audit',        name: 'Audit',          component: Audit },
+  { path: '/admins',       name: 'Admins',         component: Admins },
+]
+
+export default createRouter({
+  history: createWebHistory(),
+  routes,
+})

--- a/ui/src/views/AccessRequests.vue
+++ b/ui/src/views/AccessRequests.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="access-requests-view">
+    <h1>AccessRequests</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="admins-view">
+    <h1>Admins</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="anomalies-view">
+    <h1>Anomalies</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/src/views/Audit.vue
+++ b/ui/src/views/Audit.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="audit-view">
+    <h1>Audit</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="dashboard-view">
+    <h1>Dashboard</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="server-detail-view">
+    <h1>ServerDetail</h1>
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://127.0.0.1:5000',
+        changeOrigin: true,
+      },
+    },
+  },
+
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})


### PR DESCRIPTION
Closes #14

## Fichiers créés
- ui/package.json (vue ^3.4, vue-router ^4.3, vite ^5, vitest ^1)
- ui/vite.config.js (proxy /api → :5000, outDir: dist, test: jsdom)
- ui/index.html
- ui/src/main.js
- ui/src/App.vue (navbar, router-view, styles globaux)
- ui/src/router/index.js (6 routes, createWebHistory)
- ui/src/views/*.vue (6 stubs)
- ui/.gitignore

## Critères d'acceptation
- [x] npm run build produit dist/ sans erreur
- [x] Vue Router configuré avec 6 routes
- [x] Proxy Vite vers Flask :5000
- [x] Styles globaux table/badge/button dans App.vue