### PR TITLE
fix(admins): validator visible dans le modal édition mot de passe

### DIFF
--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -121,11 +121,11 @@
               id="edit-password"
               v-model="editPassword"
               type="password"
-              placeholder="••••••••"
+              placeholder="Nouveau mot de passe"
               autofocus
               :class="{ 'input-error': editPassword && !pwdRules(editPassword).every(r => r.ok) }"
             />
-            <ul v-if="editPassword" class="pwd-rules">
+            <ul class="pwd-rules">
               <li v-for="r in pwdRules(editPassword)" :key="r.label" :class="r.ok ? 'rule-ok' : 'rule-fail'">
                 {{ r.ok ? '✓' : '✗' }} {{ r.label }}
               </li>
@@ -137,7 +137,7 @@
               id="edit-password-confirm"
               v-model="editPasswordConfirm"
               type="password"
-              placeholder="••••••••"
+              placeholder="Confirmer le mot de passe"
               :class="{ 'input-error': editPasswordConfirm && editPassword !== editPasswordConfirm }"
             />
             <span v-if="editPasswordConfirm && editPassword !== editPasswordConfirm" class="field-error">


### PR DESCRIPTION
## Problème

Le `placeholder="••••••••"` du modal utilisait des vrais caractères bullet `•` qui ressemblaient à un mot de passe tapé alors que le champ était vide. `v-if="editPassword"` restait `false` et le validator ne s'affichait jamais.

## Correctif

- Suppression du `v-if` sur la liste des règles dans le modal → règles affichées dès l'ouverture (toutes en rouge, passent au vert au fur et à mesure)
- Placeholders remplacés par du texte descriptif

## Test plan

- [ ] Ouvrir le modal "Mot de passe" → les 5 règles apparaissent immédiatement en rouge
- [ ] Taper un mot de passe valide → toutes les règles passent au vert, bouton "Enregistrer" actif