### PR TITLE
fix(frontend): encoder les fingerprints dans les URLs — 404 sur Valider/Révoquer

### DIFF
--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -150,8 +150,10 @@ async function load() {
   }
 }
 
+const efp = (fp) => encodeURIComponent(fp)
+
 async function validate(fingerprint) {
-  await apiAction(`/api/keys/${fingerprint}/validate`, {}, 'Clé validée.')
+  await apiAction(`/api/keys/${efp(fingerprint)}/validate`, {}, 'Clé validée.')
 }
 
 function openRevoke(key) {
@@ -161,7 +163,7 @@ function openRevoke(key) {
 
 async function confirmRevoke() {
   const fp = revokeTarget.value.fingerprint
-  await apiAction(`/api/keys/${fp}/revoke`, { reason: revokeReason.value }, 'Clé révoquée.')
+  await apiAction(`/api/keys/${efp(fp)}/revoke`, { reason: revokeReason.value }, 'Clé révoquée.')
   revokeTarget.value = null
 }
 

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -203,8 +203,10 @@ async function scanServer() {
   }
 }
 
+const efp = (fp) => encodeURIComponent(fp)
+
 async function validateKey(fingerprint) {
-  await apiAction(`/api/keys/${fingerprint}/validate`, {}, `Clé validée.`)
+  await apiAction(`/api/keys/${efp(fingerprint)}/validate`, {}, `Clé validée.`)
 }
 
 function openRevoke(key) {
@@ -214,7 +216,7 @@ function openRevoke(key) {
 
 async function confirmRevoke() {
   const fp = revokeTarget.value.fingerprint
-  await apiAction(`/api/keys/${fp}/revoke`, { reason: revokeReason.value }, `Clé révoquée.`)
+  await apiAction(`/api/keys/${efp(fp)}/revoke`, { reason: revokeReason.value }, `Clé révoquée.`)
   revokeTarget.value = null
 }
 
@@ -225,7 +227,7 @@ function openAssign(fingerprint) {
 
 async function confirmAssign() {
   await apiAction(
-    `/api/keys/${assignTarget.value}/assign`,
+    `/api/keys/${efp(assignTarget.value)}/assign`,
     { owner_username: assignUsername.value },
     `Clé assignée à ${assignUsername.value}.`,
   )
@@ -244,7 +246,7 @@ async function confirmExpiry() {
     ? { hours: expiryHours.value }
     : { date: expiryDate.value }
   await apiAction(
-    `/api/keys/${expiryTarget.value.fingerprint}/set-expiry`,
+    `/api/keys/${efp(expiryTarget.value.fingerprint)}/set-expiry`,
     body,
     'Expiration définie.',
   )


### PR DESCRIPTION
## Problème

Les fingerprints SHA256 contiennent `/` (base64 standard). Dans l'URL `/api/keys/SHA256:abc/def/validate`, le `/` est interprété comme un séparateur de chemin — Flask ne trouve pas la route → HTTP 404.

## Correctif

`encodeURIComponent(fingerprint)` dans tous les appels API de `ServerDetail.vue` et `Anomalies.vue`. Le `/` devient `%2F`, Werkzeug le décode correctement côté backend.

## Fichiers modifiés

- `ui/src/views/ServerDetail.vue` : validate, revoke, assign, set-expiry
- `ui/src/views/Anomalies.vue` : validate, revoke

## Test plan

- [ ] Cliquer "Valider" sur une clé PENDING_REVIEW → succès (plus de 404)
- [ ] Cliquer "Révoquer" → modal puis révocation OK
- [ ] Vérifier que les fingerprints sans `/` fonctionnent aussi