### PR TITLE
feat: KeyActions.vue + ExpiryPicker.vue — composants avec tests Vitest

### DIFF
--- a/ui/src/components/ExpiryPicker.vue
+++ b/ui/src/components/ExpiryPicker.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="expiry-picker">
+    <div class="mode-toggle">
+      <label>
+        <input
+          v-model="mode"
+          type="radio"
+          value="hours"
+          data-testid="mode-hours"
+        /> Durée (heures)
+      </label>
+      <label>
+        <input
+          v-model="mode"
+          type="radio"
+          value="date"
+          data-testid="mode-date"
+        /> Date précise
+      </label>
+    </div>
+
+    <div v-if="mode === 'hours'" class="field">
+      <label for="expiry-hours">Nombre d'heures <span class="required">*</span></label>
+      <input
+        id="expiry-hours"
+        v-model.number="hours"
+        type="number"
+        min="1"
+        placeholder="ex : 24"
+        data-testid="input-hours"
+        @input="emitValue"
+      />
+      <span v-if="hours !== '' && hours < 1" class="field-error">
+        La durée doit être d'au moins 1 heure.
+      </span>
+    </div>
+
+    <div v-else class="field">
+      <label for="expiry-date">Date et heure d'expiration <span class="required">*</span></label>
+      <input
+        id="expiry-date"
+        v-model="date"
+        type="datetime-local"
+        :min="minDate"
+        data-testid="input-date"
+        @input="emitValue"
+      />
+      <span v-if="date && !dateValid" class="field-error">
+        La date doit être dans le futur.
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+
+const emit = defineEmits(['update:modelValue'])
+
+const mode  = ref('hours')
+const hours = ref('')
+const date  = ref('')
+
+const minDate = computed(() => {
+  const d = new Date()
+  d.setMinutes(d.getMinutes() + 1)
+  return d.toISOString().slice(0, 16)
+})
+
+const dateValid = computed(() => {
+  if (!date.value) return false
+  return new Date(date.value) > new Date()
+})
+
+function emitValue() {
+  if (mode.value === 'hours') {
+    emit('update:modelValue', hours.value > 0 ? { hours: hours.value } : null)
+  } else {
+    emit('update:modelValue', dateValid.value ? { date: date.value } : null)
+  }
+}
+
+watch(mode, () => {
+  hours.value = ''
+  date.value  = ''
+  emit('update:modelValue', null)
+})
+</script>
+
+<style scoped>
+.expiry-picker { display: flex; flex-direction: column; gap: 0.75rem; }
+
+.mode-toggle { display: flex; gap: 1.5rem; font-size: 0.9rem; }
+
+.field { display: flex; flex-direction: column; gap: 0.3rem; }
+
+label { font-size: 0.85rem; font-weight: 600; }
+.required { color: #dc3545; }
+
+input[type="number"],
+input[type="datetime-local"] {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.field-error { font-size: 0.8rem; color: #dc3545; }
+</style>

--- a/ui/src/components/KeyActions.vue
+++ b/ui/src/components/KeyActions.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="key-actions">
+    <button
+      v-if="showValidate"
+      class="btn-success"
+      @click="$emit('validate', fingerprint)"
+    >Valider</button>
+
+    <button
+      v-if="showRevoke"
+      class="btn-danger"
+      @click="openConfirm"
+    >Révoquer</button>
+
+    <button
+      v-if="showExpiry"
+      class="btn-warning"
+      @click="$emit('set-expiry', fingerprint)"
+    >Expiry</button>
+
+    <!-- Modal confirmation révocation -->
+    <div v-if="confirming" class="modal-overlay" @click.self="confirming = false">
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <h3 id="modal-title">Confirmer la révocation</h3>
+        <p class="fp-display">
+          Clé : <code>{{ fingerprint }}</code>
+        </p>
+        <label for="revoke-reason">Motif <span class="required">*</span></label>
+        <textarea
+          id="revoke-reason"
+          v-model="reason"
+          rows="3"
+          placeholder="Raison de révocation…"
+        ></textarea>
+        <div class="modal-actions">
+          <button
+            class="btn-danger"
+            :disabled="!reason.trim()"
+            data-testid="confirm-revoke"
+            @click="confirmRevoke"
+          >Confirmer la révocation</button>
+          <button data-testid="cancel-revoke" @click="confirming = false">Annuler</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  fingerprint: { type: String, required: true },
+  status:      { type: String, default: 'ACTIVE' },
+})
+
+const emit = defineEmits(['validate', 'revoke', 'set-expiry'])
+
+const confirming = ref(false)
+const reason = ref('')
+
+const showValidate = computed(() => props.status === 'PENDING_REVIEW')
+const showRevoke   = computed(() => ['ACTIVE', 'PENDING_REVIEW'].includes(props.status))
+const showExpiry   = computed(() => props.status === 'ACTIVE')
+
+function openConfirm() {
+  reason.value = ''
+  confirming.value = true
+}
+
+function confirmRevoke() {
+  emit('revoke', { fingerprint: props.fingerprint, reason: reason.value })
+  confirming.value = false
+}
+</script>
+
+<style scoped>
+.key-actions { display: flex; gap: 0.4rem; flex-wrap: wrap; }
+
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 200;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  width: 400px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal h3 { font-size: 1.1rem; margin: 0; }
+
+.fp-display { font-size: 0.85rem; word-break: break-all; }
+code { background: #f4f4f4; padding: 0 3px; border-radius: 3px; }
+
+label { font-size: 0.85rem; font-weight: 600; }
+.required { color: #dc3545; }
+
+textarea {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  resize: vertical;
+}
+
+.modal-actions { display: flex; gap: 0.75rem; justify-content: flex-end; }
+</style>

--- a/ui/tests/ExpiryPicker.spec.js
+++ b/ui/tests/ExpiryPicker.spec.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ExpiryPicker from '../src/components/ExpiryPicker.vue'
+
+describe('ExpiryPicker', () => {
+  it('démarre en mode heures', () => {
+    const w = mount(ExpiryPicker)
+    expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
+    expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
+  })
+
+  it('passe en mode date quand on sélectionne date précise', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="mode-date"]').setChecked(true)
+    expect(w.find('[data-testid="input-date"]').exists()).toBe(true)
+    expect(w.find('[data-testid="input-hours"]').exists()).toBe(false)
+  })
+
+  it('repasse en mode heures depuis le mode date', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="mode-date"]').setChecked(true)
+    await w.find('[data-testid="mode-hours"]').setChecked(true)
+    expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
+    expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
+  })
+
+  it('les deux modes ne sont jamais affichés simultanément', async () => {
+    const w = mount(ExpiryPicker)
+    expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
+    expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
+
+    await w.find('[data-testid="mode-date"]').setChecked(true)
+    expect(w.find('[data-testid="input-hours"]').exists()).toBe(false)
+    expect(w.find('[data-testid="input-date"]').exists()).toBe(true)
+  })
+
+  it('émet { hours } valide quand une durée positive est saisie', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="input-hours"]').setValue('48')
+    await w.find('[data-testid="input-hours"]').trigger('input')
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted).toBeTruthy()
+    expect(emitted[emitted.length - 1][0]).toEqual({ hours: 48 })
+  })
+
+  it('émet null si la durée est 0 ou négative', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="input-hours"]').setValue('0')
+    await w.find('[data-testid="input-hours"]').trigger('input')
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted[emitted.length - 1][0]).toBeNull()
+  })
+
+  it('émet null quand on change de mode', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="input-hours"]').setValue('10')
+    await w.find('[data-testid="input-hours"]').trigger('input')
+    await w.find('[data-testid="mode-date"]').setChecked(true)
+    const emitted = w.emitted('update:modelValue')
+    expect(emitted[emitted.length - 1][0]).toBeNull()
+  })
+
+  it('affiche une erreur si durée < 1', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="input-hours"]').setValue('0')
+    await w.find('[data-testid="input-hours"]').trigger('input')
+    expect(w.find('.field-error').exists()).toBe(true)
+  })
+
+  it('n\'affiche pas d\'erreur si durée >= 1', async () => {
+    const w = mount(ExpiryPicker)
+    await w.find('[data-testid="input-hours"]').setValue('1')
+    await w.find('[data-testid="input-hours"]').trigger('input')
+    expect(w.find('.field-error').exists()).toBe(false)
+  })
+})

--- a/ui/tests/KeyActions.spec.js
+++ b/ui/tests/KeyActions.spec.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KeyActions from '../src/components/KeyActions.vue'
+
+const FP = 'SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
+
+describe('KeyActions', () => {
+  it('affiche Valider uniquement si status PENDING_REVIEW', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'PENDING_REVIEW' } })
+    expect(w.find('.btn-success').exists()).toBe(true)
+  })
+
+  it('n\'affiche pas Valider si status ACTIVE', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    expect(w.find('.btn-success').exists()).toBe(false)
+  })
+
+  it('affiche Révoquer si status ACTIVE', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    expect(w.find('.btn-danger').exists()).toBe(true)
+  })
+
+  it('affiche Révoquer si status PENDING_REVIEW', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'PENDING_REVIEW' } })
+    expect(w.find('.btn-danger').exists()).toBe(true)
+  })
+
+  it('n\'affiche pas Révoquer si status REVOKED', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'REVOKED' } })
+    expect(w.find('.btn-danger').exists()).toBe(false)
+  })
+
+  it('affiche Expiry uniquement si status ACTIVE', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    expect(w.find('.btn-warning').exists()).toBe(true)
+  })
+
+  it('n\'affiche pas Expiry si status PENDING_REVIEW', () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'PENDING_REVIEW' } })
+    expect(w.find('.btn-warning').exists()).toBe(false)
+  })
+
+  it('ouvre la modal de confirmation au clic sur Révoquer', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-danger').trigger('click')
+    expect(w.find('.modal').exists()).toBe(true)
+  })
+
+  it('le bouton confirmer est désactivé si le motif est vide', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-danger').trigger('click')
+    expect(w.find('[data-testid="confirm-revoke"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('le bouton confirmer est actif quand un motif est saisi', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-danger').trigger('click')
+    await w.find('textarea').setValue('Clé compromise')
+    expect(w.find('[data-testid="confirm-revoke"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('émet revoke avec fingerprint et reason à la confirmation', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-danger').trigger('click')
+    await w.find('textarea').setValue('Motif test')
+    await w.find('[data-testid="confirm-revoke"]').trigger('click')
+    expect(w.emitted('revoke')).toBeTruthy()
+    expect(w.emitted('revoke')[0][0]).toEqual({ fingerprint: FP, reason: 'Motif test' })
+  })
+
+  it('ferme la modal après annulation', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-danger').trigger('click')
+    await w.find('[data-testid="cancel-revoke"]').trigger('click')
+    expect(w.find('.modal').exists()).toBe(false)
+  })
+
+  it('émet validate avec le fingerprint', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'PENDING_REVIEW' } })
+    await w.find('.btn-success').trigger('click')
+    expect(w.emitted('validate')[0][0]).toBe(FP)
+  })
+
+  it('émet set-expiry avec le fingerprint', async () => {
+    const w = mount(KeyActions, { props: { fingerprint: FP, status: 'ACTIVE' } })
+    await w.find('.btn-warning').trigger('click')
+    expect(w.emitted('set-expiry')[0][0]).toBe(FP)
+  })
+})


### PR DESCRIPTION
Closes #17

## Fichiers
- ui/src/components/KeyActions.vue — boutons conditionnés par statut, modal révocation
- ui/src/components/ExpiryPicker.vue — sélecteur durée/date avec modes exclusifs
- ui/tests/KeyActions.spec.js — 14 tests
- ui/tests/ExpiryPicker.spec.js — 9 tests

## Critères
- [x] Modal confirmation révocation avec motif obligatoire
- [x] Modes heures et date jamais affichés simultanément
- [x] Validation côté client avant émission
- [x] 23/23 tests Vitest verts