### PR TITLE
fix: update key_size_bits on rescan for existing keys

### DIFF
--- a/app/collect.py
+++ b/app/collect.py
@@ -129,8 +129,8 @@ def scan_server(server: dict) -> dict:
             result["new"] += 1
         else:
             db.execute(
-                "UPDATE ssh_keys SET last_seen = now() WHERE id = %s",
-                (existing_key["id"],),
+                "UPDATE ssh_keys SET last_seen = now(), key_size_bits = %s WHERE id = %s",
+                (parsed["key_size_bits"], existing_key["id"]),
             )
             auth = db.query_one(
                 """


### PR DESCRIPTION
The existing-key path only updated `last_seen`. Now also updates `key_size_bits` so the corrected RSA formula takes effect on the next scan.