### PR TITLE
fix: chown nobody sur known_hosts pour que Flask puisse écrire

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -58,6 +58,7 @@ if [ ! -f /data/pg/PG_VERSION ]; then
 
     # 4. Créer known_hosts vide
     touch /data/keys/known_hosts
+    chown nobody:nobody /data/keys/known_hosts
     chmod 644 /data/keys/known_hosts
 
     # 5. Initialiser le cluster PostgreSQL


### PR DESCRIPTION
## Problème

`known_hosts` était `root:root 644` — `nobody` (Flask) pouvait lire mais pas écrire → `Permission denied` lors du keyscan depuis l'UI.

## Fix

`chown nobody:nobody /data/keys/known_hosts` au bootstrap. Flask peut maintenant écrire dans le fichier lors de l'ajout d'un serveur via l'UI.