### PR TITLE
fix: connexions SSH via IP plutôt que hostname

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -412,9 +412,9 @@ def add_server(
     """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
     import servers as servers_mod
     try:
-        servers_mod.add_to_known_hosts(hostname)
+        servers_mod.add_to_known_hosts(ip)
     except Exception as e:
-        raise ValueError(f"Impossible de joindre {hostname} pour le keyscan : {e}") from e
+        raise ValueError(f"Impossible de joindre {hostname} ({ip}) pour le keyscan : {e}") from e
     db.execute(
         "INSERT INTO servers (hostname, ip_address, environment, os_family) VALUES (%s, %s, %s, %s)",
         (hostname, ip, env, os_family),

--- a/app/collect.py
+++ b/app/collect.py
@@ -69,12 +69,13 @@ def scan_server(server: dict) -> dict:
     Returns a result dict with counts and optional error.
     """
     hostname = server["hostname"]
+    ip = server["ip_address"]
     server_id = server["id"]
     result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None}
 
     try:
-        ssh.ensure_scripts(hostname, server_id)
-        raw_lines = ssh.collect_keys(hostname)
+        ssh.ensure_scripts(ip, server_id)
+        raw_lines = ssh.collect_keys(ip)
     except Exception as exc:
         result["error"] = str(exc)
         db.execute(
@@ -154,7 +155,7 @@ def scan_server(server: dict) -> dict:
     )
     for row in active_on_server:
         if row["fingerprint"] not in collected_fps:
-            actions.handle_disappeared_key(row["key_id"], server_id, hostname)
+            actions.handle_disappeared_key(row["key_id"], server_id, ip)
             result["disappeared"] += 1
 
     db.execute(


### PR DESCRIPTION
## Summary

`collect.py` et `actions.py` utilisaient le `hostname` pour les connexions SSH, ce qui échoue si le hostname n'est pas résolvable DNS depuis le container. L'`ip_address` stockée en base est utilisée à la place. Le hostname reste utilisé pour les logs et l'audit. Closes #80

## Changements

- `collect.py` : `ensure_scripts(ip)`, `collect_keys(ip)`, `handle_disappeared_key(..., ip)`
- `actions.py` : `add_to_known_hosts(ip)` lors de l'ajout d'un serveur

## Test plan

- [ ] Ajouter `rocky9-pve.org` via le Dashboard → keyscan par IP réussit
- [ ] Lancer un scan → connexion SSH par IP réussit
- [ ] Les logs d'audit affichent toujours le hostname