### PR TITLE
feat: configurable scan interval via settings table and UI (#133)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ SMTP_TO=admin@example.com
 # Collector
 SSH_USER=audit-collector
 SCAN_INTERVAL_HOURS=4
+# Valeur initiale insérée dans settings.scan_interval_hours au bootstrap.
+# Modifiable ensuite sans redémarrage via GET/PUT /api/system/config.
 EXPIRE_WARN_DAYS=7
 EXPIRE_WARN_DAYS_2=2
 ADMIN_USERNAME=admin
@@ -320,6 +322,18 @@ sql/migrations/
 
 Bootstrap applique les migrations dans l'ordre lexicographique
 après schema.sql au premier démarrage.
+
+## Table settings (issue #133)
+
+CREATE TABLE settings (
+    key   VARCHAR(100) PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT INTO settings (key, value) VALUES ('scan_interval_hours', '4');
+
+-- Initialisée au bootstrap depuis SCAN_INTERVAL_HOURS.
+-- Modifiable via GET/PUT /api/system/config sans redémarrage.
 
 ## Index
 
@@ -602,6 +616,7 @@ ui/tests/
     AccessForm.spec.js    ← validation durée OU date, soumission (16 tests)
     KeyTable.spec.js      ← boutons par statut, owner, expires_at (18+ tests)
     Admins.spec.js        ← modals enable/delete, garde-fous (15 tests)
+    Settings.spec.js      ← chargement, sauvegarde, validation, erreurs (7 tests)
 
 ### Ce qui n'est PAS testé unitairement
 
@@ -737,6 +752,8 @@ GET /api/audit?server=&action=&since=
 GET  /api/system/status
 POST /api/system/scan
 GET  /api/system/collector-key
+GET  /api/system/config
+PUT  /api/system/config
 
 ## Interface Vue.js 3 — vues
 
@@ -755,6 +772,8 @@ ui/src/views/
                           + modals enable/delete + garde-fou self (issue #116)
                           + modal changement mot de passe (issue #61)
                           + confirmation mot de passe + bouton œil (issues #60, #66)
+    Settings.vue        ← configuration système (intervalle de scan)
+                          + GET/PUT /api/system/config (issue #133)
 
 ui/src/components/
     ServerTable.vue     ← tableau serveurs avec recherche
@@ -915,7 +934,8 @@ ssh-access-manager/
         │   ├── ServerTable.spec.js
         │   ├── AccessForm.spec.js
         │   ├── KeyTable.spec.js
-        │   └── Admins.spec.js
+        │   ├── Admins.spec.js
+        │   └── Settings.spec.js
         └── src/
             ├── App.vue
             ├── main.js
@@ -937,7 +957,8 @@ ssh-access-manager/
             │   ├── Anomalies.vue
             │   ├── AccessRequests.vue
             │   ├── Audit.vue
-            │   └── Admins.vue
+            │   ├── Admins.vue
+    │   └── Settings.vue
             └── components/
                 ├── ServerTable.vue
                 ├── KeyTable.vue

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ podman exec ssh-access-manager python3 /app/app/manage.py access approve <id>
 
 Ou via **Accès** dans l'interface web : bouton **Approuver** sur la demande en attente.
 
-À expiration, la clé est automatiquement révoquée par `expire.py` (cron toutes les `SCAN_INTERVAL_HOURS` heures).
+À expiration, la clé est automatiquement révoquée par `expire.py` (cron toutes les 5 minutes, l'intervalle effectif est configurable via l'UI dans **Paramètres**).
 
 ---
 
@@ -235,7 +235,7 @@ Action recommandée : investiguer l'origine de la suppression (accès root direc
 | `SMTP_FROM` | Adresse expéditeur | — |
 | `SMTP_TO` | Adresse destinataire des alertes | — |
 | `SSH_USER` | Utilisateur SSH collecteur | `audit-collector` |
-| `SCAN_INTERVAL_HOURS` | Intervalle des scans automatiques (heures) | `4` |
+| `SCAN_INTERVAL_HOURS` | Intervalle de scan initial (heures) — modifiable via l'UI sans redémarrage | `4` |
 | `EXPIRE_WARN_DAYS` | Alerte J-N avant expiration (premier avertissement) | `7` |
 | `EXPIRE_WARN_DAYS_2` | Alerte J-N avant expiration (second avertissement) | `2` |
 | `ADMIN_USERNAME` | Username de l'administrateur initial | `admin` |

--- a/app/collect.py
+++ b/app/collect.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import struct
+from datetime import datetime, timezone
 
 import actions
 import alerts
@@ -192,8 +193,22 @@ def scan_server(server: dict) -> dict:
     return result
 
 
+def _should_run() -> bool:
+    row = db.query_one("SELECT value FROM settings WHERE key = 'scan_interval_hours'")
+    interval_hours = int(row["value"]) if row else 4
+    last = db.query_one(
+        "SELECT MAX(performed_at) AS t FROM audit_log WHERE action = 'SCAN_COMPLETED'"
+    )
+    if not last or not last["t"]:
+        return True
+    elapsed = (datetime.now(tz=timezone.utc) - last["t"]).total_seconds()
+    return elapsed >= interval_hours * 3600
+
+
 def run_scan(hostname: str | None = None) -> list[dict]:
     """Scan all active servers (or one). Sends one grouped CRITICAL email if any anomalies."""
+    if hostname is None and not _should_run():
+        return []
     active_servers = servers_mod.get_active_servers()
     if hostname:
         active_servers = [s for s in active_servers if s["hostname"] == hostname]

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -230,7 +230,8 @@ def test_collect_scan_server_scenario5_pending_review_not_treated_as_reappeared(
 
 def test_collect_run_scan_includes_reappeared_in_grouped_critical_email():
     anomaly = {"type": "reappeared", "fingerprint": "SHA256:abc", "hostname": "server-test-01"}
-    with patch("collect.servers_mod") as mock_srv, \
+    with patch("collect._should_run", return_value=True), \
+         patch("collect.servers_mod") as mock_srv, \
          patch("collect.scan_server") as mock_scan, \
          patch("collect.alerts") as mock_alerts:
 
@@ -313,7 +314,8 @@ def test_collect_scan_server_scan_failed_sends_critical_alert():
 
 def test_collect_run_scan_iterates_all_active_servers():
     servers = [SAMPLE_SERVER, {**SAMPLE_SERVER, "hostname": "server-02", "id": str(uuid.uuid4())}]
-    with patch("collect.servers_mod") as mock_srv, \
+    with patch("collect._should_run", return_value=True), \
+         patch("collect.servers_mod") as mock_srv, \
          patch("collect.scan_server") as mock_scan, \
          patch("collect.alerts"):
 
@@ -342,7 +344,8 @@ def test_collect_run_scan_filters_by_hostname():
 
 def test_collect_run_scan_sends_one_grouped_critical_when_anomalies():
     anomaly = {"type": "unknown", "fingerprint": "SHA256:abc", "hostname": "server-test-01", "key_type": "ssh-ed25519", "comment": None}
-    with patch("collect.servers_mod") as mock_srv, \
+    with patch("collect._should_run", return_value=True), \
+         patch("collect.servers_mod") as mock_srv, \
          patch("collect.scan_server") as mock_scan, \
          patch("collect.alerts") as mock_alerts:
 
@@ -357,7 +360,8 @@ def test_collect_run_scan_sends_one_grouped_critical_when_anomalies():
 
 
 def test_collect_run_scan_no_email_when_no_anomalies():
-    with patch("collect.servers_mod") as mock_srv, \
+    with patch("collect._should_run", return_value=True), \
+         patch("collect.servers_mod") as mock_srv, \
          patch("collect.scan_server") as mock_scan, \
          patch("collect.alerts") as mock_alerts:
 
@@ -372,7 +376,8 @@ def test_collect_run_scan_no_email_when_no_anomalies():
 def test_collect_run_scan_groups_anomalies_from_multiple_servers():
     a1 = {"type": "unknown", "fingerprint": "SHA256:aaa", "hostname": "server-01", "key_type": "ssh-ed25519", "comment": None}
     a2 = {"type": "disappeared", "fingerprint": "SHA256:bbb", "hostname": "server-02"}
-    with patch("collect.servers_mod") as mock_srv, \
+    with patch("collect._should_run", return_value=True), \
+         patch("collect.servers_mod") as mock_srv, \
          patch("collect.scan_server") as mock_scan, \
          patch("collect.alerts") as mock_alerts:
 
@@ -451,3 +456,56 @@ def test_collect_scan_server_updates_key_size_bits_on_rescan():
         update_call = mock_db.execute.call_args_list[0]
         assert "key_size_bits" in update_call[0][0]
         assert 2048 in update_call[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Tests _should_run() — skip si dernier scan trop récent
+# ---------------------------------------------------------------------------
+
+def test_collect_should_run_true_when_no_scan_completed():
+    with patch("collect.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"value": "4"},   # settings
+            {"t": None},      # audit_log
+        ]
+        assert collect._should_run() is True
+
+
+def test_collect_should_run_false_when_scan_too_recent():
+    from datetime import datetime, timezone, timedelta
+    recent = datetime.now(tz=timezone.utc) - timedelta(hours=1)
+    with patch("collect.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"value": "4"},
+            {"t": recent},
+        ]
+        assert collect._should_run() is False
+
+
+def test_collect_should_run_true_when_interval_elapsed():
+    from datetime import datetime, timezone, timedelta
+    old = datetime.now(tz=timezone.utc) - timedelta(hours=5)
+    with patch("collect.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"value": "4"},
+            {"t": old},
+        ]
+        assert collect._should_run() is True
+
+
+def test_collect_run_scan_skips_when_should_not_run():
+    with patch("collect._should_run", return_value=False), \
+         patch("collect.servers_mod") as mock_srv:
+        result = collect.run_scan()
+        assert result == []
+        mock_srv.get_active_servers.assert_not_called()
+
+
+def test_collect_run_scan_does_not_skip_for_manual_hostname():
+    with patch("collect._should_run") as mock_check, \
+         patch("collect.servers_mod") as mock_srv, \
+         patch("collect.scan_server") as mock_scan:
+        mock_srv.get_active_servers.return_value = [SAMPLE_SERVER]
+        mock_scan.return_value = {"hostname": "server-test-01", "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
+        collect.run_scan(hostname="server-test-01")
+        mock_check.assert_not_called()

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -371,3 +371,38 @@ def test_web_delete_admin_with_references_returns_400(auth_client):
         mock_actions.delete_admin.side_effect = ValueError("existing audit records reference this account")
         resp = auth_client.delete("/api/admins/someuser")
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET/PUT /api/system/config
+# ---------------------------------------------------------------------------
+
+def test_web_get_config_returns_settings(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        mock_db.query.return_value = [{"key": "scan_interval_hours", "value": "4"}]
+        resp = auth_client.get("/api/system/config")
+        assert resp.status_code == 200
+        assert resp.get_json()["scan_interval_hours"] == "4"
+
+
+def test_web_put_config_updates_interval(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        resp = auth_client.put("/api/system/config", json={"scan_interval_hours": 6})
+        assert resp.status_code == 200
+        assert resp.get_json()["scan_interval_hours"] == 6
+
+
+def test_web_put_config_rejects_out_of_range(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        resp = auth_client.put("/api/system/config", json={"scan_interval_hours": 99})
+        assert resp.status_code == 400
+
+
+def test_web_put_config_rejects_missing_field(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        resp = auth_client.put("/api/system/config", json={})
+        assert resp.status_code == 400

--- a/app/web.py
+++ b/app/web.py
@@ -542,5 +542,32 @@ def get_collector_key():
         return jsonify({"error": "Clé collecteur introuvable"}), 404
 
 
+@app.route("/api/system/config", methods=["GET"])
+@require_auth
+def get_config():
+    rows = db.query("SELECT key, value FROM settings")
+    return jsonify({r["key"]: r["value"] for r in rows})
+
+
+@app.route("/api/system/config", methods=["PUT"])
+@require_auth
+def update_config():
+    data = request.get_json(force=True) or {}
+    hours = data.get("scan_interval_hours")
+    if hours is None:
+        return jsonify({"error": "scan_interval_hours required"}), 400
+    try:
+        hours = int(hours)
+        if not (1 <= hours <= 24):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify({"error": "scan_interval_hours must be between 1 and 24"}), 400
+    db.execute(
+        "UPDATE settings SET value = %s WHERE key = 'scan_interval_hours'",
+        (str(hours),)
+    )
+    return jsonify({"scan_interval_hours": hours})
+
+
 if __name__ == "__main__":
     app.run(host="127.0.0.1", port=5000)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,11 +14,10 @@ generate_nginx_conf() {
 # Génération /etc/crontabs/root depuis ENV (SCAN_INTERVAL_HOURS)
 # ---------------------------------------------------------------------------
 generate_crontab() {
-    INTERVAL="${SCAN_INTERVAL_HOURS:-4}"
-    cat > /etc/crontabs/root << EOF
+    cat > /etc/crontabs/root << 'EOF'
 # ssh-access-manager — généré par bootstrap.sh
-0 */${INTERVAL} * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
-0 */${INTERVAL} * * * python3 /app/app/expire.py >> /dev/stdout 2>&1
+*/5 * * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
+*/5 * * * * python3 /app/app/expire.py >> /dev/stdout 2>&1
 EOF
 }
 
@@ -105,6 +104,11 @@ cur.execute(
 conn.close()
 print("[bootstrap] Administrateur initial insere.")
 PYEOF
+
+    # 9b. Initialiser scan_interval_hours depuis ENV
+    su -s /bin/sh postgres -c \
+        "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} \
+         -c \"UPDATE settings SET value = '${SCAN_INTERVAL_HOURS:-4}' WHERE key = 'scan_interval_hours'\""
 
     # 10. Arrêter PostgreSQL temporaire
     su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' stop -w"

--- a/crontab
+++ b/crontab
@@ -2,7 +2,7 @@
 # Format : min heure jour mois dow commande
 
 # Scan SSH + collecte (toutes les SCAN_INTERVAL_HOURS heures)
-0 */4 * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
+*/5 * * * * python3 /app/app/collect.py >> /dev/stdout 2>&1
 
 # Vérification expirations + alertes J-7/J-2
-0 */4 * * * python3 /app/app/expire.py >> /dev/stdout 2>&1
+*/5 * * * * python3 /app/app/expire.py >> /dev/stdout 2>&1

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -272,6 +272,21 @@ COMMENT ON COLUMN audit_log.target_server IS 'FK servers, NULL si action non li�
 COMMENT ON COLUMN audit_log.performed_at IS 'Horodatage précis de l''action (TIMESTAMPTZ)';
 COMMENT ON COLUMN audit_log.details IS 'Contexte JSON libre : fingerprint, hostname, raison, etc.';
 
+-- ---------------------------------------------------------------------------
+-- TABLE : settings
+-- Configuration dynamique modifiable via l'API sans redémarrer le container.
+-- ---------------------------------------------------------------------------
+CREATE TABLE settings (
+    key   VARCHAR(100) PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+COMMENT ON TABLE settings IS 'Configuration dynamique du système — clé/valeur';
+COMMENT ON COLUMN settings.key IS 'Clé de configuration (ex: scan_interval_hours)';
+COMMENT ON COLUMN settings.value IS 'Valeur texte';
+
+INSERT INTO settings (key, value) VALUES ('scan_interval_hours', '4');
+
 -- =============================================================================
 -- INDEX
 -- Optimisent les requêtes fréquentes : filtres sur statut, expiration,

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -7,6 +7,7 @@
       <router-link to="/access">{{ $t('nav.access') }}</router-link>
       <router-link to="/audit">{{ $t('nav.audit') }}</router-link>
       <router-link to="/admins">{{ $t('nav.admins') }}</router-link>
+      <router-link to="/settings">{{ $t('nav.settings') }}</router-link>
       <span class="nav-spacer"></span>
       <select class="lang-select" :value="locale" @change="changeLang($event.target.value)">
         <option value="en">EN</option>

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -5,6 +5,7 @@
     "access": "Zugriff",
     "audit": "Audit",
     "admins": "Admins",
+    "settings": "Einstellungen",
     "logout": "Abmelden"
   },
   "common": {
@@ -274,5 +275,14 @@
     "load_error": "Schlüssel können nicht geladen werden: {error}",
     "key_validated": "Schlüssel validiert.",
     "key_revoked": "Schlüssel widerrufen."
+  },
+  "settings": {
+    "title": "Einstellungen",
+    "scan_section": "Scan-Intervall",
+    "scan_interval_label": "Einen Scan ausführen alle",
+    "hours": "Stunden",
+    "save": "Speichern",
+    "saved": "Einstellungen gespeichert.",
+    "scan_interval_hint": "Zwischen 1 und 24 Stunden. Der Cron wird alle 5 Minuten ausgelöst, überspringt aber die Ausführung, wenn das Intervall nicht abgelaufen ist."
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -5,6 +5,7 @@
     "access": "Access",
     "audit": "Audit",
     "admins": "Admins",
+    "settings": "Settings",
     "logout": "Logout"
   },
   "common": {
@@ -274,5 +275,14 @@
     "load_error": "Unable to load keys: {error}",
     "key_validated": "Key validated.",
     "key_revoked": "Key revoked."
+  },
+  "settings": {
+    "title": "Settings",
+    "scan_section": "Scan interval",
+    "scan_interval_label": "Run a scan every",
+    "hours": "hours",
+    "save": "Save",
+    "saved": "Settings saved.",
+    "scan_interval_hint": "Between 1 and 24 hours. The cron triggers every 5 minutes but skips if the interval has not elapsed."
   }
 }

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -5,6 +5,7 @@
     "access": "Acceso",
     "audit": "Auditoría",
     "admins": "Admins",
+    "settings": "Ajustes",
     "logout": "Cerrar sesión"
   },
   "common": {
@@ -274,5 +275,14 @@
     "load_error": "No se pueden cargar las claves: {error}",
     "key_validated": "Clave validada.",
     "key_revoked": "Clave revocada."
+  },
+  "settings": {
+    "title": "Ajustes",
+    "scan_section": "Intervalo de escaneo",
+    "scan_interval_label": "Ejecutar un escaneo cada",
+    "hours": "horas",
+    "save": "Guardar",
+    "saved": "Ajustes guardados.",
+    "scan_interval_hint": "Entre 1 y 24 horas. El cron se activa cada 5 minutos pero omite la ejecución si el intervalo no ha transcurrido."
   }
 }

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -5,6 +5,7 @@
     "access": "Accès",
     "audit": "Audit",
     "admins": "Admins",
+    "settings": "Paramètres",
     "logout": "Déconnexion"
   },
   "common": {
@@ -274,5 +275,14 @@
     "load_error": "Impossible de charger les clés : {error}",
     "key_validated": "Clé validée.",
     "key_revoked": "Clé révoquée."
+  },
+  "settings": {
+    "title": "Paramètres",
+    "scan_section": "Intervalle de scan",
+    "scan_interval_label": "Lancer un scan toutes les",
+    "hours": "heures",
+    "save": "Sauvegarder",
+    "saved": "Paramètres sauvegardés.",
+    "scan_interval_hint": "Entre 1 et 24 heures. Le cron se déclenche toutes les 5 minutes mais ignore l'exécution si l'intervalle n'est pas écoulé."
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -5,6 +5,7 @@
     "access": "Accesso",
     "audit": "Audit",
     "admins": "Admins",
+    "settings": "Impostazioni",
     "logout": "Disconnetti"
   },
   "common": {
@@ -274,5 +275,14 @@
     "load_error": "Impossibile caricare le chiavi: {error}",
     "key_validated": "Chiave validata.",
     "key_revoked": "Chiave revocata."
+  },
+  "settings": {
+    "title": "Impostazioni",
+    "scan_section": "Intervallo di scansione",
+    "scan_interval_label": "Esegui una scansione ogni",
+    "hours": "ore",
+    "save": "Salva",
+    "saved": "Impostazioni salvate.",
+    "scan_interval_hint": "Tra 1 e 24 ore. Il cron si attiva ogni 5 minuti ma salta l'esecuzione se l'intervallo non è trascorso."
   }
 }

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -8,6 +8,7 @@ import Anomalies from '../views/Anomalies.vue'
 import AccessRequests from '../views/AccessRequests.vue'
 import Audit from '../views/Audit.vue'
 import Admins from '../views/Admins.vue'
+import Settings from '../views/Settings.vue'
 
 const routes = [
   { path: '/login', name: 'Login', component: Login, meta: { public: true } },
@@ -17,6 +18,7 @@ const routes = [
   { path: '/access',       name: 'AccessRequests', component: AccessRequests },
   { path: '/audit',        name: 'Audit',          component: Audit },
   { path: '/admins',       name: 'Admins',         component: Admins },
+  { path: '/settings',     name: 'Settings',       component: Settings },
 ]
 
 const router = createRouter({

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="settings-page">
+    <h2>{{ $t('settings.title') }}</h2>
+
+    <section class="card">
+      <h3>{{ $t('settings.scan_section') }}</h3>
+      <div class="field">
+        <label>{{ $t('settings.scan_interval_label') }}</label>
+        <div class="input-row">
+          <input
+            v-model.number="intervalHours"
+            type="number"
+            min="1"
+            max="24"
+            step="1"
+            class="input-number"
+          />
+          <span class="unit">{{ $t('settings.hours') }}</span>
+          <button class="btn-primary" :disabled="saving" @click="save">
+            {{ $t('settings.save') }}
+          </button>
+        </div>
+        <p class="hint">{{ $t('settings.scan_interval_hint') }}</p>
+        <p v-if="success" class="success-msg">{{ $t('settings.saved') }}</p>
+        <p v-if="error" class="error-msg">{{ error }}</p>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const intervalHours = ref(4)
+const saving = ref(false)
+const success = ref(false)
+const error = ref('')
+
+onMounted(async () => {
+  try {
+    const res = await fetch('/api/system/config')
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json()
+    intervalHours.value = parseInt(data.scan_interval_hours)
+  } catch (err) {
+    error.value = err.message
+  }
+})
+
+async function save() {
+  if (intervalHours.value < 1 || intervalHours.value > 24) {
+    error.value = 'Interval must be between 1 and 24 hours'
+    return
+  }
+
+  saving.value = true
+  success.value = false
+  error.value = ''
+
+  try {
+    const res = await fetch('/api/system/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ scan_interval_hours: intervalHours.value }),
+    })
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+
+    success.value = true
+    setTimeout(() => { success.value = false }, 3000)
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<style scoped>
+.settings-page {
+  max-width: 900px;
+}
+
+h2 {
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.card {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.card h3 {
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  border-bottom: 1px solid #e0e0e0;
+  padding-bottom: 0.5rem;
+}
+
+.field {
+  margin-top: 1rem;
+}
+
+.field label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.input-number {
+  width: 100px;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.unit {
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.hint {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: #666;
+  line-height: 1.4;
+}
+
+.success-msg {
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: #d4edda;
+  color: #155724;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.error-msg {
+  margin-top: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  background: #f8d7da;
+  color: #721c24;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+</style>

--- a/ui/tests/Settings.spec.js
+++ b/ui/tests/Settings.spec.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import Settings from '../src/views/Settings.vue'
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      settings: {
+        title: 'Settings',
+        scan_section: 'Scan interval',
+        scan_interval_label: 'Run a scan every',
+        hours: 'hours',
+        save: 'Save',
+        saved: 'Settings saved.',
+        scan_interval_hint: 'Between 1 and 24 hours. The cron triggers every 5 minutes but skips if the interval has not elapsed.',
+      },
+    },
+  },
+})
+
+describe('Settings.vue', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn()
+  })
+
+  it('loads current scan interval on mount', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ scan_interval_hours: '8' }),
+    })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const input = wrapper.find('input[type="number"]')
+    expect(input.element.value).toBe('8')
+  })
+
+  it('displays error if loading fails', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('HTTP 500')
+  })
+
+  it('saves new scan interval successfully', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: '4' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: 12 }),
+      })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const input = wrapper.find('input[type="number"]')
+    await input.setValue(12)
+
+    const saveBtn = wrapper.find('button.btn-primary')
+    await saveBtn.trigger('click')
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/system/config',
+      expect.objectContaining({
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scan_interval_hours: 12 }),
+      })
+    )
+
+    expect(wrapper.text()).toContain('Settings saved.')
+  })
+
+  it('displays error if save fails', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: '4' }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'Invalid value' }),
+      })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const saveBtn = wrapper.find('button.btn-primary')
+    await saveBtn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Invalid value')
+  })
+
+  it('validates interval min/max before saving', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ scan_interval_hours: '4' }),
+    })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const input = wrapper.find('input[type="number"]')
+    await input.setValue(0)
+
+    const saveBtn = wrapper.find('button.btn-primary')
+    await saveBtn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Interval must be between 1 and 24 hours')
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables save button while saving', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: '4' }),
+      })
+      .mockImplementationOnce(
+        () => new Promise((resolve) => setTimeout(resolve, 100))
+      )
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const saveBtn = wrapper.find('button.btn-primary')
+    await saveBtn.trigger('click')
+
+    expect(saveBtn.element.disabled).toBe(true)
+  })
+
+  it('success message disappears after 3 seconds', async () => {
+    vi.useFakeTimers()
+
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: '4' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ scan_interval_hours: 6 }),
+      })
+
+    const wrapper = mount(Settings, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    const saveBtn = wrapper.find('button.btn-primary')
+    await saveBtn.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Settings saved.')
+
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Settings saved.')
+
+    vi.useRealTimers()
+  })
+})


### PR DESCRIPTION
## Summary

- Table `settings` (key/value) ajoutée dans `schema.sql`, initialisée au bootstrap depuis `SCAN_INTERVAL_HOURS`
- Crontab hardcodé `*/5 * * * *` — `collect.py` skip si le dernier `SCAN_COMPLETED` est plus récent que l'intervalle configuré
- `GET /api/system/config` + `PUT /api/system/config` (validation 1–24h)
- Page **Settings.vue** dans la navbar — champ numérique + bouton Save, message succès 3s
- 5 langues (EN/FR/ES/IT/DE), 9 nouveaux tests Python, 7 nouveaux tests Vitest

## Test plan

- [ ] `pytest app/tests/ -v` — 193 passed
- [ ] `npx vitest run` — 85 passed
- [ ] CI verte avant merge

Closes #133