### PR TITLE
fix: style btn-secondary manquant dans App.vue

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -114,8 +114,10 @@ button {
   cursor: pointer;
   font-size: 0.85rem;
 }
-.btn-primary  { background: #0d6efd; color: #fff; }
-.btn-danger   { background: #dc3545; color: #fff; }
-.btn-success  { background: #198754; color: #fff; }
-.btn-warning  { background: #ffc107; color: #000; }
+.btn-primary   { background: #0d6efd; color: #fff; }
+.btn-secondary { background: #fff; color: #0d6efd; border-color: #0d6efd; }
+.btn-secondary:hover { background: #e7f0ff; }
+.btn-danger    { background: #dc3545; color: #fff; }
+.btn-success   { background: #198754; color: #fff; }
+.btn-warning   { background: #ffc107; color: #000; }
 </style>


### PR DESCRIPTION
## Summary

Le bouton "+ Ajouter un serveur" utilisait la classe `btn-secondary` qui n'était pas définie dans les styles globaux — le bouton était invisible. Ajout du style : fond blanc, texte et bordure bleus.