### PR TITLE
fix: nginx htpasswd — openssl apr1 + permissions 644

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk update && apk add --no-cache \
     nginx \
     msmtp \
     openssh-client \
+    openssl \
     busybox-extras \
     wget \
     tzdata && \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,9 +7,12 @@ set -e
 generate_nginx_conf() {
     sed \
         -e "s|{{NGINX_PORT}}|${NGINX_PORT:-8080}|g" \
-        -e "s|{{NGINX_USER}}|${NGINX_USER:-admin}|g" \
-        -e "s|{{NGINX_PASSWORD_HASH}}|$(echo "${NGINX_PASSWORD:-changeme}" | openssl passwd -apr1 -stdin)|g" \
         /app/nginx.conf.template > /etc/nginx/nginx.conf
+
+    # Générer /etc/nginx/.htpasswd
+    _hash=$(openssl passwd -apr1 "${NGINX_PASSWORD:-changeme}")
+    printf '%s:%s\n' "${NGINX_USER:-admin}" "${_hash}" > /etc/nginx/.htpasswd
+    chmod 644 /etc/nginx/.htpasswd
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problèmes corrigés

**1. Fichier .htpasswd jamais créé**
bootstrap.sh ne créait pas /etc/nginx/.htpasswd → 403 Forbidden.
Fix : generate_nginx_conf() génère le fichier via `openssl passwd -apr1`.

**2. openssl absent de l'image**
Fix : ajout de `openssl` dans le Dockerfile (apk add).

**3. Permission denied sur .htpasswd**
chmod 640 empêchait le worker nginx (nobody) de lire le fichier → 500.
Fix : chmod 644.