### PR TITLE
feat: visual indicators for disabled servers

### DIFF
--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -28,9 +28,10 @@
         <tr v-for="s in filtered" :key="s.id" :class="rowClass(s)">
           <td>{{ statusIcon(s) }}</td>
           <td>
-            <router-link :to="`/servers/${s.hostname}`" class="server-link">
+            <router-link :to="`/servers/${s.hostname}`" class="server-link" :class="{ 'link-disabled': !s.is_active }">
               {{ s.hostname }}
             </router-link>
+            <span v-if="!s.is_active" class="badge badge-disabled">DÉSACTIVÉ</span>
           </td>
           <td>{{ s.ip_address }}</td>
           <td>
@@ -124,8 +125,14 @@ function formatDate(iso) {
 
 .empty { text-align: center; color: #888; padding: 1rem 0; }
 
-.row-danger { background: #fff5f5; }
+.row-danger { background: #fde8e8; opacity: 0.8; }
+.row-danger td { color: #6c6c6c; }
 .row-warning { background: #fffbf0; }
+
+.link-disabled { color: #999; }
+.link-disabled:hover { color: #777; }
+
+.badge-disabled { background: #dc3545; color: #fff; margin-left: 0.5rem; font-size: 0.7rem; padding: 0.1rem 0.4rem; }
 
 .badge-critical { background: #f8d7da; color: #721c24; }
 .badge-pending  { background: #fff3cd; color: #856404; }

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -21,6 +21,10 @@
       </div>
     </div>
 
+    <div v-if="!loading && !server.is_active" class="alert-disabled">
+      🔴 Ce serveur est <strong>désactivé</strong> — il n'est plus scanné automatiquement.
+    </div>
+
     <div v-if="error" class="alert-error">{{ error }}</div>
     <div v-if="message" class="alert-info">{{ message }}</div>
 
@@ -395,8 +399,9 @@ dd { margin: 0; }
 .empty { color: #888; font-size: 0.9rem; padding: 0.5rem 0; }
 .loading { text-align: center; padding: 2rem; color: #888; }
 
-.alert-error { background: #f8d7da; color: #721c24; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
-.alert-info  { background: #d4edda; color: #155724; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+.alert-error    { background: #f8d7da; color: #721c24; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+.alert-info     { background: #d4edda; color: #155724; padding: 0.6rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+.alert-disabled { background: #f8d7da; color: #721c24; border: 1px solid #f5c6cb; padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; font-size: 0.95rem; }
 
 .modal-overlay {
   position: fixed; inset: 0;


### PR DESCRIPTION
## Summary

- ServerDetail.vue: red banner at top when server is disabled ("🔴 Ce serveur est désactivé")
- ServerTable.vue: grayed-out row + red "DÉSACTIVÉ" badge next to hostname + dimmed link color

## Test plan

- [ ] Disable a server → banner appears in ServerDetail, row grayed out in Dashboard with DÉSACTIVÉ badge
- [ ] Reactivate server → indicators disappear