### PR TITLE
fix: connexion SSH tente hostname d'abord, fallback sur IP si DNS échoue

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -96,7 +96,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
         )
 
 
-def handle_disappeared_key(key_id: str, server_id: str, hostname: str) -> None:
+def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str | None = None) -> None:
     """
     Scenario 2 — key was ACTIVE but disappeared from server (out-of-system revocation).
     Sets REVOKED + revoked_automatically=True, logs ANOMALY_DETECTED, sends CRITICAL alert.
@@ -412,7 +412,7 @@ def add_server(
     """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
     import servers as servers_mod
     try:
-        servers_mod.add_to_known_hosts(ip)
+        servers_mod.add_to_known_hosts(hostname, ip=ip)
     except Exception as e:
         raise ValueError(f"Impossible de joindre {hostname} ({ip}) pour le keyscan : {e}") from e
     db.execute(

--- a/app/collect.py
+++ b/app/collect.py
@@ -74,8 +74,8 @@ def scan_server(server: dict) -> dict:
     result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None}
 
     try:
-        ssh.ensure_scripts(ip, server_id)
-        raw_lines = ssh.collect_keys(ip)
+        ssh.ensure_scripts(hostname, server_id, ip=ip)
+        raw_lines = ssh.collect_keys(hostname, ip=ip)
     except Exception as exc:
         result["error"] = str(exc)
         db.execute(
@@ -155,7 +155,7 @@ def scan_server(server: dict) -> dict:
     )
     for row in active_on_server:
         if row["fingerprint"] not in collected_fps:
-            actions.handle_disappeared_key(row["key_id"], server_id, ip)
+            actions.handle_disappeared_key(row["key_id"], server_id, hostname, ip=ip)
             result["disappeared"] += 1
 
     db.execute(

--- a/app/servers.py
+++ b/app/servers.py
@@ -24,18 +24,30 @@ def _hostname_in_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS) -> b
         return False
 
 
-def add_to_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS) -> None:
-    """Run ssh-keyscan and append the result to known_hosts if not present."""
-    if _hostname_in_known_hosts(hostname, known_hosts):
-        return
-    result = subprocess.run(
-        ["ssh-keyscan", "-H", "-T", "10", hostname],
-        capture_output=True,
-        text=True,
-    )
-    if result.stdout:
-        with open(known_hosts, "a") as f:
-            f.write(result.stdout)
+def add_to_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS, ip: str | None = None) -> None:
+    """Run ssh-keyscan on hostname (fallback to ip) and append to known_hosts if not present."""
+    target = hostname
+    if not _hostname_in_known_hosts(hostname, known_hosts):
+        result = subprocess.run(
+            ["ssh-keyscan", "-H", "-T", "10", hostname],
+            capture_output=True,
+            text=True,
+        )
+        if result.stdout:
+            with open(known_hosts, "a") as f:
+                f.write(result.stdout)
+            return
+        if ip and ip != hostname and not _hostname_in_known_hosts(ip, known_hosts):
+            result = subprocess.run(
+                ["ssh-keyscan", "-H", "-T", "10", ip],
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                with open(known_hosts, "a") as f:
+                    f.write(result.stdout)
+            else:
+                raise RuntimeError(f"ssh-keyscan failed for {hostname} and {ip}")
 
 
 def sync_servers(path: str = SERVERS_YML) -> list[dict]:

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import os
+import socket
 
 import paramiko
 
@@ -91,17 +92,21 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _connect(hostname: str) -> paramiko.SSHClient:
+def _try_connect(host: str) -> paramiko.SSHClient:
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.RejectPolicy())
     client.load_host_keys(KNOWN_HOSTS)
-    client.connect(
-        hostname=hostname,
-        username=SSH_USER,
-        key_filename=COLLECTOR_KEY,
-        timeout=15,
-    )
+    client.connect(hostname=host, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
     return client
+
+
+def _connect(hostname: str, ip: str | None = None) -> paramiko.SSHClient:
+    try:
+        return _try_connect(hostname)
+    except (socket.gaierror, OSError):
+        if ip and ip != hostname:
+            return _try_connect(ip)
+        raise
 
 
 def _run(client: paramiko.SSHClient, cmd: str) -> tuple[str, str, int]:
@@ -134,12 +139,12 @@ def _deploy_script(
     _run(client, f"sudo /bin/chmod 755 {remote_path}")
 
 
-def ensure_scripts(hostname: str, server_id: str) -> None:
+def ensure_scripts(hostname: str, server_id: str, ip: str | None = None) -> None:
     """
     Deploy SAM_COLLECT and SAM_REVOKE on the remote host if absent or outdated.
     Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
     """
-    client = _connect(hostname)
+    client = _connect(hostname, ip)
     try:
         sftp = client.open_sftp()
         for content, remote_path in (
@@ -169,9 +174,9 @@ def ensure_scripts(hostname: str, server_id: str) -> None:
         client.close()
 
 
-def revoke_on_server(hostname: str, fingerprint: str) -> None:
+def revoke_on_server(hostname: str, fingerprint: str, ip: str | None = None) -> None:
     """Run sam-revoke on the remote host to remove the key with given fingerprint."""
-    client = _connect(hostname)
+    client = _connect(hostname, ip)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_REVOKE_PATH} '{fingerprint}'"
@@ -184,9 +189,9 @@ def revoke_on_server(hostname: str, fingerprint: str) -> None:
         client.close()
 
 
-def collect_keys(hostname: str) -> list[str]:
+def collect_keys(hostname: str, ip: str | None = None) -> list[str]:
     """Run sam-collect on the remote host and return raw output lines."""
-    client = _connect(hostname)
+    client = _connect(hostname, ip)
     try:
         out, _, rc = _run(client, f"sudo {SAM_COLLECT_PATH}")
         if rc != 0:


### PR DESCRIPTION
## Summary

Approche plus robuste que le #80 : on tente le hostname en premier (comportement standard), et si une erreur DNS/socket se produit, on réessaie avec l'IP. Closes #82

## Changements

- `ssh.py` : `_connect(hostname, ip=None)` — essaie hostname, fallback IP sur `socket.gaierror` / `OSError`. Nouvelle fonction interne `_try_connect(host)`
- `ssh.py` : `ensure_scripts()`, `collect_keys()`, `revoke_on_server()` acceptent `ip=None`
- `collect.py` : passe `ip=server["ip_address"]` à tous les appels SSH
- `servers.py` : `add_to_known_hosts()` tente keyscan hostname, fallback keyscan IP
- `actions.py` : passe `ip=ip` au keyscan et `hostname` en premier argument

## Test plan

- [ ] Hostname résolvable → connexion par hostname (pas de fallback)
- [ ] Hostname non résolvable → fallback IP transparent
- [ ] Ajout serveur via UI → keyscan hostname puis IP si nécessaire
- [ ] Scan complet fonctionne sur `rocky9-pve.org`