### PR TITLE
feat: désactiver, réactiver et supprimer un serveur depuis l'UI

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -447,6 +447,35 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
     )
 
 
+def enable_server(hostname: str, admin_id: str | None = None) -> None:
+    """Set is_active=true and log SERVER_ADDED."""
+    server = db.query_one(
+        "SELECT id FROM servers WHERE hostname = %s AND is_active = false", (hostname,)
+    )
+    if not server:
+        raise ValueError(f"Inactive server not found: {hostname}")
+    db.execute("UPDATE servers SET is_active = true WHERE id = %s", (server["id"],))
+    db.execute(
+        """
+        INSERT INTO audit_log (action, performed_by, target_server, details)
+        VALUES ('SERVER_ADDED', %s, %s, %s::jsonb)
+        """,
+        (admin_id, server["id"], json.dumps({"hostname": hostname, "reactivated": True})),
+    )
+
+
+def delete_server(hostname: str, admin_id: str | None = None) -> None:
+    """Hard delete a server and all related data."""
+    server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+    if not server:
+        raise ValueError(f"Server not found: {hostname}")
+    sid = server["id"]
+    db.execute("DELETE FROM audit_log WHERE target_server = %s", (sid,))
+    db.execute("DELETE FROM access_requests WHERE server_id = %s", (sid,))
+    db.execute("DELETE FROM key_authorizations WHERE server_id = %s", (sid,))
+    db.execute("DELETE FROM servers WHERE id = %s", (sid,))
+
+
 # ---------------------------------------------------------------------------
 # Administrateurs
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -140,6 +140,26 @@ def disable_server(hostname):
         return jsonify({"error": str(e)}), 404
 
 
+@app.route("/api/servers/<hostname>/enable", methods=["PUT"])
+@require_auth
+def enable_server(hostname):
+    try:
+        actions.enable_server(hostname, g.admin_id)
+        return jsonify({"status": "enabled"})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 404
+
+
+@app.route("/api/servers/<hostname>", methods=["DELETE"])
+@require_auth
+def delete_server(hostname):
+    try:
+        actions.delete_server(hostname, g.admin_id)
+        return jsonify({"status": "deleted"})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 404
+
+
 @app.route("/api/servers/<hostname>/scan", methods=["POST"])
 @require_auth
 def scan_server(hostname):

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -5,9 +5,20 @@
         <button class="btn-back" @click="$router.back()">← Retour</button>
         <h1>{{ hostname }}</h1>
       </div>
-      <button class="btn-primary" :disabled="scanning" @click="scanServer">
-        {{ scanning ? 'Scan en cours…' : 'Scanner' }}
-      </button>
+      <div class="header-actions">
+        <button class="btn-primary" :disabled="scanning" @click="scanServer">
+          {{ scanning ? 'Scan en cours…' : 'Scanner' }}
+        </button>
+        <button v-if="server.is_active" class="btn-warning" @click="confirmDisable">
+          Désactiver
+        </button>
+        <button v-else class="btn-success" @click="reactivate">
+          Réactiver
+        </button>
+        <button class="btn-danger" @click="showDeleteModal = true">
+          Supprimer
+        </button>
+      </div>
     </div>
 
     <div v-if="error" class="alert-error">{{ error }}</div>
@@ -68,6 +79,22 @@
         <p v-else class="empty">Aucun accès temporaire actif.</p>
       </section>
     </template>
+
+    <!-- Modal suppression -->
+    <div v-if="showDeleteModal" class="modal-overlay" @click.self="showDeleteModal = false">
+      <div class="modal">
+        <h3>Supprimer le serveur</h3>
+        <p class="warn-text">
+          ⚠️ Cette action est <strong>irréversible</strong>. Toutes les clés,
+          autorisations et logs associés à <strong>{{ hostname }}</strong> seront
+          définitivement supprimés.
+        </p>
+        <div class="modal-actions">
+          <button class="btn-danger" @click="deleteServer">Supprimer définitivement</button>
+          <button @click="showDeleteModal = false">Annuler</button>
+        </div>
+      </div>
+    </div>
 
     <!-- Modal révocation -->
     <div v-if="revokeTarget" class="modal-overlay" @click.self="revokeTarget = null">
@@ -139,10 +166,11 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import KeyTable from '../components/KeyTable.vue'
 
 const route = useRoute()
+const router = useRouter()
 const hostname = route.params.hostname
 
 const server = ref({})
@@ -152,6 +180,8 @@ const loading = ref(true)
 const scanning = ref(false)
 const error = ref('')
 const message = ref('')
+
+const showDeleteModal = ref(false)
 
 const revokeTarget = ref(null)
 const revokeReason = ref('')
@@ -184,6 +214,30 @@ async function load() {
     error.value = e.message
   } finally {
     loading.value = false
+  }
+}
+
+async function confirmDisable() {
+  if (!confirm(`Désactiver ${hostname} ?`)) return
+  await apiAction(`/api/servers/${hostname}/disable`, null, 'PUT', 'Serveur désactivé.')
+}
+
+async function reactivate() {
+  await apiAction(`/api/servers/${hostname}/enable`, null, 'PUT', 'Serveur réactivé.')
+}
+
+async function deleteServer() {
+  showDeleteModal.value = false
+  error.value = ''
+  try {
+    const res = await fetch(`/api/servers/${hostname}`, { method: 'DELETE' })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    router.push('/')
+  } catch (e) {
+    error.value = e.message
   }
 }
 
@@ -253,14 +307,15 @@ async function confirmExpiry() {
   expiryTarget.value = null
 }
 
-async function apiAction(url, body, successMsg) {
+async function apiAction(url, body, method = 'POST', successMsg) {
+  if (typeof method !== 'string') { successMsg = method; method = 'POST' }
   error.value = ''
   message.value = ''
   try {
     const res = await fetch(url, {
-      method: 'POST',
+      method,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
+      body: body != null ? JSON.stringify(body) : undefined,
     })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
@@ -302,6 +357,8 @@ onMounted(load)
   margin-bottom: 1.25rem;
 }
 .page-header > div { display: flex; align-items: center; gap: 1rem; }
+.header-actions { display: flex; gap: 0.5rem; }
+.warn-text { font-size: 0.9rem; line-height: 1.5; }
 
 h1 { font-size: 1.5rem; }
 h2 { font-size: 1.1rem; margin-bottom: 0.75rem; }


### PR DESCRIPTION
## Summary

- **Backend** : `enable_server()` + `PUT /api/servers/<hostname>/enable` et `delete_server()` + `DELETE /api/servers/<hostname>`. La suppression efface en cascade audit_log, access_requests, key_authorizations puis servers. Closes #88
- **Frontend** : trois boutons dans `ServerDetail.vue` — Désactiver (confirm natif), Réactiver, Supprimer (modal d'avertissement irréversible). Après suppression, redirection vers Dashboard. Closes #89

## Test plan

- [ ] Bouton "Désactiver" visible sur un serveur actif → confirmation → serveur passe inactif
- [ ] Bouton "Réactiver" visible sur un serveur inactif → serveur repasse actif
- [ ] Bouton "Supprimer" → modal avertissement → suppression → redirection Dashboard
- [ ] Serveur supprimé n'apparaît plus dans la liste