### PR TITLE
feat: ajout de serveur via l'UI + keyscan automatique

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -409,7 +409,12 @@ def add_server(
     hostname: str, ip: str, env: str, os_family: str | None = None,
     admin_id: str | None = None,
 ) -> dict:
-    """Insert a new server and log SERVER_ADDED."""
+    """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
+    import servers as servers_mod
+    try:
+        servers_mod.add_to_known_hosts(hostname)
+    except Exception as e:
+        raise ValueError(f"Impossible de joindre {hostname} pour le keyscan : {e}") from e
     db.execute(
         "INSERT INTO servers (hostname, ip_address, environment, os_family) VALUES (%s, %s, %s, %s)",
         (hostname, ip, env, os_family),

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -2,9 +2,12 @@
   <div class="dashboard-view">
     <div class="page-header">
       <h1>Dashboard</h1>
-      <button class="btn-primary" :disabled="scanning" @click="scanAll">
-        {{ scanning ? 'Scan en cours…' : 'Scanner maintenant' }}
-      </button>
+      <div class="header-actions">
+        <button class="btn-secondary" @click="openAddServer">+ Ajouter un serveur</button>
+        <button class="btn-primary" :disabled="scanning" @click="scanAll">
+          {{ scanning ? 'Scan en cours…' : 'Scanner maintenant' }}
+        </button>
+      </div>
     </div>
 
     <div v-if="error" class="alert-error">{{ error }}</div>
@@ -31,6 +34,43 @@
 
     <div v-if="loading" class="loading">Chargement…</div>
     <ServerTable v-else :servers="servers" @scan="scanOne" />
+
+    <!-- Modal ajout serveur -->
+    <div v-if="showAddServer" class="modal-overlay" @click.self="closeAddServer">
+      <div class="modal">
+        <h3>Ajouter un serveur</h3>
+
+        <div v-if="addError" class="alert-error">{{ addError }}</div>
+
+        <label>Hostname <span class="required">*</span></label>
+        <input v-model="addForm.hostname" type="text" placeholder="ex: server-prod-01" />
+
+        <label>Adresse IP <span class="required">*</span></label>
+        <input v-model="addForm.ip" type="text" placeholder="ex: 192.168.1.10" />
+
+        <label>Environnement <span class="required">*</span></label>
+        <select v-model="addForm.environment">
+          <option value="">— Choisir —</option>
+          <option value="production">production</option>
+          <option value="staging">staging</option>
+          <option value="lab">lab</option>
+        </select>
+
+        <label>OS Family</label>
+        <input v-model="addForm.os_family" type="text" placeholder="ex: rhel, debian (optionnel)" />
+
+        <div class="modal-actions">
+          <button
+            class="btn-primary"
+            :disabled="!addFormValid || adding"
+            @click="confirmAddServer"
+          >
+            {{ adding ? 'Ajout en cours…' : 'Ajouter' }}
+          </button>
+          <button @click="closeAddServer">Annuler</button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -44,11 +84,58 @@ const scanning = ref(false)
 const error = ref('')
 const scanMessage = ref('')
 
+const showAddServer = ref(false)
+const adding = ref(false)
+const addError = ref('')
+const addForm = ref({ hostname: '', ip: '', environment: '', os_family: '' })
+
 const counts = computed(() => ({
   ok:     servers.value.filter(s => s.is_active && !s.has_anomalies).length,
   warn:   servers.value.filter(s => s.is_active && s.has_anomalies).length,
   danger: servers.value.filter(s => !s.is_active).length,
 }))
+
+const addFormValid = computed(() =>
+  addForm.value.hostname.trim() &&
+  addForm.value.ip.trim() &&
+  addForm.value.environment,
+)
+
+function openAddServer() {
+  addForm.value = { hostname: '', ip: '', environment: '', os_family: '' }
+  addError.value = ''
+  showAddServer.value = true
+}
+
+function closeAddServer() {
+  showAddServer.value = false
+}
+
+async function confirmAddServer() {
+  adding.value = true
+  addError.value = ''
+  try {
+    const res = await fetch('/api/servers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hostname: addForm.value.hostname.trim(),
+        ip: addForm.value.ip.trim(),
+        environment: addForm.value.environment,
+        os_family: addForm.value.os_family.trim() || null,
+      }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
+    closeAddServer()
+    scanMessage.value = `Serveur ${addForm.value.hostname} ajouté.`
+    await loadServers()
+  } catch (e) {
+    addError.value = e.message
+  } finally {
+    adding.value = false
+  }
+}
 
 async function loadServers() {
   loading.value = true
@@ -100,6 +187,8 @@ onMounted(loadServers)
   justify-content: space-between;
   margin-bottom: 1.25rem;
 }
+
+.header-actions { display: flex; gap: 0.75rem; }
 
 h1 { font-size: 1.5rem; }
 
@@ -153,4 +242,38 @@ h1 { font-size: 1.5rem; }
   border-radius: 4px;
   margin-bottom: 1rem;
 }
+
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.45);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  width: 440px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal h3 { font-size: 1.1rem; margin: 0; }
+.modal label { font-size: 0.85rem; font-weight: 600; }
+.required { color: #dc3545; }
+
+.modal input[type="text"],
+.modal select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.modal-actions { display: flex; gap: 0.75rem; justify-content: flex-end; }
 </style>


### PR DESCRIPTION
## Summary

- **Backend** (`actions.py`) : `add_server()` appelle désormais `add_to_known_hosts()` avant l'INSERT — le serveur est immédiatement joignable par paramiko après ajout. Si le keyscan échoue (hôte injoignable), une `ValueError` est levée et le serveur n'est pas inséré. Closes #70
- **Frontend** (`Dashboard.vue`) : bouton "+ Ajouter un serveur" ouvre un modal avec les champs hostname, IP, environnement (select), OS family (optionnel). Messages d'erreur affichés dans le modal. Closes #71

## Test plan

- [ ] Cliquer "+ Ajouter un serveur" ouvre le modal
- [ ] Soumettre sans hostname ou IP : bouton désactivé
- [ ] Ajouter un serveur valide : modal se ferme, liste rafraîchie, message de confirmation
- [ ] Ajouter un serveur injoignable : message d'erreur affiché dans le modal
- [ ] Après ajout, lancer un scan : aucune erreur `not found in known_hosts`