### PR TITLE
fix: key owner column shows username after assign

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -177,10 +177,12 @@ def list_keys():
     status = request.args.get("status")
     server = request.args.get("server")
     sql = """
-        SELECT sk.*, ka.status AS status, ka.server_id, ka.expires_at
+        SELECT sk.*, ka.status AS status, ka.server_id, ka.expires_at,
+               a.username AS owner
         FROM ssh_keys sk
         LEFT JOIN key_authorizations ka ON ka.key_id = sk.id
         LEFT JOIN servers s ON s.id = ka.server_id
+        LEFT JOIN administrators a ON a.id = sk.owner_id
         WHERE 1=1
     """
     params = []


### PR DESCRIPTION
The /api/keys query returned owner_id (UUID) but never joined administrators. Added LEFT JOIN to return owner username, which the frontend already expects as `k.owner`.