### PR TITLE
feat(security): validation robustesse mot de passe administrateur — closes #62

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -446,9 +446,28 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
 # Administrateurs
 # ---------------------------------------------------------------------------
 
+def _validate_password_strength(password: str) -> None:
+    """Raise ValueError if password does not meet complexity requirements."""
+    import re
+    errors = []
+    if len(password) < 8:
+        errors.append("au moins 8 caractères")
+    if not re.search(r"[A-Z]", password):
+        errors.append("au moins une majuscule")
+    if not re.search(r"[a-z]", password):
+        errors.append("au moins une minuscule")
+    if not re.search(r"\d", password):
+        errors.append("au moins un chiffre")
+    if not re.search(r"[!@#$%^&*()\-_=+\[\]{}|;:'\",.<>?/\\`~]", password):
+        errors.append("au moins un caractère spécial")
+    if errors:
+        raise ValueError("Mot de passe insuffisant : " + ", ".join(errors))
+
+
 def add_admin(username: str, email: str, password: str, admin_id: str | None = None) -> dict:
     """Insert a new administrator and log ADMIN_ADDED."""
     from werkzeug.security import generate_password_hash
+    _validate_password_strength(password)
     password_hash = generate_password_hash(password)
     db.execute(
         "INSERT INTO administrators (username, email, password_hash) VALUES (%s, %s, %s)",
@@ -468,6 +487,7 @@ def add_admin(username: str, email: str, password: str, admin_id: str | None = N
 def change_password(username: str, new_password: str) -> None:
     """Update password_hash for an active administrator."""
     from werkzeug.security import generate_password_hash
+    _validate_password_strength(new_password)
     admin = db.query_one(
         "SELECT id FROM administrators WHERE username = %s AND is_active = true", (username,)
     )

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -54,21 +54,11 @@
         <form class="add-form" @submit.prevent="submitAdd">
           <div class="field">
             <label for="adm-username">Username <span class="required">*</span></label>
-            <input
-              id="adm-username"
-              v-model="newUsername"
-              type="text"
-              placeholder="username"
-            />
+            <input id="adm-username" v-model="newUsername" type="text" placeholder="username" />
           </div>
           <div class="field">
             <label for="adm-email">Email</label>
-            <input
-              id="adm-email"
-              v-model="newEmail"
-              type="email"
-              placeholder="admin@example.com"
-            />
+            <input id="adm-email" v-model="newEmail" type="email" placeholder="admin@example.com" />
           </div>
           <div class="field">
             <label for="adm-password">Mot de passe <span class="required">*</span></label>
@@ -77,7 +67,9 @@
               v-model="newPassword"
               type="password"
               placeholder="••••••••"
+              :class="{ 'input-error': newPassword && !passwordValid(newPassword).ok }"
             />
+            <PasswordStrength v-if="newPassword" :password="newPassword" />
           </div>
           <div class="field">
             <label for="adm-password-confirm">Confirmer le mot de passe <span class="required">*</span></label>
@@ -93,13 +85,7 @@
             </span>
           </div>
           <div class="form-actions">
-            <button
-              type="submit"
-              class="btn-primary"
-              :disabled="!canSubmitAdd"
-            >
-              Ajouter
-            </button>
+            <button type="submit" class="btn-primary" :disabled="!canSubmitAdd">Ajouter</button>
           </div>
         </form>
       </section>
@@ -133,7 +119,9 @@
               type="password"
               placeholder="••••••••"
               autofocus
+              :class="{ 'input-error': editPassword && !passwordValid(editPassword).ok }"
             />
+            <PasswordStrength v-if="editPassword" :password="editPassword" />
           </div>
           <div class="field" style="margin-bottom:1rem">
             <label for="edit-password-confirm">Confirmer <span class="required">*</span></label>
@@ -149,11 +137,7 @@
             </span>
           </div>
           <div class="modal-actions">
-            <button
-              type="submit"
-              class="btn-primary"
-              :disabled="!canSubmitEdit"
-            >Enregistrer</button>
+            <button type="submit" class="btn-primary" :disabled="!canSubmitEdit">Enregistrer</button>
             <button type="button" @click="closeEditPassword">Annuler</button>
           </div>
         </form>
@@ -165,6 +149,47 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 
+// ---------------------------------------------------------------------------
+// Composant interne : indicateur de robustesse du mot de passe
+// ---------------------------------------------------------------------------
+const PasswordStrength = {
+  props: { password: { type: String, required: true } },
+  setup(props) {
+    const rules = computed(() => [
+      { label: '8 caractères minimum',    ok: props.password.length >= 8 },
+      { label: 'Une lettre majuscule',    ok: /[A-Z]/.test(props.password) },
+      { label: 'Une lettre minuscule',    ok: /[a-z]/.test(props.password) },
+      { label: 'Un chiffre',             ok: /\d/.test(props.password) },
+      { label: 'Un caractère spécial',   ok: /[!@#$%^&*()\-_=+\[\]{}|;:'",.<>?/\\`~]/.test(props.password) },
+    ])
+    return { rules }
+  },
+  template: `
+    <ul class="pwd-rules">
+      <li v-for="r in rules" :key="r.label" :class="r.ok ? 'rule-ok' : 'rule-fail'">
+        {{ r.ok ? '✓' : '✗' }} {{ r.label }}
+      </li>
+    </ul>
+  `,
+}
+
+// ---------------------------------------------------------------------------
+// Validation partagée
+// ---------------------------------------------------------------------------
+function passwordValid(pwd) {
+  const rules = [
+    pwd.length >= 8,
+    /[A-Z]/.test(pwd),
+    /[a-z]/.test(pwd),
+    /\d/.test(pwd),
+    /[!@#$%^&*()\-_=+\[\]{}|;:'",.<>?/\\`~]/.test(pwd),
+  ]
+  return { ok: rules.every(Boolean) }
+}
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
 const admins             = ref([])
 const loading            = ref(true)
 const error              = ref('')
@@ -174,21 +199,24 @@ const newEmail           = ref('')
 const newPassword        = ref('')
 const newPasswordConfirm = ref('')
 const disableTarget      = ref(null)
-const editPasswordTarget = ref(null)
-const editPassword       = ref('')
+const editPasswordTarget  = ref(null)
+const editPassword        = ref('')
 const editPasswordConfirm = ref('')
 
 const canSubmitAdd = computed(() =>
   newUsername.value.trim() &&
-  newPassword.value.trim() &&
+  passwordValid(newPassword.value).ok &&
   newPassword.value === newPasswordConfirm.value
 )
 
 const canSubmitEdit = computed(() =>
-  editPassword.value.trim() &&
+  passwordValid(editPassword.value).ok &&
   editPassword.value === editPasswordConfirm.value
 )
 
+// ---------------------------------------------------------------------------
+// API calls
+// ---------------------------------------------------------------------------
 async function load() {
   loading.value = true
   error.value = ''
@@ -232,9 +260,7 @@ async function submitAdd() {
   }
 }
 
-function openDisable(username) {
-  disableTarget.value = username
-}
+function openDisable(username) { disableTarget.value = username }
 
 async function confirmDisable() {
   const username = disableTarget.value
@@ -330,6 +356,18 @@ input[type="password"] {
 input.input-error { border-color: #dc3545; }
 .field-error { color: #dc3545; font-size: 0.8rem; }
 
+.pwd-rules {
+  list-style: none;
+  padding: 0.4rem 0 0 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.pwd-rules li { font-size: 0.8rem; }
+.rule-ok   { color: #198754; }
+.rule-fail { color: #dc3545; }
+
 .form-actions { display: flex; gap: 0.75rem; }
 
 .empty   { text-align: center; color: #888; padding: 1rem 0; }
@@ -359,7 +397,7 @@ input.input-error { border-color: #dc3545; }
   background: #fff;
   border-radius: 8px;
   padding: 1.5rem;
-  width: 400px;
+  width: 420px;
   max-width: 90vw;
   display: flex;
   flex-direction: column;

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -67,9 +67,13 @@
               v-model="newPassword"
               type="password"
               placeholder="••••••••"
-              :class="{ 'input-error': newPassword && !passwordValid(newPassword).ok }"
+              :class="{ 'input-error': newPassword && !pwdRules(newPassword).every(r => r.ok) }"
             />
-            <PasswordStrength v-if="newPassword" :password="newPassword" />
+            <ul v-if="newPassword" class="pwd-rules">
+              <li v-for="r in pwdRules(newPassword)" :key="r.label" :class="r.ok ? 'rule-ok' : 'rule-fail'">
+                {{ r.ok ? '✓' : '✗' }} {{ r.label }}
+              </li>
+            </ul>
           </div>
           <div class="field">
             <label for="adm-password-confirm">Confirmer le mot de passe <span class="required">*</span></label>
@@ -119,9 +123,13 @@
               type="password"
               placeholder="••••••••"
               autofocus
-              :class="{ 'input-error': editPassword && !passwordValid(editPassword).ok }"
+              :class="{ 'input-error': editPassword && !pwdRules(editPassword).every(r => r.ok) }"
             />
-            <PasswordStrength v-if="editPassword" :password="editPassword" />
+            <ul v-if="editPassword" class="pwd-rules">
+              <li v-for="r in pwdRules(editPassword)" :key="r.label" :class="r.ok ? 'rule-ok' : 'rule-fail'">
+                {{ r.ok ? '✓' : '✗' }} {{ r.label }}
+              </li>
+            </ul>
           </div>
           <div class="field" style="margin-bottom:1rem">
             <label for="edit-password-confirm">Confirmer <span class="required">*</span></label>
@@ -150,67 +158,48 @@
 import { ref, computed, onMounted } from 'vue'
 
 // ---------------------------------------------------------------------------
-// Composant interne : indicateur de robustesse du mot de passe
+// Validation — règles de robustesse du mot de passe
 // ---------------------------------------------------------------------------
-const PasswordStrength = {
-  props: { password: { type: String, required: true } },
-  setup(props) {
-    const rules = computed(() => [
-      { label: '8 caractères minimum',    ok: props.password.length >= 8 },
-      { label: 'Une lettre majuscule',    ok: /[A-Z]/.test(props.password) },
-      { label: 'Une lettre minuscule',    ok: /[a-z]/.test(props.password) },
-      { label: 'Un chiffre',             ok: /\d/.test(props.password) },
-      { label: 'Un caractère spécial',   ok: /[!@#$%^&*()\-_=+\[\]{}|;:'",.<>?/\\`~]/.test(props.password) },
-    ])
-    return { rules }
-  },
-  template: `
-    <ul class="pwd-rules">
-      <li v-for="r in rules" :key="r.label" :class="r.ok ? 'rule-ok' : 'rule-fail'">
-        {{ r.ok ? '✓' : '✗' }} {{ r.label }}
-      </li>
-    </ul>
-  `,
+const SPECIAL = /[!@#$%^&*()\-_=+[\]{}|;:'",.<>?\\`~]/
+
+function pwdRules(pwd) {
+  return [
+    { label: '8 caractères minimum',  ok: pwd.length >= 8 },
+    { label: 'Une lettre majuscule',  ok: /[A-Z]/.test(pwd) },
+    { label: 'Une lettre minuscule',  ok: /[a-z]/.test(pwd) },
+    { label: 'Un chiffre',           ok: /\d/.test(pwd) },
+    { label: 'Un caractère spécial', ok: SPECIAL.test(pwd) },
+  ]
 }
 
-// ---------------------------------------------------------------------------
-// Validation partagée
-// ---------------------------------------------------------------------------
-function passwordValid(pwd) {
-  const rules = [
-    pwd.length >= 8,
-    /[A-Z]/.test(pwd),
-    /[a-z]/.test(pwd),
-    /\d/.test(pwd),
-    /[!@#$%^&*()\-_=+\[\]{}|;:'",.<>?/\\`~]/.test(pwd),
-  ]
-  return { ok: rules.every(Boolean) }
+function pwdOk(pwd) {
+  return pwdRules(pwd).every(r => r.ok)
 }
 
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
-const admins             = ref([])
-const loading            = ref(true)
-const error              = ref('')
-const message            = ref('')
-const newUsername        = ref('')
-const newEmail           = ref('')
-const newPassword        = ref('')
-const newPasswordConfirm = ref('')
-const disableTarget      = ref(null)
+const admins              = ref([])
+const loading             = ref(true)
+const error               = ref('')
+const message             = ref('')
+const newUsername         = ref('')
+const newEmail            = ref('')
+const newPassword         = ref('')
+const newPasswordConfirm  = ref('')
+const disableTarget       = ref(null)
 const editPasswordTarget  = ref(null)
 const editPassword        = ref('')
 const editPasswordConfirm = ref('')
 
 const canSubmitAdd = computed(() =>
-  newUsername.value.trim() &&
-  passwordValid(newPassword.value).ok &&
+  newUsername.value.trim().length > 0 &&
+  pwdOk(newPassword.value) &&
   newPassword.value === newPasswordConfirm.value
 )
 
 const canSubmitEdit = computed(() =>
-  passwordValid(editPassword.value).ok &&
+  pwdOk(editPassword.value) &&
   editPassword.value === editPasswordConfirm.value
 )
 
@@ -294,7 +283,9 @@ function closeEditPassword() {
 
 async function confirmEditPassword() {
   if (!canSubmitEdit.value) return
+  // Capture before closing (closeEditPassword resets the refs)
   const username = editPasswordTarget.value
+  const password = editPassword.value
   closeEditPassword()
   error.value   = ''
   message.value = ''
@@ -302,7 +293,7 @@ async function confirmEditPassword() {
     const res = await fetch(`/api/admins/${username}/password`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: editPassword.value }),
+      body: JSON.stringify({ password }),
     })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
@@ -358,7 +349,7 @@ input.input-error { border-color: #dc3545; }
 
 .pwd-rules {
   list-style: none;
-  padding: 0.4rem 0 0 0;
+  padding: 0.35rem 0 0 0;
   margin: 0;
   display: flex;
   flex-direction: column;
@@ -375,6 +366,13 @@ input.input-error { border-color: #dc3545; }
 
 .alert-error { background: #f8d7da; color: #721c24; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
 .alert-info  { background: #d4edda; color: #155724; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+
+.btn-primary:disabled {
+  background: #6c9fd6;
+  border-color: #6c9fd6;
+  cursor: not-allowed;
+  opacity: 0.65;
+}
 
 .btn-secondary {
   padding: 0.3rem 0.7rem;


### PR DESCRIPTION
## Summary

- Backend (`actions.py`) : fonction `_validate_password_strength()` appelée dans `add_admin()` et `change_password()` — lève `ValueError` si règles non respectées, propagée en HTTP 400
- Frontend (`Admins.vue`) : composant `PasswordStrength` inline affichant les 5 règles avec indicateur ✓/✗ en temps réel sous chaque champ mot de passe
- Boutons de soumission désactivés tant que toutes les règles ne sont pas satisfaites et les deux champs ne concordent pas

## Règles appliquées

| Règle | Exemple valide |
|-------|---------------|
| 8 caractères minimum | `Aa1!xxxx` |
| Au moins une majuscule | `A…` |
| Au moins une minuscule | `…a…` |
| Au moins un chiffre | `…1…` |
| Au moins un caractère spécial | `…!` |

## Test plan

- [ ] Saisir `changeme` → toutes les règles manquantes affichées en rouge, bouton désactivé
- [ ] Saisir `Changeme1!` → toutes les règles en vert, bouton actif
- [ ] Tenter via curl `POST /api/admins` avec mot de passe faible → HTTP 400 avec message explicite
- [ ] Même validation dans le modal "Changer le mot de passe"