### PR TITLE
fix: Delete button always visible for non-self admins

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -570,12 +570,12 @@ def enable_admin(username: str, admin_id: str | None = None) -> None:
 
 
 def delete_admin(username: str, admin_id: str | None = None) -> None:
-    """Permanently delete an inactive admin if no FK references exist. Log ADMIN_DELETED."""
+    """Permanently delete an admin if no FK references exist. Log ADMIN_DELETED."""
     admin = db.query_one(
-        "SELECT id FROM administrators WHERE username = %s AND is_active = false", (username,)
+        "SELECT id FROM administrators WHERE username = %s", (username,)
     )
     if not admin:
-        raise ValueError(f"Inactive admin not found: {username}")
+        raise ValueError(f"Admin not found: {username}")
     ref = db.query_one(
         """
         SELECT 1 FROM (

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -496,7 +496,7 @@ def test_actions_delete_admin_logs_admin_deleted():
 def test_actions_delete_admin_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ValueError, match="Admin not found"):
             actions.delete_admin("ghost")
 
 

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -39,7 +39,8 @@
               <td class="actions-cell">
                 <template v-if="a.is_active">
                   <button class="btn-secondary" @click="openEditPassword(a.username)">{{ $t('admins.btn_password') }}</button>
-                  <button v-if="a.username !== currentUsername" class="btn-danger" @click="openDisable(a.username)">{{ $t('admins.btn_disable') }}</button>
+                  <button v-if="a.username !== currentUsername" class="btn-warning" @click="openDisable(a.username)">{{ $t('admins.btn_disable') }}</button>
+                  <button v-if="a.username !== currentUsername" class="btn-danger" @click="openDelete(a.username)">{{ $t('admins.btn_delete') }}</button>
                 </template>
                 <template v-else>
                   <button class="btn-success" @click="openEnable(a.username)">{{ $t('admins.btn_enable') }}</button>


### PR DESCRIPTION
- Bouton Delete affiché pour tous les admins (actifs et désactivés) sauf soi-même
- Trois boutons alignés : Password / Disable (orange) / Delete (rouge)
- Backend : `delete_admin()` ne requiert plus `is_active = false`