### PR TITLE
fix: support SHA256 fingerprints with slashes in key action routes

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -189,7 +189,7 @@ def search_keys():
     return jsonify(rows)
 
 
-@app.route("/api/keys/<fingerprint>", methods=["GET"])
+@app.route("/api/keys/get/<path:fingerprint>", methods=["GET"])
 @require_auth
 def get_key(fingerprint):
     row = db.query_one("SELECT * FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
@@ -198,7 +198,7 @@ def get_key(fingerprint):
     return jsonify(row)
 
 
-@app.route("/api/keys/<fingerprint>/validate", methods=["POST"])
+@app.route("/api/keys/validate/<path:fingerprint>", methods=["POST"])
 @require_auth
 def validate_key(fingerprint):
     try:
@@ -208,7 +208,7 @@ def validate_key(fingerprint):
         return jsonify({"error": str(e)}), 404
 
 
-@app.route("/api/keys/<fingerprint>/revoke", methods=["POST"])
+@app.route("/api/keys/revoke/<path:fingerprint>", methods=["POST"])
 @require_auth
 def revoke_key(fingerprint):
     data = request.get_json(force=True) or {}
@@ -220,7 +220,7 @@ def revoke_key(fingerprint):
         return jsonify({"error": str(e)}), 404
 
 
-@app.route("/api/keys/<fingerprint>/assign", methods=["POST"])
+@app.route("/api/keys/assign/<path:fingerprint>", methods=["POST"])
 @require_auth
 def assign_key(fingerprint):
     data = request.get_json(force=True) or {}
@@ -231,13 +231,16 @@ def assign_key(fingerprint):
         return jsonify({"error": str(e)}), 400
 
 
-@app.route("/api/keys/<fingerprint>/set-expiry", methods=["POST"])
+@app.route("/api/keys/set-expiry/<path:fingerprint>", methods=["POST"])
 @require_auth
 def set_key_expiry(fingerprint):
+    from datetime import timedelta
     data = request.get_json(force=True) or {}
-    expires_at = _parse_datetime(data.get("expires_at"))
+    expires_at = _parse_datetime(data.get("expires_at") or data.get("date"))
+    if not expires_at and data.get("hours"):
+        expires_at = datetime.now(tz=timezone.utc) + timedelta(hours=int(data["hours"]))
     if not expires_at:
-        return jsonify({"error": "expires_at required (ISO format)"}), 400
+        return jsonify({"error": "hours or date required"}), 400
     try:
         actions.set_key_expiry(fingerprint, expires_at)
         return jsonify({"status": "expiry set", "expires_at": expires_at.isoformat()})
@@ -245,7 +248,7 @@ def set_key_expiry(fingerprint):
         return jsonify({"error": str(e)}), 404
 
 
-@app.route("/api/keys/<fingerprint>/remove-expiry", methods=["POST"])
+@app.route("/api/keys/remove-expiry/<path:fingerprint>", methods=["POST"])
 @require_auth
 def remove_key_expiry(fingerprint):
     try:

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -153,7 +153,7 @@ async function load() {
 const efp = (fp) => encodeURIComponent(fp)
 
 async function validate(fingerprint) {
-  await apiAction(`/api/keys/${efp(fingerprint)}/validate`, {}, 'Clé validée.')
+  await apiAction(`/api/keys/validate/${efp(fingerprint)}`, {}, 'Clé validée.')
 }
 
 function openRevoke(key) {
@@ -163,7 +163,7 @@ function openRevoke(key) {
 
 async function confirmRevoke() {
   const fp = revokeTarget.value.fingerprint
-  await apiAction(`/api/keys/${efp(fp)}/revoke`, { reason: revokeReason.value }, 'Clé révoquée.')
+  await apiAction(`/api/keys/revoke/${efp(fp)}`, { reason: revokeReason.value }, 'Clé révoquée.')
   revokeTarget.value = null
 }
 

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -206,7 +206,7 @@ async function scanServer() {
 const efp = (fp) => encodeURIComponent(fp)
 
 async function validateKey(fingerprint) {
-  await apiAction(`/api/keys/${efp(fingerprint)}/validate`, {}, `Clé validée.`)
+  await apiAction(`/api/keys/validate/${efp(fingerprint)}`, {}, `Clé validée.`)
 }
 
 function openRevoke(key) {
@@ -216,7 +216,7 @@ function openRevoke(key) {
 
 async function confirmRevoke() {
   const fp = revokeTarget.value.fingerprint
-  await apiAction(`/api/keys/${efp(fp)}/revoke`, { reason: revokeReason.value }, `Clé révoquée.`)
+  await apiAction(`/api/keys/revoke/${efp(fp)}`, { reason: revokeReason.value }, `Clé révoquée.`)
   revokeTarget.value = null
 }
 
@@ -227,7 +227,7 @@ function openAssign(fingerprint) {
 
 async function confirmAssign() {
   await apiAction(
-    `/api/keys/${efp(assignTarget.value)}/assign`,
+    `/api/keys/assign/${efp(assignTarget.value)}`,
     { owner_username: assignUsername.value },
     `Clé assignée à ${assignUsername.value}.`,
   )
@@ -246,7 +246,7 @@ async function confirmExpiry() {
     ? { hours: expiryHours.value }
     : { date: expiryDate.value }
   await apiAction(
-    `/api/keys/${efp(expiryTarget.value.fingerprint)}/set-expiry`,
+    `/api/keys/set-expiry/${efp(expiryTarget.value.fingerprint)}`,
     body,
     'Expiration définie.',
   )


### PR DESCRIPTION
## Summary

- Flask `<string:fingerprint>` rejects `/` characters; Werkzeug also decodes `%2F` before routing, making `encodeURIComponent` alone insufficient
- Restructured all key action routes from `POST /api/keys/<fp>/action` to `POST /api/keys/action/<path:fingerprint>` — the `<path:>` converter accepts slashes
- Fixed `set-expiry` endpoint to accept `hours` or `date` body params (matching what the frontend sends)
- Updated `ServerDetail.vue` and `Anomalies.vue` URLs to match new route structure

## Test plan

- [ ] Click "Valider" on a key with a SHA256 fingerprint containing `/` — should return 200 and refresh
- [ ] Click "Révoquer" with a reason — should return 200 and mark key as REVOKED
- [ ] Valider/Révoquer from Anomalies view works identically
- [ ] Set expiry with hours mode works
- [ ] Set expiry with date mode works