### PR TITLE
fix: apiAction calls passing success message as HTTP method

### DIFF
--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -264,7 +264,7 @@ async function scanServer() {
 const efp = (fp) => encodeURIComponent(fp)
 
 async function validateKey(fingerprint) {
-  await apiAction(`/api/keys/validate/${efp(fingerprint)}`, {}, `Clé validée.`)
+  await apiAction(`/api/keys/validate/${efp(fingerprint)}`, {}, 'POST', 'Clé validée.')
 }
 
 function openRevoke(key) {
@@ -274,7 +274,7 @@ function openRevoke(key) {
 
 async function confirmRevoke() {
   const fp = revokeTarget.value.fingerprint
-  await apiAction(`/api/keys/revoke/${efp(fp)}`, { reason: revokeReason.value }, `Clé révoquée.`)
+  await apiAction(`/api/keys/revoke/${efp(fp)}`, { reason: revokeReason.value }, 'POST', 'Clé révoquée.')
   revokeTarget.value = null
 }
 
@@ -287,6 +287,7 @@ async function confirmAssign() {
   await apiAction(
     `/api/keys/assign/${efp(assignTarget.value)}`,
     { owner_username: assignUsername.value },
+    'POST',
     `Clé assignée à ${assignUsername.value}.`,
   )
   assignTarget.value = null
@@ -306,13 +307,13 @@ async function confirmExpiry() {
   await apiAction(
     `/api/keys/set-expiry/${efp(expiryTarget.value.fingerprint)}`,
     body,
+    'POST',
     'Expiration définie.',
   )
   expiryTarget.value = null
 }
 
 async function apiAction(url, body, method = 'POST', successMsg) {
-  if (typeof method !== 'string') { successMsg = method; method = 'POST' }
   error.value = ''
   message.value = ''
   try {


### PR DESCRIPTION
## Summary

- `validateKey`, `confirmRevoke`, `confirmAssign`, `confirmExpiry` all omitted the `method` argument, causing the success message string (e.g. `'Clé validée.'`) to land in the `method` parameter of `apiAction`
- The existing overload guard `typeof method !== 'string'` couldn't detect this since the message is also a string
- Fix: pass `'POST'` explicitly in all 4 callers and remove the now-dead overload guard

## Test plan

- [ ] Click Valider on a PENDING_REVIEW key → "Clé validée." success message, no fetch error
- [ ] Click Révoquer → modal → confirm → key revoked, no fetch error