### PR TITLE
fix: chown nobody sur collector_key pour que Flask puisse lire la clé privée SSH

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,6 +54,7 @@ if [ ! -f /data/pg/PG_VERSION ]; then
         -f /data/keys/collector_key \
         -N "" \
         -C "ssh-access-manager@$(hostname)"
+    chown nobody:nobody /data/keys/collector_key
     chmod 600 /data/keys/collector_key
 
     # 4. Créer known_hosts vide


### PR DESCRIPTION
## Problème

`collector_key` (clé privée ED25519) était `root:root 600` — Flask (`nobody`) ne pouvait pas la lire → `Permission denied` lors de la connexion SSH pour le scan.

## Fix

`chown nobody:nobody /data/keys/collector_key` au bootstrap, en conservant `chmod 600` pour que seul `nobody` puisse lire la clé.