### PR TITLE
ci: upgrade Docker actions to Node 24 (login v4, build-push v6)

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,13 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

- `docker/login-action@v3` → `@v4` (Node 24 native)
- `docker/build-push-action@v5` → `@v6` (Node 24 native)

Supprime le warning "Node.js 20 is deprecated" dans le job `Build & push pr-*`.