### PR TITLE
fix: connexions SSH toujours par IP, hostname uniquement pour l'affichage

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -60,7 +60,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
 
     active_auths = db.query(
         """
-        SELECT ka.server_id, s.hostname
+        SELECT ka.server_id, s.hostname, s.ip_address
         FROM key_authorizations ka
         JOIN servers s ON s.id = ka.server_id
         WHERE ka.key_id = %s AND ka.status = 'ACTIVE'
@@ -69,7 +69,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
     )
 
     for auth in active_auths:
-        ssh.revoke_on_server(auth["hostname"], fingerprint)
+        ssh.revoke_on_server(auth["hostname"], fingerprint, ip=auth["ip_address"])
         db.execute(
             """
             UPDATE key_authorizations
@@ -96,7 +96,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
         )
 
 
-def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str | None = None) -> None:
+def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str) -> None:
     """
     Scenario 2 — key was ACTIVE but disappeared from server (out-of-system revocation).
     Sets REVOKED + revoked_automatically=True, logs ANOMALY_DETECTED, sends CRITICAL alert.
@@ -383,9 +383,9 @@ def revoke_request(request_id: str, admin_id: str) -> None:
 
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (req["key_id"],))
     if key:
-        server = db.query_one("SELECT hostname FROM servers WHERE id = %s", (req["server_id"],))
+        server = db.query_one("SELECT hostname, ip_address FROM servers WHERE id = %s", (req["server_id"],))
         if server:
-            ssh.revoke_on_server(server["hostname"], key["fingerprint"])
+            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"])
 
     db.execute(
         """
@@ -412,7 +412,7 @@ def add_server(
     """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
     import servers as servers_mod
     try:
-        servers_mod.add_to_known_hosts(hostname, ip=ip)
+        servers_mod.add_to_known_hosts(ip)
     except Exception as e:
         raise ValueError(f"Impossible de joindre {hostname} ({ip}) pour le keyscan : {e}") from e
     db.execute(

--- a/app/servers.py
+++ b/app/servers.py
@@ -24,30 +24,20 @@ def _hostname_in_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS) -> b
         return False
 
 
-def add_to_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS, ip: str | None = None) -> None:
-    """Run ssh-keyscan on hostname (fallback to ip) and append to known_hosts if not present."""
-    target = hostname
-    if not _hostname_in_known_hosts(hostname, known_hosts):
-        result = subprocess.run(
-            ["ssh-keyscan", "-H", "-T", "10", hostname],
-            capture_output=True,
-            text=True,
-        )
-        if result.stdout:
-            with open(known_hosts, "a") as f:
-                f.write(result.stdout)
-            return
-        if ip and ip != hostname and not _hostname_in_known_hosts(ip, known_hosts):
-            result = subprocess.run(
-                ["ssh-keyscan", "-H", "-T", "10", ip],
-                capture_output=True,
-                text=True,
-            )
-            if result.stdout:
-                with open(known_hosts, "a") as f:
-                    f.write(result.stdout)
-            else:
-                raise RuntimeError(f"ssh-keyscan failed for {hostname} and {ip}")
+def add_to_known_hosts(ip: str, known_hosts: str = KNOWN_HOSTS) -> None:
+    """Run ssh-keyscan on ip and append to known_hosts if not present."""
+    if _hostname_in_known_hosts(ip, known_hosts):
+        return
+    result = subprocess.run(
+        ["ssh-keyscan", "-H", "-T", "10", ip],
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout:
+        with open(known_hosts, "a") as f:
+            f.write(result.stdout)
+    else:
+        raise RuntimeError(f"ssh-keyscan failed for {ip}")
 
 
 def sync_servers(path: str = SERVERS_YML) -> list[dict]:

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,7 +1,6 @@
 import hashlib
 import io
 import os
-import socket
 
 import paramiko
 
@@ -92,21 +91,12 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _try_connect(host: str) -> paramiko.SSHClient:
+def _connect(ip: str) -> paramiko.SSHClient:
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.RejectPolicy())
     client.load_host_keys(KNOWN_HOSTS)
-    client.connect(hostname=host, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
+    client.connect(hostname=ip, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
     return client
-
-
-def _connect(hostname: str, ip: str | None = None) -> paramiko.SSHClient:
-    try:
-        return _try_connect(hostname)
-    except (socket.gaierror, OSError):
-        if ip and ip != hostname:
-            return _try_connect(ip)
-        raise
 
 
 def _run(client: paramiko.SSHClient, cmd: str) -> tuple[str, str, int]:
@@ -139,12 +129,12 @@ def _deploy_script(
     _run(client, f"sudo /bin/chmod 755 {remote_path}")
 
 
-def ensure_scripts(hostname: str, server_id: str, ip: str | None = None) -> None:
+def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
     """
     Deploy SAM_COLLECT and SAM_REVOKE on the remote host if absent or outdated.
     Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
     """
-    client = _connect(hostname, ip)
+    client = _connect(ip)
     try:
         sftp = client.open_sftp()
         for content, remote_path in (
@@ -174,9 +164,9 @@ def ensure_scripts(hostname: str, server_id: str, ip: str | None = None) -> None
         client.close()
 
 
-def revoke_on_server(hostname: str, fingerprint: str, ip: str | None = None) -> None:
+def revoke_on_server(hostname: str, fingerprint: str, ip: str) -> None:
     """Run sam-revoke on the remote host to remove the key with given fingerprint."""
-    client = _connect(hostname, ip)
+    client = _connect(ip)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_REVOKE_PATH} '{fingerprint}'"
@@ -189,9 +179,9 @@ def revoke_on_server(hostname: str, fingerprint: str, ip: str | None = None) -> 
         client.close()
 
 
-def collect_keys(hostname: str, ip: str | None = None) -> list[str]:
+def collect_keys(hostname: str, ip: str) -> list[str]:
     """Run sam-collect on the remote host and return raw output lines."""
-    client = _connect(hostname, ip)
+    client = _connect(ip)
     try:
         out, _, rc = _run(client, f"sudo {SAM_COLLECT_PATH}")
         if rc != 0:


### PR DESCRIPTION
## Problème

L'approche "hostname d'abord, fallback IP" (#83) est fondamentalement incorrecte : depuis le container, un hostname peut se résoudre vers une IP publique aléatoire (ex: `ffdsf` → `92.135.44.62`) au lieu du serveur cible. Le fallback ne se déclenche jamais car le DNS "réussit" — mais vers le mauvais serveur.

## Fix

Toujours connecter par IP (`ip_address` de la DB). Le hostname reste utilisé uniquement pour les logs et l'audit. L'IP saisie par l'admin est la seule source de vérité fiable.

- `ssh.py` : `_connect(ip)` — suppression de la logique fallback
- `servers.py` : `add_to_known_hosts(ip)` — keyscan par IP directement
- `actions.py` : toutes les requêtes récupèrent `ip_address` en plus de `hostname`
- `collect.py` : inchangé (passait déjà `ip=`)