### PR TITLE
fix: known_hosts en 644 pour permettre l'écriture par Flask (nobody)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,7 +58,7 @@ if [ ! -f /data/pg/PG_VERSION ]; then
 
     # 4. Créer known_hosts vide
     touch /data/keys/known_hosts
-    chmod 600 /data/keys/known_hosts
+    chmod 644 /data/keys/known_hosts
 
     # 5. Initialiser le cluster PostgreSQL
     su -s /bin/sh postgres -c "initdb -D /data/pg --encoding=UTF8 --locale=C"


### PR DESCRIPTION
## Problème

`/data/keys/known_hosts` était créé en `chmod 600` (root uniquement). Flask tourne en `nobody` → `Permission denied` lors du keyscan depuis l'UI.

## Fix

`chmod 644` — sans risque car `known_hosts` ne contient que des clés publiques d'hôtes (aucune donnée confidentielle).