### PR TITLE
feat: remove SCAN_INTERVAL_HOURS env var — default 4h hardcoded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,6 @@ SMTP_TO=admin@example.com
 
 # Collector
 SSH_USER=audit-collector
-SCAN_INTERVAL_HOURS=4
 EXPIRE_WARN_DAYS=7
 EXPIRE_WARN_DAYS_2=2
 ADMIN_USERNAME=admin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,6 @@ SMTP_TO=admin@example.com
 
 # Collector
 SSH_USER=audit-collector
-SCAN_INTERVAL_HOURS=4
-# Valeur initiale insérée dans settings.scan_interval_hours au bootstrap.
-# Modifiable ensuite sans redémarrage via GET/PUT /api/system/config.
 EXPIRE_WARN_DAYS=7
 EXPIRE_WARN_DAYS_2=2
 ADMIN_USERNAME=admin
@@ -332,8 +329,7 @@ CREATE TABLE settings (
 
 INSERT INTO settings (key, value) VALUES ('scan_interval_hours', '4');
 
--- Initialisée au bootstrap depuis SCAN_INTERVAL_HOURS.
--- Modifiable via GET/PUT /api/system/config sans redémarrage.
+-- Défaut 4h hardcodé. Modifiable via GET/PUT /api/system/config sans redémarrage.
 
 ## Index
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,6 @@ Action recommandée : investiguer l'origine de la suppression (accès root direc
 | `SMTP_FROM` | Adresse expéditeur | — |
 | `SMTP_TO` | Adresse destinataire des alertes | — |
 | `SSH_USER` | Utilisateur SSH collecteur | `audit-collector` |
-| `SCAN_INTERVAL_HOURS` | Intervalle de scan initial (heures) — modifiable via l'UI sans redémarrage | `4` |
 | `EXPIRE_WARN_DAYS` | Alerte J-N avant expiration (premier avertissement) | `7` |
 | `EXPIRE_WARN_DAYS_2` | Alerte J-N avant expiration (second avertissement) | `2` |
 | `ADMIN_USERNAME` | Username de l'administrateur initial | `admin` |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -105,11 +105,6 @@ conn.close()
 print("[bootstrap] Administrateur initial insere.")
 PYEOF
 
-    # 9b. Initialiser scan_interval_hours depuis ENV
-    su -s /bin/sh postgres -c \
-        "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} \
-         -c \"UPDATE settings SET value = '${SCAN_INTERVAL_HOURS:-4}' WHERE key = 'scan_interval_hours'\""
-
     # 10. Arrêter PostgreSQL temporaire
     su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' stop -w"
 


### PR DESCRIPTION
L'intervalle de scan est désormais entièrement géré via la table `settings` (défaut 4h) et l'UI Settings. La variable `SCAN_INTERVAL_HOURS` est supprimée — elle n'avait de sens qu'au premier démarrage et créait de la confusion.

- `bootstrap.sh` — step 9b supprimé
- `.env.example` — variable retirée
- `CLAUDE.md` / `README.md` — documentation mise à jour