### PR TITLE
fix: détecter les clés révoquées/expirées réapparues sur le serveur

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,7 +419,7 @@ expire_keys() :
 → status=EXPIRED, revoked_automatically=TRUE
 → audit_log KEY_EXPIRED, email INFO
 
-## Les 4 scénarios de révocation
+## Les 5 scénarios de révocation / détection
 
 1. Via système (actions.py revoke_key)
    → sam-revoke, revoked_by=admin_id
@@ -440,6 +440,12 @@ expire_keys() :
    → sam-revoke automatique
    → status=EXPIRED, revoked_automatically=TRUE
    → audit_log KEY_EXPIRED, email INFO
+
+5. Clé révoquée/expirée réapparue (présente serveur, status REVOKED ou EXPIRED en BDD)
+   → status=PENDING_REVIEW, audit_log ANOMALY_DETECTED
+   → reason: revoked_key_reappeared
+   → 1 seul email CRITICAL par scan regroupant toutes les anomalies (issue #123)
+   Cas typique : ssh-copy-id d'une clé précédemment révoquée
 
 ## Alertes email — niveaux
 
@@ -480,6 +486,7 @@ Validation robustesse mot de passe (issue #62) :
   ↳ fonctionne sur ACTIVE et PENDING_REVIEW (issue #85)
 - handle_disappeared_key(key_id, server_id, db)    ← scénario 2
 - handle_unknown_key(key_type, key_b64, comment, server_id, db)  ← scénario 3
+- handle_reappeared_key(key_id, server_id, hostname)             ← scénario 5 (issue #123)
 - warn_expiring_key(key_id, server_id, expires_at, db)
 - assign_key(fingerprint, owner_username, db)
 - set_key_expiry(fingerprint, expires_at, db)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -369,11 +369,11 @@ que soit la voie d'accès.
 
 ---
 
-## 8. Les 4 scénarios de révocation
+## 8. Les 5 scénarios de révocation / détection
 
-Le modèle de données distingue explicitement quatre scénarios de révocation, chacun
-traçable par les colonnes `revoked_by`, `revoked_automatically` et le type d'entrée
-dans `audit_log`.
+Le modèle de données distingue explicitement cinq scénarios de révocation et détection,
+chacun traçable par les colonnes `revoked_by`, `revoked_automatically` et le type
+d'entrée dans `audit_log`.
 
 ### Scénario 1 — Révocation manuelle via le système
 
@@ -446,6 +446,28 @@ expire.expire_keys()
 **Colonnes discriminantes** : `status = 'EXPIRED'`, `revoked_automatically = true`.
 Le niveau d'alerte est INFO car l'expiration était attendue et planifiée.
 
+### Scénario 5 — Clé révoquée/expirée réapparue
+
+**Déclencheur** : le scan détecte une clé présente sur le serveur dont le statut
+en base est `REVOKED` ou `EXPIRED` — typiquement un `ssh-copy-id` après révocation.
+
+```
+collect.scan_server()
+  → clé présente dans ssh_keys avec key_authorizations.status IN ('REVOKED','EXPIRED')
+  → actions.handle_reappeared_key(key_id, server_id, hostname)
+  → UPDATE key_authorizations SET status='PENDING_REVIEW', revoked_at=NULL, ...
+  → INSERT audit_log('ANOMALY_DETECTED', reason='revoked_key_reappeared')
+  → alerts.send_alert('CRITICAL', ...)  # inclus dans l'email groupé du scan
+```
+
+**Pourquoi PENDING_REVIEW et non ACTIVE** : l'administrateur doit décider si la
+réapparition est intentionnelle (re-déploiement légitime) ou malveillante (tentative
+de contournement d'une révocation). Le niveau CRITICAL garantit que la situation
+est traitée.
+
+**Différence avec scénario 3** : la clé est déjà connue en base (`ssh_keys` existe).
+Le scénario 3 concerne les clés totalement inconnues.
+
 ### Tableau comparatif
 
 | Scénario | `revoked_by` | `revoked_automatically` | `status` | `audit_log.action` | Alerte |
@@ -454,6 +476,7 @@ Le niveau d'alerte est INFO car l'expiration était attendue et planifiée.
 | 2 — Hors système | `NULL` | `true` | `REVOKED` | `ANOMALY_DETECTED` | CRITICAL |
 | 3 — Clé inconnue | — | — | `PENDING_REVIEW` | `ANOMALY_DETECTED` | CRITICAL |
 | 4 — Expiration | `NULL` | `true` | `EXPIRED` | `KEY_EXPIRED` | INFO |
+| 5 — Réapparue | — | — | `PENDING_REVIEW` | `ANOMALY_DETECTED` | CRITICAL |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Lors du premier scan :
 
 Après le premier scan, toutes les clés détectées sont en attente de validation.
 
+Une clé passe également en `PENDING_REVIEW` si elle était révoquée ou expirée et
+réapparaît physiquement sur un serveur (ex. `ssh-copy-id` après révocation). Ce
+cas est détecté automatiquement au prochain scan et génère une alerte CRITIQUE.
+
 ### Via l'interface web
 
 1. Aller dans **Anomalies**

--- a/app/actions.py
+++ b/app/actions.py
@@ -177,6 +177,40 @@ def handle_unknown_key(
     return {"type": "unknown", "fingerprint": fingerprint, "hostname": hostname, "key_type": key_type, "comment": comment}
 
 
+def handle_reappeared_key(key_id: str, server_id: str, hostname: str) -> dict:
+    """
+    Scenario 5 — key was REVOKED or EXPIRED but reappeared on the server.
+    Sets PENDING_REVIEW, logs ANOMALY_DETECTED.
+    Returns info dict for grouped alert in caller.
+    """
+    db.execute(
+        """
+        UPDATE key_authorizations
+        SET status = 'PENDING_REVIEW',
+            revoked_at = NULL,
+            revoked_by = NULL,
+            revoked_automatically = false,
+            revocation_justification = NULL
+        WHERE key_id = %s AND server_id = %s AND status IN ('REVOKED', 'EXPIRED')
+        """,
+        (key_id, server_id),
+    )
+    db.execute(
+        """
+        INSERT INTO audit_log (action, target_key, target_server, details)
+        VALUES ('ANOMALY_DETECTED', %s, %s, %s::jsonb)
+        """,
+        (
+            key_id,
+            server_id,
+            json.dumps({"reason": "revoked_key_reappeared", "hostname": hostname}),
+        ),
+    )
+    key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (key_id,))
+    fp = key["fingerprint"] if key else "unknown"
+    return {"type": "reappeared", "fingerprint": fp, "hostname": hostname}
+
+
 def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> dict | None:
     """
     Log EXPIRY_WARNING with 24h anti-spam.

--- a/app/collect.py
+++ b/app/collect.py
@@ -150,6 +150,11 @@ def scan_server(server: dict) -> dict:
                     (existing_key["id"], server_id),
                 )
                 result["new"] += 1
+            elif auth["status"] in ("REVOKED", "EXPIRED"):
+                # Scenario 5 — revoked/expired key reappeared on the server
+                info = actions.handle_reappeared_key(existing_key["id"], server_id, hostname)
+                result["anomalies"].append(info)
+                result["new"] += 1
             else:
                 result["known"] += 1
 
@@ -198,6 +203,7 @@ def run_scan(hostname: str | None = None) -> list[dict]:
     if all_anomalies:
         unknowns = [a for a in all_anomalies if a["type"] == "unknown"]
         disappeared = [a for a in all_anomalies if a["type"] == "disappeared"]
+        reappeared = [a for a in all_anomalies if a["type"] == "reappeared"]
         body_lines = []
         if unknowns:
             body_lines.append(f"=== Cles inconnues ({len(unknowns)}) ===")
@@ -211,6 +217,12 @@ def run_scan(hostname: str | None = None) -> list[dict]:
             body_lines.append(f"=== Revocations hors systeme ({len(disappeared)}) ===")
             for a in disappeared:
                 body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → REVOKED automatiquement")
+        if reappeared:
+            if body_lines:
+                body_lines.append("")
+            body_lines.append(f"=== Cles revoquees reapparues ({len(reappeared)}) ===")
+            for a in reappeared:
+                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → PENDING_REVIEW (etait REVOKED/EXPIRED)")
         alerts.send_alert(
             "CRITICAL",
             f"[ssh-access-manager] Scan — {len(all_anomalies)} anomalie(s) detectee(s)",

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -167,6 +167,39 @@ def test_actions_handle_unknown_key_scenario3_returns_info_dict(sample_key):
 
 
 # ---------------------------------------------------------------------------
+# handle_reappeared_key — scenario 5 (cle revoquee/expiree reapparue)
+# ---------------------------------------------------------------------------
+
+def test_actions_handle_reappeared_key_scenario5_sets_pending_review():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"fingerprint": "SHA256:abc"}
+        actions.handle_reappeared_key(KEY_ID, SERVER_ID, "server-test-01")
+        update_call = mock_db.execute.call_args_list[0]
+        assert "PENDING_REVIEW" in update_call[0][0]
+        assert "REVOKED" in update_call[0][0]
+        assert "EXPIRED" in update_call[0][0]
+
+
+def test_actions_handle_reappeared_key_scenario5_logs_anomaly_detected():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"fingerprint": "SHA256:abc"}
+        actions.handle_reappeared_key(KEY_ID, SERVER_ID, "server-test-01")
+        audit_call = mock_db.execute.call_args_list[1]
+        assert "ANOMALY_DETECTED" in audit_call[0][0]
+        params_json = audit_call[0][1][2]
+        assert "revoked_key_reappeared" in params_json
+
+
+def test_actions_handle_reappeared_key_scenario5_returns_info_dict():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"fingerprint": "SHA256:testfp"}
+        info = actions.handle_reappeared_key(KEY_ID, SERVER_ID, "server-test-01")
+        assert info["type"] == "reappeared"
+        assert info["fingerprint"] == "SHA256:testfp"
+        assert info["hostname"] == "server-test-01"
+
+
+# ---------------------------------------------------------------------------
 # warn_expiring_key — anti-spam EXPIRY_WARNING 24h
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -133,6 +133,123 @@ def test_collect_scan_server_scenario2_disappeared_key_calls_handle_disappeared(
 
 
 # ---------------------------------------------------------------------------
+# Tests scan_server() — scenario 5 (cle revoquee/expiree reapparue)
+# ---------------------------------------------------------------------------
+
+def test_collect_scan_server_scenario5_revoked_key_reappeared_calls_handle_reappeared():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db, \
+         patch("collect.actions") as mock_actions, \
+         patch("collect.alerts"):
+
+        mock_ssh.collect_keys.return_value = [SAMPLE_LINE]
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},              # key found in DB
+            {"status": "REVOKED"},       # authorization exists but REVOKED
+        ]
+        mock_db.query.return_value = []  # no disappeared keys
+        mock_actions.handle_reappeared_key.return_value = {
+            "type": "reappeared", "fingerprint": "SHA256:abc", "hostname": "server-test-01"
+        }
+
+        result = collect.scan_server(SAMPLE_SERVER)
+
+        mock_actions.handle_reappeared_key.assert_called_once_with(
+            KEY_ID, SERVER_ID, "server-test-01"
+        )
+        assert result["new"] == 1
+        assert len(result["anomalies"]) == 1
+        assert result["anomalies"][0]["type"] == "reappeared"
+
+
+def test_collect_scan_server_scenario5_expired_key_reappeared_calls_handle_reappeared():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db, \
+         patch("collect.actions") as mock_actions, \
+         patch("collect.alerts"):
+
+        mock_ssh.collect_keys.return_value = [SAMPLE_LINE]
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},              # key found in DB
+            {"status": "EXPIRED"},       # authorization exists but EXPIRED
+        ]
+        mock_db.query.return_value = []
+        mock_actions.handle_reappeared_key.return_value = {
+            "type": "reappeared", "fingerprint": "SHA256:abc", "hostname": "server-test-01"
+        }
+
+        result = collect.scan_server(SAMPLE_SERVER)
+
+        mock_actions.handle_reappeared_key.assert_called_once()
+        assert result["anomalies"][0]["type"] == "reappeared"
+
+
+def test_collect_scan_server_scenario5_active_key_not_treated_as_reappeared():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db, \
+         patch("collect.actions") as mock_actions, \
+         patch("collect.alerts"):
+
+        mock_ssh.collect_keys.return_value = [SAMPLE_LINE]
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            {"status": "ACTIVE"},        # ACTIVE → should remain known, not reappeared
+        ]
+        mock_db.query.return_value = []
+
+        result = collect.scan_server(SAMPLE_SERVER)
+
+        mock_actions.handle_reappeared_key.assert_not_called()
+        assert result["known"] == 1
+        assert result["anomalies"] == []
+
+
+def test_collect_scan_server_scenario5_pending_review_not_treated_as_reappeared():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db, \
+         patch("collect.actions") as mock_actions, \
+         patch("collect.alerts"):
+
+        mock_ssh.collect_keys.return_value = [SAMPLE_LINE]
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            {"status": "PENDING_REVIEW"},  # already pending → unchanged
+        ]
+        mock_db.query.return_value = []
+
+        result = collect.scan_server(SAMPLE_SERVER)
+
+        mock_actions.handle_reappeared_key.assert_not_called()
+        assert result["known"] == 1
+        assert result["anomalies"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests run_scan() — email groupe inclut les reapparitions
+# ---------------------------------------------------------------------------
+
+def test_collect_run_scan_includes_reappeared_in_grouped_critical_email():
+    anomaly = {"type": "reappeared", "fingerprint": "SHA256:abc", "hostname": "server-test-01"}
+    with patch("collect.servers_mod") as mock_srv, \
+         patch("collect.scan_server") as mock_scan, \
+         patch("collect.alerts") as mock_alerts:
+
+        mock_srv.get_active_servers.return_value = [SAMPLE_SERVER]
+        mock_scan.return_value = {
+            "hostname": "server-test-01", "new": 1, "disappeared": 0,
+            "known": 0, "error": None, "anomalies": [anomaly]
+        }
+
+        collect.run_scan()
+
+        mock_alerts.send_alert.assert_called_once()
+        assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
+        body = mock_alerts.send_alert.call_args[0][2]
+        assert "reapparues" in body
+        assert "SHA256:abc" in body
+
+
+# ---------------------------------------------------------------------------
 # Tests scan_server() — cle connue et ACTIVE (mise a jour last_seen)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Résumé

Closes #123

Correction d'un angle mort de sécurité : une clé révoquée ou expirée ré-ajoutée manuellement sur un serveur (ex. `ssh-copy-id`) n'était pas détectée comme anomalie lors du scan. Elle tombait dans le compteur `known` sans aucune alerte.

## Scénario 5 ajouté

```
collect.scan_server()
  → clé présente sur le serveur + key_authorizations.status IN ('REVOKED', 'EXPIRED')
  → actions.handle_reappeared_key(key_id, server_id, hostname)
  → UPDATE key_authorizations SET status='PENDING_REVIEW'
  → INSERT audit_log('ANOMALY_DETECTED', reason='revoked_key_reappeared')
  → inclus dans l'email CRITICAL groupé du scan
```

## Fichiers modifiés

- **`app/actions.py`** — nouvelle fonction `handle_reappeared_key()`
- **`app/collect.py`** — cas `REVOKED`/`EXPIRED` dans `scan_server()`, section "reapparues" dans email groupé `run_scan()`
- **`app/tests/test_actions.py`** — 3 tests : PENDING_REVIEW, ANOMALY_DETECTED, info dict
- **`app/tests/test_collect.py`** — 5 tests : REVOKED→reappeared, EXPIRED→reappeared, ACTIVE inchangé, PENDING_REVIEW inchangé, email groupé
- **`CLAUDE.md`** — 4 scénarios → 5 scénarios, `handle_reappeared_key` dans actions.py
- **`DESIGN.md`** — section scénario 5, tableau comparatif mis à jour
- **`README.md`** — mention du comportement en cas de ssh-copy-id après révocation

## Test plan

- [ ] 185 tests pytest passent (`python -m pytest tests/ -q`)
- [ ] Clé REVOKED sur serveur → PENDING_REVIEW + ANOMALY_DETECTED après scan
- [ ] Clé EXPIRED sur serveur → PENDING_REVIEW + ANOMALY_DETECTED après scan
- [ ] Clé ACTIVE → comportement inchangé (known)
- [ ] Email CRITICAL groupé contient la section "Clés révoquées réapparues"
