### PR TITLE
fix: notification emails in English (#129)

### DIFF
--- a/app/collect.py
+++ b/app/collect.py
@@ -96,8 +96,8 @@ def scan_server(server: dict) -> dict:
         )
         alerts.send_alert(
             "CRITICAL",
-            f"[ssh-access-manager] Scan echoue sur {hostname}",
-            f"Serveur: {hostname}\nErreur: {exc}",
+            f"[ssh-access-manager] Scan failed on {hostname}",
+            f"Server: {hostname}\nError: {exc}",
         )
         return result
 
@@ -206,7 +206,7 @@ def run_scan(hostname: str | None = None) -> list[dict]:
         reappeared = [a for a in all_anomalies if a["type"] == "reappeared"]
         body_lines = []
         if unknowns:
-            body_lines.append(f"=== Cles inconnues ({len(unknowns)}) ===")
+            body_lines.append(f"=== Unknown keys ({len(unknowns)}) ===")
             for a in unknowns:
                 body_lines.append(
                     f"  {a['hostname']} — {a['fingerprint']} ({a['key_type']}, {a['comment'] or '—'}) → PENDING_REVIEW"
@@ -214,18 +214,19 @@ def run_scan(hostname: str | None = None) -> list[dict]:
         if disappeared:
             if body_lines:
                 body_lines.append("")
-            body_lines.append(f"=== Revocations hors systeme ({len(disappeared)}) ===")
+            body_lines.append(f"=== Out-of-system revocations ({len(disappeared)}) ===")
             for a in disappeared:
-                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → REVOKED automatiquement")
+                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → REVOKED automatically")
         if reappeared:
             if body_lines:
                 body_lines.append("")
-            body_lines.append(f"=== Cles revoquees reapparues ({len(reappeared)}) ===")
+            body_lines.append(f"=== Revoked/expired keys reappeared ({len(reappeared)}) ===")
             for a in reappeared:
-                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → PENDING_REVIEW (etait REVOKED/EXPIRED)")
+                body_lines.append(f"  {a['hostname']} — {a['fingerprint']} → PENDING_REVIEW (was REVOKED/EXPIRED)")
+        n = len(all_anomalies)
         alerts.send_alert(
             "CRITICAL",
-            f"[ssh-access-manager] Scan — {len(all_anomalies)} anomalie(s) detectee(s)",
+            f"[ssh-access-manager] Scan — {n} {'anomaly' if n == 1 else 'anomalies'} detected",
             "\n".join(body_lines),
         )
     return results

--- a/app/expire.py
+++ b/app/expire.py
@@ -40,14 +40,15 @@ def warn_expiring_keys() -> int:
         if info:
             warnings.append(info)
     if warnings:
-        body_lines = ["=== Cles expirant bientot ==="]
+        body_lines = ["=== Keys expiring soon ==="]
         for w in warnings:
             expires_at = w["expires_at"]
             expires_str = expires_at.strftime("%Y-%m-%d %H:%M UTC") if hasattr(expires_at, "strftime") else str(expires_at)
-            body_lines.append(f"  {w['fingerprint']} — {w['hostname']} — expire le {expires_str}")
+            body_lines.append(f"  {w['fingerprint']} — {w['hostname']} — expires {expires_str}")
+        n = len(warnings)
         alerts.send_alert(
             "WARNING",
-            f"[ssh-access-manager] {len(warnings)} cle(s) expirant bientot",
+            f"[ssh-access-manager] {n} {'key' if n == 1 else 'keys'} expiring soon",
             "\n".join(body_lines),
         )
     return len(warnings)
@@ -78,8 +79,8 @@ def expire_keys() -> int:
         except Exception as exc:
             alerts.send_alert(
                 "CRITICAL",
-                f"[ssh-access-manager] Echec revocation expiree sur {row['hostname']}",
-                f"Fingerprint: {row['fingerprint']}\nErreur: {exc}",
+                f"[ssh-access-manager] Expired key revocation failed on {row['hostname']}",
+                f"Fingerprint: {row['fingerprint']}\nError: {exc}",
             )
             continue
 

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -245,7 +245,7 @@ def test_collect_run_scan_includes_reappeared_in_grouped_critical_email():
         mock_alerts.send_alert.assert_called_once()
         assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
         body = mock_alerts.send_alert.call_args[0][2]
-        assert "reapparues" in body
+        assert "reappeared" in body
         assert "SHA256:abc" in body
 
 
@@ -353,7 +353,7 @@ def test_collect_run_scan_sends_one_grouped_critical_when_anomalies():
 
         mock_alerts.send_alert.assert_called_once()
         assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
-        assert "1 anomalie" in mock_alerts.send_alert.call_args[0][1]
+        assert "1 anomaly" in mock_alerts.send_alert.call_args[0][1]
 
 
 def test_collect_run_scan_no_email_when_no_anomalies():
@@ -385,7 +385,7 @@ def test_collect_run_scan_groups_anomalies_from_multiple_servers():
         collect.run_scan()
 
         mock_alerts.send_alert.assert_called_once()
-        assert "2 anomalie" in mock_alerts.send_alert.call_args[0][1]
+        assert "2 anomalies" in mock_alerts.send_alert.call_args[0][1]
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -81,7 +81,7 @@ def test_expire_warn_expiring_keys_sends_one_grouped_email():
         expire.warn_expiring_keys()
         mock_alerts.send_alert.assert_called_once()
         assert mock_alerts.send_alert.call_args[0][0] == "WARNING"
-        assert "2 cle" in mock_alerts.send_alert.call_args[0][1]
+        assert "2 keys" in mock_alerts.send_alert.call_args[0][1]
 
 
 def test_expire_warn_expiring_keys_no_email_when_all_antispammed():


### PR DESCRIPTION
## Summary

- `collect.py` — scan failed, anomaly subject/body sections translated to English
- `expire.py` — warning subject/body, revocation failure translated to English
- `test_collect.py`, `test_expire.py` — assertions updated to match English strings

## Test plan

- [ ] `pytest app/tests/ -v` — 184 passed
- [ ] CI verte avant merge

Closes #129