### PR TITLE
fix: sam-revoke preserves authorized_keys ownership after rewrite

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -73,7 +73,9 @@ revoke_from_file() {
         fi
     done < "$keyfile"
     if [ "$changed" -eq 1 ]; then
+        dir_owner=$(stat -c '%u:%g' "$(dirname "$keyfile")")
         chmod 600 "$tmp"
+        chown "$dir_owner" "$tmp"
         mv "$tmp" "$keyfile"
     else
         rm -f "$tmp"


### PR DESCRIPTION
## Problem

`sam-revoke` uses `mktemp + mv` for atomic rewrite. The tmp file is created by root (script runs via sudo), so after `mv` the `authorized_keys` file becomes `root:root`. This breaks SSH access for the `audit-collector` user on subsequent scans.

## Fix

Before `mv`, read the owner from the parent `.ssh` directory (which is always correctly owned) and apply it to the tmp file:
\`\`\`sh
dir_owner=$(stat -c '%u:%g' "$(dirname "$keyfile")")
chown "$dir_owner" "$tmp"
\`\`\`

The script will be redeployed automatically on next scan via hash comparison.