### PR TITLE
feat: proper disabled state for all buttons

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -138,11 +138,22 @@ button {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.85rem;
+  transition: opacity 0.15s, filter 0.15s;
+}
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  filter: grayscale(30%);
+  pointer-events: none;
 }
 .btn-primary   { background: #0d6efd; color: #fff; }
+.btn-primary:hover:not(:disabled)   { background: #0b5ed7; }
 .btn-secondary { background: #fff; color: #0d6efd; border-color: #0d6efd; }
-.btn-secondary:hover { background: #e7f0ff; }
+.btn-secondary:hover:not(:disabled) { background: #e7f0ff; }
 .btn-danger    { background: #dc3545; color: #fff; }
+.btn-danger:hover:not(:disabled)    { background: #bb2d3b; }
 .btn-success   { background: #198754; color: #fff; }
+.btn-success:hover:not(:disabled)   { background: #146c43; }
 .btn-warning   { background: #ffc107; color: #000; }
+.btn-warning:hover:not(:disabled)   { background: #e0a800; }
 </style>


### PR DESCRIPTION
## Summary

- `button:disabled` global rule: opacity 45%, cursor not-allowed, subtle grayscale
- `pointer-events: none` prevents accidental clicks on visually disabled buttons
- `:hover:not(:disabled)` added on all btn-* classes so hover effects don't apply to disabled buttons
- `transition` for smooth opacity change
- Covers all buttons across the app (Scan en cours…, Révoquer, Valider, Ajouter, etc.)

## Test plan

- [ ] "Scan en cours…" button appears visually dimmed during scan
- [ ] Revoke modal confirm button dimmed when reason is empty
- [ ] Assign button dimmed when username is empty
- [ ] Expiry button dimmed when no hours/date set