### PR TITLE
fix: provision-host.sh append la clé sans écraser les existantes

### DIFF
--- a/provision-host.sh
+++ b/provision-host.sh
@@ -28,8 +28,11 @@ mkdir -p "${SSH_DIR}"
 chmod 700 "${SSH_DIR}"
 chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "${SSH_DIR}"
 
-# 3. Déployer la clé publique
-echo "${COLLECTOR_PUBKEY}" > "${AUTH_KEYS}"
+# 3. Déployer la clé publique (ajout si absente, ne pas écraser les clés existantes)
+touch "${AUTH_KEYS}"
+if ! grep -qF "${COLLECTOR_PUBKEY}" "${AUTH_KEYS}" 2>/dev/null; then
+    echo "${COLLECTOR_PUBKEY}" >> "${AUTH_KEYS}"
+fi
 chmod 600 "${AUTH_KEYS}"
 chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "${AUTH_KEYS}"
 echo "[provision] Clé publique déployée dans ${AUTH_KEYS}."


### PR DESCRIPTION
## Problème

- `provision-host.sh` utilisait `>` → écrasait toutes les clés existantes à chaque exécution
- Le `chown audit-collector` était déjà présent mais le déploiement manuel via `echo >>` (sans chown) causait `root:root` → `Authentication failed` avec `StrictModes yes`

## Fix

- Utilise `>>` avec vérification `grep -qF` pour n'ajouter la clé que si elle est absente (idempotent)
- `chown audit-collector:audit-collector` garanti après chaque exécution

Closes #86