### PR TITLE
feat: password_hash dans administrators + ADMIN_PASSWORD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,5 @@ EXPIRE_WARN_DAYS=7
 EXPIRE_WARN_DAYS_2=2
 ADMIN_USERNAME=admin
 ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=changeme
 TZ=Europe/Paris

--- a/app/actions.py
+++ b/app/actions.py
@@ -446,10 +446,13 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
 # Administrateurs
 # ---------------------------------------------------------------------------
 
-def add_admin(username: str, email: str, admin_id: str | None = None) -> dict:
+def add_admin(username: str, email: str, password: str, admin_id: str | None = None) -> dict:
     """Insert a new administrator and log ADMIN_ADDED."""
+    from werkzeug.security import generate_password_hash
+    password_hash = generate_password_hash(password)
     db.execute(
-        "INSERT INTO administrators (username, email) VALUES (%s, %s)", (username, email)
+        "INSERT INTO administrators (username, email, password_hash) VALUES (%s, %s, %s)",
+        (username, email, password_hash),
     )
     admin = db.query_one("SELECT id FROM administrators WHERE username = %s", (username,))
     db.execute(

--- a/app/manage.py
+++ b/app/manage.py
@@ -389,11 +389,12 @@ def admin_list():
 @admin.command("add")
 @click.option("--username", required=True, help="Login")
 @click.option("--email", required=True, help="Email")
-def admin_add(username, email):
+@click.option("--password", required=True, help="Mot de passe")
+def admin_add(username, email, password):
     """Ajouter un administrateur."""
     performer_id = _require_admin()
     try:
-        actions.add_admin(username, email, performer_id)
+        actions.add_admin(username, email, password, performer_id)
         click.echo(f"Administrateur {username} cree.")
     except Exception as e:
         raise click.ClickException(str(e))

--- a/app/web.py
+++ b/app/web.py
@@ -340,7 +340,7 @@ def list_admins():
 def add_admin():
     data = request.get_json(force=True) or {}
     try:
-        admin = actions.add_admin(data["username"], data.get("email", ""), g.admin_id)
+        admin = actions.add_admin(data["username"], data.get("email", ""), data["password"], g.admin_id)
         return jsonify(admin), 201
     except (KeyError, Exception) as e:
         return jsonify({"error": str(e)}), 400

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -82,14 +82,19 @@ if [ ! -f /data/pg/PG_VERSION ]; then
          -f /app/sql/schema.sql"
 
     # 9. Insérer l'administrateur initial depuis ENV
+    _admin_hash=$(python3 -c "
+from werkzeug.security import generate_password_hash
+print(generate_password_hash('${ADMIN_PASSWORD:-changeme}'))
+")
     su -s /bin/sh postgres -c "psql -h /tmp \
         -U ${POSTGRES_USER:-ssh_manager} \
         -d ${POSTGRES_DB:-ssh_manager} -c \"
-        INSERT INTO administrators (username, email, role)
+        INSERT INTO administrators (username, email, role, password_hash)
         VALUES (
             '${ADMIN_USERNAME:-admin}',
             '${ADMIN_EMAIL:-admin@example.com}',
-            'sysadmin'
+            'sysadmin',
+            '${_admin_hash}'
         ) ON CONFLICT (username) DO NOTHING;
     \""
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -56,11 +56,13 @@ CREATE TABLE administrators (
     -- Adresse email pour les notifications
     email       VARCHAR(255),
     -- Rôle fonctionnel (extensible)
-    role        VARCHAR(50) DEFAULT 'sysadmin',
+    role          VARCHAR(50) DEFAULT 'sysadmin',
+    -- Hash du mot de passe (werkzeug generate_password_hash)
+    password_hash VARCHAR(255),
     -- Compte actif ou désactivé (jamais supprimé pour préserver l'audit)
-    is_active   BOOLEAN DEFAULT true,
+    is_active     BOOLEAN DEFAULT true,
     -- Date de création du compte
-    created_at  TIMESTAMPTZ DEFAULT now()
+    created_at    TIMESTAMPTZ DEFAULT now()
 );
 
 COMMENT ON TABLE administrators IS 'Utilisateurs autorisés à gérer les accès SSH';
@@ -68,6 +70,7 @@ COMMENT ON COLUMN administrators.id IS 'UUID généré automatiquement';
 COMMENT ON COLUMN administrators.username IS 'Login unique de l''administrateur';
 COMMENT ON COLUMN administrators.email IS 'Email pour les alertes et notifications';
 COMMENT ON COLUMN administrators.role IS 'Rôle fonctionnel, défaut : sysadmin';
+COMMENT ON COLUMN administrators.password_hash IS 'Hash werkzeug (pbkdf2:sha256) du mot de passe';
 COMMENT ON COLUMN administrators.is_active IS 'False = compte désactivé (jamais supprimé)';
 COMMENT ON COLUMN administrators.created_at IS 'Horodatage de création du compte';
 


### PR DESCRIPTION
Closes #51

## Critères
- [x] password_hash dans schema.sql
- [x] Bootstrap insère l'admin initial avec hash scrypt (werkzeug)
- [x] ADMIN_PASSWORD dans .env.example
- [x] manage.py admin add --password requis
- [x] web.py POST /api/admins transmet le password