### PR TITLE
feat: grouped alert emails — 1 CRITICAL per scan, 1 WARNING per expiry cycle

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -96,10 +96,11 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
         )
 
 
-def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str) -> None:
+def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str) -> dict:
     """
     Scenario 2 — key was ACTIVE but disappeared from server (out-of-system revocation).
-    Sets REVOKED + revoked_automatically=True, logs ANOMALY_DETECTED, sends CRITICAL alert.
+    Sets REVOKED + revoked_automatically=True, logs ANOMALY_DETECTED.
+    Returns info dict for grouped alert in caller.
     """
     db.execute(
         """
@@ -126,11 +127,7 @@ def handle_disappeared_key(key_id: str, server_id: str, hostname: str, ip: str) 
     )
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (key_id,))
     fp = key["fingerprint"] if key else "unknown"
-    alerts.send_alert(
-        "CRITICAL",
-        f"[ssh-access-manager] Cle revoquee hors systeme sur {hostname}",
-        f"Fingerprint: {fp}\nServeur: {hostname}\nStatut: ANOMALY_DETECTED",
-    )
+    return {"type": "disappeared", "fingerprint": fp, "hostname": hostname}
 
 
 def handle_unknown_key(
@@ -141,10 +138,11 @@ def handle_unknown_key(
     comment: str | None,
     server_id: str,
     hostname: str,
-) -> None:
+) -> dict:
     """
     Scenario 3 — key present on server but absent from DB.
-    Inserts with PENDING_REVIEW, logs ANOMALY_DETECTED, sends CRITICAL alert.
+    Inserts with PENDING_REVIEW, logs ANOMALY_DETECTED.
+    Returns info dict for grouped alert in caller.
     """
     db.execute(
         """
@@ -176,17 +174,13 @@ def handle_unknown_key(
             json.dumps({"reason": "unknown_key", "fingerprint": fingerprint, "hostname": hostname}),
         ),
     )
-    alerts.send_alert(
-        "CRITICAL",
-        f"[ssh-access-manager] Cle inconnue detectee sur {hostname}",
-        f"Fingerprint: {fingerprint}\nServeur: {hostname}\nType: {key_type}\nStatut: PENDING_REVIEW",
-    )
+    return {"type": "unknown", "fingerprint": fingerprint, "hostname": hostname, "key_type": key_type, "comment": comment}
 
 
-def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> None:
+def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> dict | None:
     """
-    Send EXPIRY_WARNING with 24h anti-spam.
-    Called by expire.py for each key approaching expiration.
+    Log EXPIRY_WARNING with 24h anti-spam.
+    Returns info dict for grouped alert in caller, or None if already warned.
     """
     already_warned = db.query_one(
         """
@@ -199,7 +193,7 @@ def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> None
         (key_id, server_id),
     )
     if already_warned:
-        return
+        return None
 
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (key_id,))
     server = db.query_one("SELECT hostname FROM servers WHERE id = %s", (server_id,))
@@ -217,11 +211,7 @@ def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> None
             json.dumps({"fingerprint": fp, "hostname": hostname, "expires_at": str(expires_at)}),
         ),
     )
-    alerts.send_alert(
-        "WARNING",
-        f"[ssh-access-manager] Cle expirant bientot sur {hostname}",
-        f"Fingerprint: {fp}\nServeur: {hostname}\nExpiration: {expires_at}",
-    )
+    return {"fingerprint": fp, "hostname": hostname, "expires_at": expires_at}
 
 
 def assign_key(fingerprint: str, owner_username: str) -> None:

--- a/app/collect.py
+++ b/app/collect.py
@@ -80,7 +80,7 @@ def scan_server(server: dict) -> dict:
     hostname = server["hostname"]
     ip = server["ip_address"]
     server_id = server["id"]
-    result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None}
+    result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
 
     try:
         ssh.ensure_scripts(hostname, server_id, ip=ip)
@@ -117,7 +117,7 @@ def scan_server(server: dict) -> dict:
 
         if not existing_key:
             # Scenario 3 — unknown key present on server but absent from DB
-            actions.handle_unknown_key(
+            info = actions.handle_unknown_key(
                 parsed["key_type"],
                 parsed["key_size_bits"],
                 parsed["public_key"],
@@ -126,6 +126,7 @@ def scan_server(server: dict) -> dict:
                 server_id,
                 hostname,
             )
+            result["anomalies"].append(info)
             result["new"] += 1
         else:
             db.execute(
@@ -164,7 +165,8 @@ def scan_server(server: dict) -> dict:
     )
     for row in active_on_server:
         if row["fingerprint"] not in collected_fps:
-            actions.handle_disappeared_key(row["key_id"], server_id, hostname, ip=ip)
+            info = actions.handle_disappeared_key(row["key_id"], server_id, hostname, ip=ip)
+            result["anomalies"].append(info)
             result["disappeared"] += 1
 
     db.execute(
@@ -186,11 +188,35 @@ def scan_server(server: dict) -> dict:
 
 
 def run_scan(hostname: str | None = None) -> list[dict]:
-    """Scan all active servers, or a specific one if hostname is provided."""
+    """Scan all active servers (or one). Sends one grouped CRITICAL email if any anomalies."""
     active_servers = servers_mod.get_active_servers()
     if hostname:
         active_servers = [s for s in active_servers if s["hostname"] == hostname]
-    return [scan_server(s) for s in active_servers]
+    results = [scan_server(s) for s in active_servers]
+
+    all_anomalies = [a for r in results for a in r.get("anomalies", [])]
+    if all_anomalies:
+        unknowns = [a for a in all_anomalies if a["type"] == "unknown"]
+        disappeared = [a for a in all_anomalies if a["type"] == "disappeared"]
+        body_lines = []
+        if unknowns:
+            body_lines.append(f"=== Cles inconnues ({len(unknowns)}) ===")
+            for a in unknowns:
+                body_lines.append(
+                    f"  {a['hostname']} — {a['fingerprint']} ({a['key_type']}, {a['comment'] or '—'}) → PENDING_REVIEW"
+                )
+        if disappeared:
+            if body_lines:
+                body_lines.append("")
+            body_lines.append(f"=== Revocations hors systeme ({len(disappeared)}) ===")
+            for a in disappeared:
+                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → REVOKED automatiquement")
+        alerts.send_alert(
+            "CRITICAL",
+            f"[ssh-access-manager] Scan — {len(all_anomalies)} anomalie(s) detectee(s)",
+            "\n".join(body_lines),
+        )
+    return results
 
 
 if __name__ == "__main__":

--- a/app/expire.py
+++ b/app/expire.py
@@ -20,8 +20,8 @@ EXPIRE_WARN_DAYS_2 = int(os.environ.get("EXPIRE_WARN_DAYS_2", "2"))
 def warn_expiring_keys() -> int:
     """
     Find ACTIVE keys expiring within EXPIRE_WARN_DAYS or EXPIRE_WARN_DAYS_2 days.
-    Delegates to actions.warn_expiring_key() which enforces the 24h anti-spam.
-    Returns the number of warnings actually sent.
+    Sends one grouped WARNING email for all keys needing a warning (24h anti-spam via actions).
+    Returns the number of warnings logged.
     """
     rows = db.query(
         """
@@ -34,23 +34,23 @@ def warn_expiring_keys() -> int:
         """,
         (max(EXPIRE_WARN_DAYS, EXPIRE_WARN_DAYS_2),),
     )
-    sent = 0
+    warnings = []
     for row in rows:
-        before = db.query_one(
-            """
-            SELECT id FROM audit_log
-            WHERE action = 'EXPIRY_WARNING'
-              AND target_key = %s
-              AND target_server = %s
-              AND performed_at > now() - INTERVAL '24 hours'
-            """,
-            (row["key_id"], row["server_id"]),
+        info = actions.warn_expiring_key(row["key_id"], row["server_id"], row["expires_at"])
+        if info:
+            warnings.append(info)
+    if warnings:
+        body_lines = ["=== Cles expirant bientot ==="]
+        for w in warnings:
+            expires_at = w["expires_at"]
+            expires_str = expires_at.strftime("%Y-%m-%d %H:%M UTC") if hasattr(expires_at, "strftime") else str(expires_at)
+            body_lines.append(f"  {w['fingerprint']} — {w['hostname']} — expire le {expires_str}")
+        alerts.send_alert(
+            "WARNING",
+            f"[ssh-access-manager] {len(warnings)} cle(s) expirant bientot",
+            "\n".join(body_lines),
         )
-        if before:
-            continue
-        actions.warn_expiring_key(row["key_id"], row["server_id"], row["expires_at"])
-        sent += 1
-    return sent
+    return len(warnings)
 
 
 def expire_keys() -> int:

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -115,12 +115,13 @@ def test_actions_handle_disappeared_key_scenario2_logs_anomaly_detected():
         assert "ANOMALY_DETECTED" in audit_call[0][0]
 
 
-def test_actions_handle_disappeared_key_scenario2_sends_critical_alert():
-    with patch("actions.db") as mock_db, patch("actions.alerts") as mock_alerts:
+def test_actions_handle_disappeared_key_scenario2_returns_info_dict():
+    with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"fingerprint": "SHA256:abc"}
-        actions.handle_disappeared_key(KEY_ID, SERVER_ID, "server-test-01", ip="192.168.1.10")
-        mock_alerts.send_alert.assert_called_once()
-        assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
+        info = actions.handle_disappeared_key(KEY_ID, SERVER_ID, "server-test-01", ip="192.168.1.10")
+        assert info["type"] == "disappeared"
+        assert info["fingerprint"] == "SHA256:abc"
+        assert info["hostname"] == "server-test-01"
 
 
 # ---------------------------------------------------------------------------
@@ -151,42 +152,45 @@ def test_actions_handle_unknown_key_scenario3_logs_anomaly_detected(sample_key):
         assert "ANOMALY_DETECTED" in audit_call[0][0]
 
 
-def test_actions_handle_unknown_key_scenario3_sends_critical_alert(sample_key):
-    with patch("actions.db") as mock_db, patch("actions.alerts") as mock_alerts:
+def test_actions_handle_unknown_key_scenario3_returns_info_dict(sample_key):
+    with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": KEY_ID}
-        actions.handle_unknown_key(
+        info = actions.handle_unknown_key(
             "ssh-ed25519", None,
             sample_key["public_key"], sample_key["fingerprint"],
             "test@host", SERVER_ID, "server-test-01",
         )
-        mock_alerts.send_alert.assert_called_once()
-        assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
+        assert info["type"] == "unknown"
+        assert info["fingerprint"] == sample_key["fingerprint"]
+        assert info["hostname"] == "server-test-01"
+        assert info["key_type"] == "ssh-ed25519"
 
 
 # ---------------------------------------------------------------------------
 # warn_expiring_key — anti-spam EXPIRY_WARNING 24h
 # ---------------------------------------------------------------------------
 
-def test_actions_warn_expiring_key_sends_alert_first_call():
+def test_actions_warn_expiring_key_returns_info_dict_first_call():
     expires_at = _future(hours=48)
-    with patch("actions.db") as mock_db, patch("actions.alerts") as mock_alerts:
+    with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             None,  # no existing warning
             {"fingerprint": "SHA256:abc"},  # key lookup
             {"hostname": "server-test-01"},  # server lookup
         ]
-        actions.warn_expiring_key(KEY_ID, SERVER_ID, expires_at)
-        mock_alerts.send_alert.assert_called_once()
-        assert mock_alerts.send_alert.call_args[0][0] == "WARNING"
+        info = actions.warn_expiring_key(KEY_ID, SERVER_ID, expires_at)
+        assert info is not None
+        assert info["fingerprint"] == "SHA256:abc"
+        assert info["hostname"] == "server-test-01"
+        assert info["expires_at"] == expires_at
 
 
-def test_actions_warn_expiring_key_antispam_blocks_second_call_within_24h():
+def test_actions_warn_expiring_key_antispam_returns_none():
     expires_at = _future(hours=48)
-    with patch("actions.db") as mock_db, patch("actions.alerts") as mock_alerts:
-        # existing warning found → anti-spam triggers
+    with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": str(uuid.uuid4())}
-        actions.warn_expiring_key(KEY_ID, SERVER_ID, expires_at)
-        mock_alerts.send_alert.assert_not_called()
+        info = actions.warn_expiring_key(KEY_ID, SERVER_ID, expires_at)
+        assert info is None
         mock_db.execute.assert_not_called()
 
 

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -197,10 +197,11 @@ def test_collect_scan_server_scan_failed_sends_critical_alert():
 def test_collect_run_scan_iterates_all_active_servers():
     servers = [SAMPLE_SERVER, {**SAMPLE_SERVER, "hostname": "server-02", "id": str(uuid.uuid4())}]
     with patch("collect.servers_mod") as mock_srv, \
-         patch("collect.scan_server") as mock_scan:
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts"):
 
         mock_srv.get_active_servers.return_value = servers
-        mock_scan.return_value = {"hostname": "x", "new": 0, "disappeared": 0, "known": 0, "error": None}
+        mock_scan.return_value = {"hostname": "x", "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
 
         collect.run_scan()
 
@@ -210,15 +211,64 @@ def test_collect_run_scan_iterates_all_active_servers():
 def test_collect_run_scan_filters_by_hostname():
     servers = [SAMPLE_SERVER, {**SAMPLE_SERVER, "hostname": "server-02", "id": str(uuid.uuid4())}]
     with patch("collect.servers_mod") as mock_srv, \
-         patch("collect.scan_server") as mock_scan:
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts"):
 
         mock_srv.get_active_servers.return_value = servers
-        mock_scan.return_value = {"hostname": "server-test-01", "new": 0, "disappeared": 0, "known": 0, "error": None}
+        mock_scan.return_value = {"hostname": "server-test-01", "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
 
         collect.run_scan(hostname="server-test-01")
 
         assert mock_scan.call_count == 1
         assert mock_scan.call_args[0][0]["hostname"] == "server-test-01"
+
+
+def test_collect_run_scan_sends_one_grouped_critical_when_anomalies():
+    anomaly = {"type": "unknown", "fingerprint": "SHA256:abc", "hostname": "server-test-01", "key_type": "ssh-ed25519", "comment": None}
+    with patch("collect.servers_mod") as mock_srv, \
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts") as mock_alerts:
+
+        mock_srv.get_active_servers.return_value = [SAMPLE_SERVER]
+        mock_scan.return_value = {"hostname": "server-test-01", "new": 1, "disappeared": 0, "known": 0, "error": None, "anomalies": [anomaly]}
+
+        collect.run_scan()
+
+        mock_alerts.send_alert.assert_called_once()
+        assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
+        assert "1 anomalie" in mock_alerts.send_alert.call_args[0][1]
+
+
+def test_collect_run_scan_no_email_when_no_anomalies():
+    with patch("collect.servers_mod") as mock_srv, \
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts") as mock_alerts:
+
+        mock_srv.get_active_servers.return_value = [SAMPLE_SERVER]
+        mock_scan.return_value = {"hostname": "server-test-01", "new": 0, "disappeared": 0, "known": 3, "error": None, "anomalies": []}
+
+        collect.run_scan()
+
+        mock_alerts.send_alert.assert_not_called()
+
+
+def test_collect_run_scan_groups_anomalies_from_multiple_servers():
+    a1 = {"type": "unknown", "fingerprint": "SHA256:aaa", "hostname": "server-01", "key_type": "ssh-ed25519", "comment": None}
+    a2 = {"type": "disappeared", "fingerprint": "SHA256:bbb", "hostname": "server-02"}
+    with patch("collect.servers_mod") as mock_srv, \
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts") as mock_alerts:
+
+        mock_srv.get_active_servers.return_value = [SAMPLE_SERVER, {**SAMPLE_SERVER, "hostname": "server-02"}]
+        mock_scan.side_effect = [
+            {"hostname": "server-01", "new": 1, "disappeared": 0, "known": 0, "error": None, "anomalies": [a1]},
+            {"hostname": "server-02", "new": 0, "disappeared": 1, "known": 0, "error": None, "anomalies": [a2]},
+        ]
+
+        collect.run_scan()
+
+        mock_alerts.send_alert.assert_called_once()
+        assert "2 anomalie" in mock_alerts.send_alert.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -34,40 +34,63 @@ def test_expire_warn_expiring_keys_calls_warn_for_each_key():
         {"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)},
         {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "expires_at": _future(5)},
     ]
-    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+    info = {"fingerprint": "SHA256:abc", "hostname": "server-test-01", "expires_at": _future(2)}
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts"):
         mock_db.query.return_value = rows
-        mock_db.query_one.return_value = None  # no prior warning → send
+        mock_actions.warn_expiring_key.return_value = info
         expire.warn_expiring_keys()
         assert mock_actions.warn_expiring_key.call_count == 2
 
 
 def test_expire_warn_expiring_keys_antispam_skips_already_warned():
     rows = [{"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)}]
-    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts"):
         mock_db.query.return_value = rows
-        mock_db.query_one.return_value = {"id": str(uuid.uuid4())}  # already warned
+        mock_actions.warn_expiring_key.return_value = None  # anti-spam → None
         count = expire.warn_expiring_keys()
-        mock_actions.warn_expiring_key.assert_not_called()
         assert count == 0
 
 
 def test_expire_warn_expiring_keys_returns_count_sent():
-    rows = [
-        {"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)},
-    ]
-    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+    rows = [{"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)}]
+    info = {"fingerprint": "SHA256:abc", "hostname": "server-test-01", "expires_at": _future(2)}
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts"):
         mock_db.query.return_value = rows
-        mock_db.query_one.return_value = None
+        mock_actions.warn_expiring_key.return_value = info
         count = expire.warn_expiring_keys()
         assert count == 1
 
 
 def test_expire_warn_expiring_keys_returns_zero_when_no_keys():
-    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions:
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts"):
         mock_db.query.return_value = []
         count = expire.warn_expiring_keys()
         assert count == 0
         mock_actions.warn_expiring_key.assert_not_called()
+
+
+def test_expire_warn_expiring_keys_sends_one_grouped_email():
+    rows = [
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)},
+        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "expires_at": _future(5)},
+    ]
+    info = {"fingerprint": "SHA256:abc", "hostname": "server-test-01", "expires_at": _future(2)}
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts") as mock_alerts:
+        mock_db.query.return_value = rows
+        mock_actions.warn_expiring_key.return_value = info
+        expire.warn_expiring_keys()
+        mock_alerts.send_alert.assert_called_once()
+        assert mock_alerts.send_alert.call_args[0][0] == "WARNING"
+        assert "2 cle" in mock_alerts.send_alert.call_args[0][1]
+
+
+def test_expire_warn_expiring_keys_no_email_when_all_antispammed():
+    rows = [{"key_id": KEY_ID, "server_id": SERVER_ID, "expires_at": _future(2)}]
+    with patch("expire.db") as mock_db, patch("expire.actions") as mock_actions, patch("expire.alerts") as mock_alerts:
+        mock_db.query.return_value = rows
+        mock_actions.warn_expiring_key.return_value = None
+        expire.warn_expiring_keys()
+        mock_alerts.send_alert.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Scan** : 1 seul email CRITICAL par `run_scan()` regroupant toutes les anomalies de tous les serveurs (clés inconnues + révocations hors système)
- **Expiration** : 1 seul email WARNING par cycle regroupant toutes les clés expirant bientôt
- Les erreurs bloquantes (scan failed, revocation failure) restent individuelles
- `actions.handle_unknown_key()` et `handle_disappeared_key()` retournent un dict au lieu d'envoyer directement l'email
- `actions.warn_expiring_key()` retourne un dict info ou None (anti-spam 24h) au lieu d'envoyer l'email

## Format email scan
```
[ssh-access-manager] Scan — 9 anomalie(s) detectee(s)

=== Cles inconnues (8) ===
  rocky9-pve.org — SHA256:eab... (ssh-rsa, stephdl@de-labrusse.fr) → PENDING_REVIEW
  ...

=== Revocations hors systeme (1) ===
  server-02 — SHA256:xyz... → REVOKED automatiquement
```

## Format email expiration
```
[ssh-access-manager] 3 cle(s) expirant bientot

=== Cles expirant bientot ===
  SHA256:abc — rocky9-pve.org — expire le 2026-04-29 10:00 UTC
```

## Test plan
- [ ] 177 pytest passent
- [ ] Scan avec anomalies → 1 seul email
- [ ] Scan sans anomalies → 0 email
- [ ] Expiry → 1 seul email groupé

Closes #119