### PR TITLE
fix: revoke_key() supprime la clé du serveur même si PENDING_REVIEW

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -63,7 +63,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
         SELECT ka.server_id, s.hostname, s.ip_address
         FROM key_authorizations ka
         JOIN servers s ON s.id = ka.server_id
-        WHERE ka.key_id = %s AND ka.status = 'ACTIVE'
+        WHERE ka.key_id = %s AND ka.status IN ('ACTIVE', 'PENDING_REVIEW')
         """,
         (key["id"],),
     )


### PR DESCRIPTION
## Problème

`revoke_key()` ne cherchait que `status = 'ACTIVE'`. Une clé `PENDING_REVIEW` (présente sur le serveur mais non encore validée) n'était jamais trouvée → `revoke_on_server` non appelé → la clé restait physiquement sur le serveur et le statut en DB ne changeait pas.

## Fix

Changer `status = 'ACTIVE'` en `status IN ('ACTIVE', 'PENDING_REVIEW')` — une révocation supprime la clé du serveur quelle que soit son étape de validation.