### PR TITLE
feat: admin enable/delete with self-protection guard

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -550,3 +550,56 @@ def disable_admin(username: str, admin_id: str | None = None) -> None:
         """,
         (admin_id, json.dumps({"username": username})),
     )
+
+
+def enable_admin(username: str, admin_id: str | None = None) -> None:
+    """Set is_active=true and log ADMIN_ENABLED."""
+    admin = db.query_one(
+        "SELECT id FROM administrators WHERE username = %s AND is_active = false", (username,)
+    )
+    if not admin:
+        raise ValueError(f"Inactive admin not found: {username}")
+    db.execute("UPDATE administrators SET is_active = true WHERE id = %s", (admin["id"],))
+    db.execute(
+        """
+        INSERT INTO audit_log (action, performed_by, details)
+        VALUES ('ADMIN_ENABLED', %s, %s::jsonb)
+        """,
+        (admin_id, json.dumps({"username": username})),
+    )
+
+
+def delete_admin(username: str, admin_id: str | None = None) -> None:
+    """Permanently delete an inactive admin if no FK references exist. Log ADMIN_DELETED."""
+    admin = db.query_one(
+        "SELECT id FROM administrators WHERE username = %s AND is_active = false", (username,)
+    )
+    if not admin:
+        raise ValueError(f"Inactive admin not found: {username}")
+    ref = db.query_one(
+        """
+        SELECT 1 FROM (
+            SELECT performed_by AS ref_id FROM audit_log WHERE performed_by = %s
+            UNION ALL
+            SELECT authorized_by FROM key_authorizations WHERE authorized_by = %s
+            UNION ALL
+            SELECT revoked_by    FROM key_authorizations WHERE revoked_by    = %s
+            UNION ALL
+            SELECT requested_by  FROM access_requests    WHERE requested_by  = %s
+            UNION ALL
+            SELECT approved_by   FROM access_requests    WHERE approved_by   = %s
+        ) refs
+        LIMIT 1
+        """,
+        (admin["id"],) * 5,
+    )
+    if ref:
+        raise ValueError(f"Cannot delete admin '{username}': existing audit records reference this account")
+    db.execute(
+        """
+        INSERT INTO audit_log (action, performed_by, details)
+        VALUES ('ADMIN_DELETED', %s, %s::jsonb)
+        """,
+        (admin_id, json.dumps({"username": username})),
+    )
+    db.execute("DELETE FROM administrators WHERE id = %s", (admin["id"],))

--- a/app/manage.py
+++ b/app/manage.py
@@ -412,6 +412,31 @@ def admin_disable(username):
         raise click.ClickException(str(e))
 
 
+@admin.command("enable")
+@click.argument("username")
+def admin_enable(username):
+    """Reactiver un administrateur desactive."""
+    performer_id = _require_admin()
+    try:
+        actions.enable_admin(username, performer_id)
+        click.echo(f"Administrateur {username} reactive.")
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
+
+@admin.command("delete")
+@click.argument("username")
+@click.confirmation_option(prompt="Supprimer definitivement cet administrateur ?")
+def admin_delete(username):
+    """Supprimer definitivement un administrateur (doit etre desactive, sans references)."""
+    performer_id = _require_admin()
+    try:
+        actions.delete_admin(username, performer_id)
+        click.echo(f"Administrateur {username} supprime.")
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
+
 # ---------------------------------------------------------------------------
 # audit
 # ---------------------------------------------------------------------------

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -444,3 +444,64 @@ def test_actions_delete_server_raises_if_not_found():
         mock_db.query_one.return_value = None
         with pytest.raises(ValueError, match="not found"):
             actions.delete_server("ghost")
+
+
+# ---------------------------------------------------------------------------
+# enable_admin
+# ---------------------------------------------------------------------------
+
+def test_actions_enable_admin_sets_active():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        actions.enable_admin("someuser", ADMIN_ID)
+        update_sql = mock_db.execute.call_args_list[0][0][0]
+        assert "is_active = true" in update_sql
+
+
+def test_actions_enable_admin_logs_admin_enabled():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        actions.enable_admin("someuser", ADMIN_ID)
+        audit_sql = mock_db.execute.call_args_list[1][0][0]
+        assert "ADMIN_ENABLED" in audit_sql
+
+
+def test_actions_enable_admin_raises_if_not_found():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            actions.enable_admin("ghost")
+
+
+# ---------------------------------------------------------------------------
+# delete_admin
+# ---------------------------------------------------------------------------
+
+def test_actions_delete_admin_removes_row():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, None]
+        actions.delete_admin("someuser", ADMIN_ID)
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        assert any("DELETE FROM administrators" in s for s in sqls)
+
+
+def test_actions_delete_admin_logs_admin_deleted():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, None]
+        actions.delete_admin("someuser", ADMIN_ID)
+        sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        assert any("ADMIN_DELETED" in s for s in sqls)
+
+
+def test_actions_delete_admin_raises_if_not_found():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            actions.delete_admin("ghost")
+
+
+def test_actions_delete_admin_raises_if_has_references():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, {"1": 1}]
+        with pytest.raises(ValueError, match="existing audit records"):
+            actions.delete_admin("someuser")

--- a/app/tests/test_manage.py
+++ b/app/tests/test_manage.py
@@ -244,6 +244,22 @@ def test_manage_admin_disable(runner):
         mock_actions.disable_admin.assert_called_once_with("someuser", ADMIN_ID)
 
 
+def test_manage_admin_enable(runner):
+    with patch("manage.db") as mock_db, patch("manage.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin()
+        result = runner.invoke(manage.cli, ["admin", "enable", "someuser"])
+        assert result.exit_code == 0
+        mock_actions.enable_admin.assert_called_once_with("someuser", ADMIN_ID)
+
+
+def test_manage_admin_delete(runner):
+    with patch("manage.db") as mock_db, patch("manage.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin()
+        result = runner.invoke(manage.cli, ["admin", "delete", "someuser", "--yes"])
+        assert result.exit_code == 0
+        mock_actions.delete_admin.assert_called_once_with("someuser", ADMIN_ID)
+
+
 # ---------------------------------------------------------------------------
 # audit
 # ---------------------------------------------------------------------------

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -304,3 +304,70 @@ def test_web_disable_admin_returns_200(auth_client):
         resp = auth_client.put("/api/admins/someuser/disable")
         assert resp.status_code == 200
         mock_actions.disable_admin.assert_called_once_with("someuser", ADMIN_ID)
+
+
+def test_web_disable_admin_self_returns_403(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.put("/api/admins/admin/disable")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /api/admins/me
+# ---------------------------------------------------------------------------
+
+def test_web_get_me_returns_current_admin(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.get("/api/admins/me")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["username"] == "admin"
+        assert data["id"] == ADMIN_ID
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/admins/<username>/enable
+# ---------------------------------------------------------------------------
+
+def test_web_enable_admin_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.put("/api/admins/someuser/enable")
+        assert resp.status_code == 200
+        mock_actions.enable_admin.assert_called_once_with("someuser", ADMIN_ID)
+
+
+def test_web_enable_admin_self_returns_403(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.put("/api/admins/admin/enable")
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/admins/<username>
+# ---------------------------------------------------------------------------
+
+def test_web_delete_admin_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.delete("/api/admins/someuser")
+        assert resp.status_code == 200
+        mock_actions.delete_admin.assert_called_once_with("someuser", ADMIN_ID)
+
+
+def test_web_delete_admin_self_returns_403(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.delete("/api/admins/admin")
+        assert resp.status_code == 403
+
+
+def test_web_delete_admin_with_references_returns_400(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.delete_admin.side_effect = ValueError("existing audit records reference this account")
+        resp = auth_client.delete("/api/admins/someuser")
+        assert resp.status_code == 400

--- a/app/web.py
+++ b/app/web.py
@@ -425,14 +425,46 @@ def change_admin_password(username):
         return jsonify({"error": str(e)}), 404
 
 
+@app.route("/api/admins/me", methods=["GET"])
+@require_auth
+def get_me():
+    return jsonify({"id": g.admin_id, "username": g.admin_username})
+
+
 @app.route("/api/admins/<username>/disable", methods=["PUT"])
 @require_auth
 def disable_admin(username):
+    if username == g.admin_username:
+        return jsonify({"error": "Cannot disable your own account"}), 403
     try:
         actions.disable_admin(username, g.admin_id)
         return jsonify({"status": "disabled"})
     except ValueError as e:
         return jsonify({"error": str(e)}), 404
+
+
+@app.route("/api/admins/<username>/enable", methods=["PUT"])
+@require_auth
+def enable_admin(username):
+    if username == g.admin_username:
+        return jsonify({"error": "Cannot enable your own account"}), 403
+    try:
+        actions.enable_admin(username, g.admin_id)
+        return jsonify({"status": "enabled"})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 404
+
+
+@app.route("/api/admins/<username>", methods=["DELETE"])
+@require_auth
+def delete_admin(username):
+    if username == g.admin_username:
+        return jsonify({"error": "Cannot delete your own account"}), 403
+    try:
+        actions.delete_admin(username, g.admin_id)
+        return jsonify({"status": "deleted"})
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
 
 
 # ---------------------------------------------------------------------------

--- a/sql/migrations/003_admin_enable_delete.sql
+++ b/sql/migrations/003_admin_enable_delete.sql
@@ -1,0 +1,21 @@
+-- Migration 003 — add ADMIN_ENABLED and ADMIN_DELETED to audit_log CHECK constraint
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check;
+
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check CHECK (action IN (
+    'KEY_ADDED',
+    'KEY_REVOKED',
+    'KEY_EXPIRED',
+    'EXPIRY_WARNING',
+    'REQUEST_APPROVED',
+    'REQUEST_REJECTED',
+    'ANOMALY_DETECTED',
+    'SCAN_COMPLETED',
+    'SCAN_FAILED',
+    'SCRIPT_DEPLOYED',
+    'SERVER_ADDED',
+    'SERVER_DISABLED',
+    'ADMIN_ADDED',
+    'ADMIN_DISABLED',
+    'ADMIN_ENABLED',
+    'ADMIN_DELETED'
+));

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -247,7 +247,9 @@ CREATE TABLE audit_log (
                       'SERVER_ADDED',       -- nouveau serveur enregistré
                       'SERVER_DISABLED',    -- serveur désactivé du périmètre
                       'ADMIN_ADDED',        -- nouvel administrateur créé
-                      'ADMIN_DISABLED'      -- administrateur désactivé
+                      'ADMIN_DISABLED',     -- administrateur désactivé
+                      'ADMIN_ENABLED',      -- administrateur réactivé
+                      'ADMIN_DELETED'       -- administrateur supprimé définitivement
                   )),
     -- Administrateur ayant déclenché l'action (NULL si automatique)
     performed_by  UUID REFERENCES administrators(id),

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -236,7 +236,19 @@
     "btn_save": "Speichern",
     "success_added": "Administrator {username} hinzugefügt.",
     "success_disabled": "Administrator {username} deaktiviert.",
-    "success_pwd": "Passwort von {username} aktualisiert."
+    "success_pwd": "Passwort von {username} aktualisiert.",
+    "btn_enable": "Aktivieren",
+    "btn_delete": "Löschen",
+    "enable_modal_title": "Administrator aktivieren",
+    "enable_modal_text": "Aktivierung von {username} bestätigen?",
+    "btn_enable_confirm": "Aktivieren",
+    "delete_modal_title": "Administrator löschen",
+    "delete_modal_text": "{username} dauerhaft löschen? Diese Aktion ist unumkehrbar und schlägt fehl, wenn das Konto referenziert wird.",
+    "btn_delete_confirm": "Löschen",
+    "success_enabled": "Administrator {username} aktiviert.",
+    "success_deleted": "Administrator {username} gelöscht.",
+    "error_self_action": "Diese Aktion kann nicht auf das eigene Konto angewendet werden.",
+    "error_has_records": "Löschen nicht möglich: Dieses Konto wird noch referenziert."
   },
   "anomalies": {
     "title": "Anomalien",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -236,7 +236,19 @@
     "btn_save": "Save",
     "success_added": "Administrator {username} added.",
     "success_disabled": "Administrator {username} disabled.",
-    "success_pwd": "Password for {username} updated."
+    "success_pwd": "Password for {username} updated.",
+    "btn_enable": "Enable",
+    "btn_delete": "Delete",
+    "enable_modal_title": "Enable administrator",
+    "enable_modal_text": "Confirm enabling {username}?",
+    "btn_enable_confirm": "Enable",
+    "delete_modal_title": "Delete administrator",
+    "delete_modal_text": "Permanently delete {username}? This action is irreversible and will fail if the account has existing records.",
+    "btn_delete_confirm": "Delete",
+    "success_enabled": "Administrator {username} enabled.",
+    "success_deleted": "Administrator {username} deleted.",
+    "error_self_action": "You cannot perform this action on your own account.",
+    "error_has_records": "Cannot delete: this account has existing records."
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -236,7 +236,19 @@
     "btn_save": "Guardar",
     "success_added": "Administrador {username} añadido.",
     "success_disabled": "Administrador {username} desactivado.",
-    "success_pwd": "Contraseña de {username} actualizada."
+    "success_pwd": "Contraseña de {username} actualizada.",
+    "btn_enable": "Activar",
+    "btn_delete": "Eliminar",
+    "enable_modal_title": "Activar administrador",
+    "enable_modal_text": "¿Confirmar la activación de {username}?",
+    "btn_enable_confirm": "Activar",
+    "delete_modal_title": "Eliminar administrador",
+    "delete_modal_text": "¿Eliminar definitivamente a {username}? Esta acción es irreversible y fallará si existen registros asociados.",
+    "btn_delete_confirm": "Eliminar",
+    "success_enabled": "Administrador {username} activado.",
+    "success_deleted": "Administrador {username} eliminado.",
+    "error_self_action": "No puede realizar esta acción sobre su propia cuenta.",
+    "error_has_records": "No se puede eliminar: existen registros que hacen referencia a esta cuenta."
   },
   "anomalies": {
     "title": "Anomalías",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -236,7 +236,19 @@
     "btn_save": "Enregistrer",
     "success_added": "Administrateur {username} ajouté.",
     "success_disabled": "Administrateur {username} désactivé.",
-    "success_pwd": "Mot de passe de {username} mis à jour."
+    "success_pwd": "Mot de passe de {username} mis à jour.",
+    "btn_enable": "Réactiver",
+    "btn_delete": "Supprimer",
+    "enable_modal_title": "Réactiver un administrateur",
+    "enable_modal_text": "Confirmer la réactivation de {username} ?",
+    "btn_enable_confirm": "Réactiver",
+    "delete_modal_title": "Supprimer un administrateur",
+    "delete_modal_text": "Supprimer définitivement {username} ? Action irréversible. Échoue si des enregistrements référencent ce compte.",
+    "btn_delete_confirm": "Supprimer",
+    "success_enabled": "Administrateur {username} réactivé.",
+    "success_deleted": "Administrateur {username} supprimé.",
+    "error_self_action": "Vous ne pouvez pas effectuer cette action sur votre propre compte.",
+    "error_has_records": "Impossible de supprimer : des enregistrements référencent ce compte."
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -236,7 +236,19 @@
     "btn_save": "Salva",
     "success_added": "Amministratore {username} aggiunto.",
     "success_disabled": "Amministratore {username} disabilitato.",
-    "success_pwd": "Password di {username} aggiornata."
+    "success_pwd": "Password di {username} aggiornata.",
+    "btn_enable": "Riattiva",
+    "btn_delete": "Elimina",
+    "enable_modal_title": "Riattiva amministratore",
+    "enable_modal_text": "Confermare la riattivazione di {username}?",
+    "btn_enable_confirm": "Riattiva",
+    "delete_modal_title": "Elimina amministratore",
+    "delete_modal_text": "Eliminare definitivamente {username}? Azione irreversibile. Fallisce se l'account ha record associati.",
+    "btn_delete_confirm": "Elimina",
+    "success_enabled": "Amministratore {username} riattivato.",
+    "success_deleted": "Amministratore {username} eliminato.",
+    "error_self_action": "Non è possibile eseguire questa azione sul proprio account.",
+    "error_has_records": "Impossibile eliminare: esistono record che fanno riferimento a questo account."
   },
   "anomalies": {
     "title": "Anomalie",

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -39,9 +39,12 @@
               <td class="actions-cell">
                 <template v-if="a.is_active">
                   <button class="btn-secondary" @click="openEditPassword(a.username)">{{ $t('admins.btn_password') }}</button>
-                  <button class="btn-danger" @click="openDisable(a.username)">{{ $t('admins.btn_disable') }}</button>
+                  <button v-if="a.username !== currentUsername" class="btn-danger" @click="openDisable(a.username)">{{ $t('admins.btn_disable') }}</button>
                 </template>
-                <span v-else class="text-muted">—</span>
+                <template v-else>
+                  <button class="btn-success" @click="openEnable(a.username)">{{ $t('admins.btn_enable') }}</button>
+                  <button class="btn-danger" @click="openDelete(a.username)">{{ $t('admins.btn_delete') }}</button>
+                </template>
               </td>
             </tr>
           </tbody>
@@ -129,6 +132,30 @@
         <div class="modal-actions">
           <button class="btn-danger" @click="confirmDisable">{{ $t('admins.btn_disable_confirm') }}</button>
           <button @click="disableTarget = null">{{ $t('common.cancel') }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Enable confirmation modal -->
+    <div v-if="enableTarget" class="modal-overlay" @click.self="enableTarget = null">
+      <div class="modal">
+        <h3>{{ $t('admins.enable_modal_title') }}</h3>
+        <p>{{ $t('admins.enable_modal_text', { username: enableTarget }) }}</p>
+        <div class="modal-actions">
+          <button class="btn-success" @click="confirmEnable">{{ $t('admins.btn_enable_confirm') }}</button>
+          <button @click="enableTarget = null">{{ $t('common.cancel') }}</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete confirmation modal -->
+    <div v-if="deleteTarget" class="modal-overlay" @click.self="deleteTarget = null">
+      <div class="modal">
+        <h3>{{ $t('admins.delete_modal_title') }}</h3>
+        <p>{{ $t('admins.delete_modal_text', { username: deleteTarget }) }}</p>
+        <div class="modal-actions">
+          <button class="btn-danger" @click="confirmDelete">{{ $t('admins.btn_delete_confirm') }}</button>
+          <button @click="deleteTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -233,6 +260,7 @@ const admins              = ref([])
 const loading             = ref(true)
 const error               = ref('')
 const message             = ref('')
+const currentUsername     = ref('')
 const newUsername         = ref('')
 const newEmail            = ref('')
 const newPassword         = ref('')
@@ -240,6 +268,8 @@ const newPasswordConfirm  = ref('')
 const showNewPwd          = ref(false)
 const showNewPwdConfirm   = ref(false)
 const disableTarget       = ref(null)
+const enableTarget        = ref(null)
+const deleteTarget        = ref(null)
 const editPasswordTarget  = ref(null)
 const editPassword        = ref('')
 const editPasswordConfirm = ref('')
@@ -264,9 +294,16 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const res = await fetch('/api/admins')
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    admins.value = await res.json()
+    const [adminsRes, meRes] = await Promise.all([
+      fetch('/api/admins'),
+      fetch('/api/admins/me'),
+    ])
+    if (!adminsRes.ok) throw new Error(`HTTP ${adminsRes.status}`)
+    admins.value = await adminsRes.json()
+    if (meRes.ok) {
+      const me = await meRes.json()
+      currentUsername.value = me.username
+    }
   } catch (e) {
     error.value = t('admins.load_error', { error: e.message })
   } finally {
@@ -306,6 +343,8 @@ async function submitAdd() {
 }
 
 function openDisable(username) { disableTarget.value = username }
+function openEnable(username)  { enableTarget.value  = username }
+function openDelete(username)  { deleteTarget.value  = username }
 
 async function confirmDisable() {
   const username = disableTarget.value
@@ -319,6 +358,42 @@ async function confirmDisable() {
       throw new Error(data.error || `HTTP ${res.status}`)
     }
     message.value = t('admins.success_disabled', { username })
+    await load()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function confirmEnable() {
+  const username = enableTarget.value
+  enableTarget.value = null
+  error.value = ''
+  message.value = ''
+  try {
+    const res = await fetch(`/api/admins/${username}/enable`, { method: 'PUT' })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    message.value = t('admins.success_enabled', { username })
+    await load()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function confirmDelete() {
+  const username = deleteTarget.value
+  deleteTarget.value = null
+  error.value = ''
+  message.value = ''
+  try {
+    const res = await fetch(`/api/admins/${username}`, { method: 'DELETE' })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    message.value = t('admins.success_deleted', { username })
     await load()
   } catch (e) {
     error.value = e.message

--- a/ui/tests/AccessForm.spec.js
+++ b/ui/tests/AccessForm.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import AccessForm from '../src/components/AccessForm.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 
 const VALID_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKeyPayload user@host'
 

--- a/ui/tests/Admins.spec.js
+++ b/ui/tests/Admins.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import Admins from '../src/views/Admins.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 
 const ACTIVE_ADMIN  = { id: '1', username: 'admin',    email: 'a@b.c', role: 'sysadmin', is_active: true,  created_at: null }
 const OTHER_ACTIVE  = { id: '2', username: 'alice',    email: 'alice@b.c', role: 'sysadmin', is_active: true,  created_at: null }

--- a/ui/tests/Admins.spec.js
+++ b/ui/tests/Admins.spec.js
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import Admins from '../src/views/Admins.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+
+const ACTIVE_ADMIN  = { id: '1', username: 'admin',    email: 'a@b.c', role: 'sysadmin', is_active: true,  created_at: null }
+const OTHER_ACTIVE  = { id: '2', username: 'alice',    email: 'alice@b.c', role: 'sysadmin', is_active: true,  created_at: null }
+const DISABLED_ADMIN = { id: '3', username: 'bob',    email: 'bob@b.c',   role: 'sysadmin', is_active: false, created_at: null }
+
+function mkFetch(admins, meUsername = 'admin') {
+  return vi.fn((url) => {
+    if (url === '/api/admins/me') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1', username: meUsername }) })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(admins) })
+  })
+}
+
+function mk(admins, meUsername = 'admin') {
+  global.fetch = mkFetch(admins, meUsername)
+  return mount(Admins, { global: { plugins: [i18n] } })
+}
+
+describe('Admins', () => {
+  it('affiche le bouton Disable pour un admin actif autre que soi', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    expect(aliceRow.find('.btn-danger').exists()).toBe(true)
+  })
+
+  it('masque le bouton Disable pour le compte courant', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const adminRow = rows.find(r => r.text().includes('admin') && !r.text().includes('alice'))
+    expect(adminRow.find('.btn-danger').exists()).toBe(false)
+  })
+
+  it('affiche les boutons Enable et Delete pour un admin désactivé', async () => {
+    const w = mk([DISABLED_ADMIN])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    expect(bobRow.find('.btn-success').exists()).toBe(true)
+    expect(bobRow.find('.btn-danger').exists()).toBe(true)
+  })
+
+  it('ouvre la modal Enable au clic sur Enable', async () => {
+    const w = mk([DISABLED_ADMIN])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    await bobRow.find('.btn-success').trigger('click')
+    expect(w.find('.modal').exists()).toBe(true)
+  })
+
+  it('ouvre la modal Delete au clic sur Delete', async () => {
+    const w = mk([DISABLED_ADMIN])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    await bobRow.find('.btn-danger').trigger('click')
+    expect(w.find('.modal').exists()).toBe(true)
+  })
+
+  it('appelle PUT /enable à la confirmation Enable', async () => {
+    const fetchMock = mkFetch([DISABLED_ADMIN])
+    global.fetch = fetchMock
+    const w = mount(Admins, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    await bobRow.find('.btn-success').trigger('click')
+    const confirmBtn = w.find('.modal .btn-success')
+    await confirmBtn.trigger('click')
+    await flushPromises()
+    const calls = fetchMock.mock.calls.map(c => c[0] + '|' + (c[1]?.method || 'GET'))
+    expect(calls).toContain('/api/admins/bob/enable|PUT')
+  })
+
+  it('appelle DELETE à la confirmation Delete', async () => {
+    const fetchMock = mkFetch([DISABLED_ADMIN])
+    global.fetch = fetchMock
+    const w = mount(Admins, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    await bobRow.find('.btn-danger').trigger('click')
+    const confirmBtn = w.find('.modal .btn-danger')
+    await confirmBtn.trigger('click')
+    await flushPromises()
+    const calls = fetchMock.mock.calls.map(c => c[0] + '|' + (c[1]?.method || 'GET'))
+    expect(calls).toContain('/api/admins/bob|DELETE')
+  })
+
+  it('ferme la modal Enable au clic sur annuler', async () => {
+    const w = mk([DISABLED_ADMIN])
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    await bobRow.find('.btn-success').trigger('click')
+    expect(w.find('.modal').exists()).toBe(true)
+    const buttons = w.find('.modal .modal-actions').findAll('button')
+    const cancelBtn = buttons[buttons.length - 1]
+    await cancelBtn.trigger('click')
+    expect(w.find('.modal').exists()).toBe(false)
+  })
+})

--- a/ui/tests/ExpiryPicker.spec.js
+++ b/ui/tests/ExpiryPicker.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import ExpiryPicker from '../src/components/ExpiryPicker.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 const mk = () => mount(ExpiryPicker, { global: { plugins: [i18n] } })
 
 describe('ExpiryPicker', () => {

--- a/ui/tests/KeyActions.spec.js
+++ b/ui/tests/KeyActions.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import KeyActions from '../src/components/KeyActions.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 const FP = 'SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
 
 const mk = (props) => mount(KeyActions, { props, global: { plugins: [i18n] } })

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import KeyTable from '../src/components/KeyTable.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 
 const FP = 'SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
 

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
 import ServerTable from '../src/components/ServerTable.vue'
 
-const i18n = createI18n({ legacy: false, locale: 'en', messages: { en: {} } })
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 
 const SERVERS = [
   {


### PR DESCRIPTION
## Summary

- **Enable admin** : bouton + modal + `PUT /api/admins/<username>/enable` — réactive un admin désactivé, log `ADMIN_ENABLED`
- **Delete admin** : bouton + modal + `DELETE /api/admins/<username>` — supprime définitivement si aucune référence FK, log `ADMIN_DELETED`
- **Self-protection** : bouton Disable masqué pour l'admin courant dans l'UI ; 403 côté API si on cible son propre compte (disable/enable/delete)
- **GET /api/admins/me** : retourne `{id, username}` de la session courante
- **CLI** : `admin enable <username>` et `admin delete --yes <username>`
- **Migration SQL** : `sql/migrations/003_admin_enable_delete.sql` — ajoute `ADMIN_ENABLED` + `ADMIN_DELETED` au CHECK constraint `audit_log.action`
- **5 locales** complètes (EN/FR/DE/ES/IT)

## Test plan

- [ ] pytest : 107 tests passent (48 actions, 28 web, 31 manage)
- [ ] vitest : 78 tests passent dont les 8 nouveaux dans `Admins.spec.js`
- [ ] UI : bouton Disable absent sur la propre ligne de l'admin connecté
- [ ] UI : admin désactivé → boutons Enable + Delete affichés
- [ ] UI : modals de confirmation pour Enable et Delete
- [ ] API : 403 si on tente disable/enable/delete sur son propre compte
- [ ] API : 400 si delete sur admin avec références FK

Closes #116