### PR TITLE
fix(api): status manquant dans /api/keys — boutons d'action invisibles

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -157,7 +157,7 @@ def list_keys():
     status = request.args.get("status")
     server = request.args.get("server")
     sql = """
-        SELECT sk.*, ka.status AS auth_status, ka.server_id, ka.expires_at
+        SELECT sk.*, ka.status AS status, ka.server_id, ka.expires_at
         FROM ssh_keys sk
         LEFT JOIN key_authorizations ka ON ka.key_id = sk.id
         LEFT JOIN servers s ON s.id = ka.server_id


### PR DESCRIPTION
## Problème

`KeyTable.vue` lit `k.status` pour afficher les boutons Valider/Révoquer/Expiry. Mais la requête SQL de `/api/keys` retournait `ka.status AS auth_status` — le champ `status` était donc `undefined` dans le frontend, rendant tous les boutons invisibles.

## Correctif

Renommage de l'alias SQL : `auth_status` → `status`.

## Test plan

- [ ] Ouvrir ServerDetail d'un serveur scanné → les boutons Valider/Révoquer apparaissent selon le statut de chaque clé
- [ ] Clé PENDING_REVIEW → boutons "Valider" + "Révoquer" visibles
- [ ] Clé ACTIVE → boutons "Révoquer" + "Expiry" + "Assigner" visibles