### PR TITLE
feat: supprimer Basic Auth Nginx — auth gérée par Flask session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,6 @@ POSTGRES_PASSWORD=changeme
 
 # Nginx
 NGINX_PORT=8080
-NGINX_USER=admin
-NGINX_PASSWORD=changeme
 
 # Flask
 FLASK_SECRET_KEY=changeme

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apk update && apk add --no-cache \
     nginx \
     msmtp \
     openssh-client \
-    openssl \
     busybox-extras \
     wget \
     tzdata && \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,11 +8,6 @@ generate_nginx_conf() {
     sed \
         -e "s|{{NGINX_PORT}}|${NGINX_PORT:-8080}|g" \
         /app/nginx.conf.template > /etc/nginx/nginx.conf
-
-    # Générer /etc/nginx/.htpasswd
-    _hash=$(openssl passwd -apr1 "${NGINX_PASSWORD:-changeme}")
-    printf '%s:%s\n' "${NGINX_USER:-admin}" "${_hash}" > /etc/nginx/.htpasswd
-    chmod 644 /etc/nginx/.htpasswd
 }
 
 # ---------------------------------------------------------------------------

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -12,10 +12,6 @@ http {
     access_log    /dev/stdout;
     sendfile      on;
 
-    # Fichier htpasswd généré au bootstrap depuis ENV
-    auth_basic           "ssh-access-manager";
-    auth_basic_user_file /etc/nginx/.htpasswd;
-
     server {
         listen {{NGINX_PORT}};
         server_name _;


### PR DESCRIPTION
Closes #54

## Changements
- nginx.conf.template : plus de auth_basic
- bootstrap.sh : plus de génération .htpasswd
- Dockerfile : openssl retiré de apk add
- .env.example : NGINX_USER et NGINX_PASSWORD supprimés

## Test
- HTTP 200 sans popup navigateur
- Login via POST /api/auth/login avec username/password
- Redirect /login si non connecté (géré par Vue Router)