### PR TITLE
ci: replace Docker actions with direct docker commands (no Node.js warning)

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -16,14 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
+      - name: Build and push
+        run: |
+          docker build -t ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }} .
+          docker push ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}


### PR DESCRIPTION
## Summary

`docker/login-action` et `docker/build-push-action` déclarent encore `using: node20` en interne — upgrader la version majeure ne suffit pas.

Remplacement par des commandes `run:` directes (Docker est installé nativement sur `ubuntu-latest`) :
- `docker login ghcr.io` via `--password-stdin`
- `docker build` + `docker push`

Zéro dépendance Node.js pour les étapes Docker → plus aucun warning.