### PR TITLE
feat: add Illimité button to remove key expiry

### DIFF
--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -43,6 +43,11 @@
             @click="$emit('set-expiry', k)"
           >Expiry</button>
           <button
+            v-if="k.status === 'ACTIVE' && k.expires_at"
+            class="btn-secondary"
+            @click="$emit('remove-expiry', k.fingerprint)"
+          >Illimité</button>
+          <button
             v-if="!k.owner && k.status === 'ACTIVE'"
             class="btn-primary"
             @click="$emit('assign', k.fingerprint)"
@@ -55,7 +60,7 @@
 
 <script setup>
 defineProps({ keys: { type: Array, default: () => [] } })
-defineEmits(['validate', 'revoke', 'set-expiry', 'assign'])
+defineEmits(['validate', 'revoke', 'set-expiry', 'remove-expiry', 'assign'])
 
 function statusBadge(status) {
   return {

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -53,6 +53,7 @@
           @validate="validateKey"
           @revoke="openRevoke"
           @set-expiry="openExpiry"
+          @remove-expiry="removeExpiry"
           @assign="openAssign"
         />
       </section>
@@ -311,6 +312,10 @@ async function confirmExpiry() {
     'Expiration définie.',
   )
   expiryTarget.value = null
+}
+
+async function removeExpiry(fingerprint) {
+  await apiAction(`/api/keys/remove-expiry/${efp(fingerprint)}`, null, 'POST', 'Expiration retirée — clé illimitée.')
 }
 
 async function apiAction(url, body, method = 'POST', successMsg) {


### PR DESCRIPTION
## Summary

- `KeyTable.vue`: new "Illimité" button visible when a key is ACTIVE and has `expires_at` set — emits `remove-expiry`
- `ServerDetail.vue`: handles `remove-expiry` event by calling `POST /api/keys/remove-expiry/<fingerprint>`
- Backend already supported (`actions.remove_key_expiry()` + route existed)

## Test plan

- [ ] Set an expiry on an ACTIVE key → "Illimité" button appears next to "Expiry"
- [ ] Click "Illimité" → `expires_at` cleared, button disappears, success message shown
- [ ] Key without expiry → no "Illimité" button shown