### PR TITLE
ci: commitlint + PR title — validation Conventional Commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,13 @@ jobs:
       - name: Check formatting
         run: npm run format:check
         working-directory: ui
+
+  commitlint:
+    name: Commit messages (Conventional Commits)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,17 +5,23 @@ on:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
-  statuses: write
   pull-requests: read
-
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   validate-pr-title:
     name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Check PR title format
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qP '^(feat|fix|docs|style|refactor|test|ci|chore|perf|build|revert)(\(.+\))?: .+'; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "::error::PR title does not follow Conventional Commits format."
+            echo "::error::Expected: type: description  or  type(scope): description"
+            echo "::error::Valid types: feat, fix, docs, style, refactor, test, ci, chore, perf, build, revert"
+            echo "::error::Got: $PR_TITLE"
+            exit 1
+          fi

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,21 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,6 +642,8 @@ freezegun           ← pour mocker datetime dans expire.py
                        job python-tests : pytest + coverage ≥ 80%
                        job vue-tests : vitest
                        job prettier : npm run format:check (issue #139)
+                       job commitlint : messages de commit Conventional Commits (issue #140)
+    pr-title.yml    ← validation titre de PR (Conventional Commits) (issue #140)
     build-pr.yml    ← publication image Docker sur GHCR à chaque PR
 
 ## Formatage — Prettier (issue #139)
@@ -653,6 +655,20 @@ Ignorés : ui/dist/, ui/node_modules/, *.lock
 Commandes UI :
     npm run format:check   ← vérifie sans modifier (CI)
     npm run format:write   ← formate en place (dev local)
+
+## Convention commits (issue #140)
+
+Format obligatoire : `type: description courte`
+Types valides : feat, fix, docs, style, refactor, test, ci, chore
+Exemples :
+    feat: dropdown serveurs connus (#137)
+    fix: correction calcul expiration
+    ci: ajout job prettier
+    docs: mise à jour README
+
+Deux checks CI :
+- `commitlint` (ci.yml) — vérifie chaque message de commit de la PR
+- `pr-title.yml` — vérifie le titre de la PR au même format
 
 ## Commandes — inventaire complet
 


### PR DESCRIPTION
## Résumé

Impose le format **Conventional Commits** sur les messages de commit et les titres de PR via deux checks CI indépendants.

Format : `type: description courte`
Types valides : `feat` `fix` `docs` `style` `refactor` `test` `ci` `chore`

### Checks ajoutés

| Check | Outil | Déclencheur |
|---|---|---|
| Messages de commit | `wagoid/commitlint-github-action@v6` | job `commitlint` dans `ci.yml` |
| Titre de PR | `amannn/action-semantic-pull-request@v5` | workflow `pr-title.yml` |

### Exemples valides
```
feat: dropdown serveurs connus (#137)
fix: correction calcul expiration clé
ci: ajout check Prettier
docs: mise à jour README workflow accès
```

### Exemples invalides
```
ajout du dropdown          ← pas de type
Feat: dropdown             ← majuscule
WIP                        ← pas de type ni description
```

## Note
PR #141 (Prettier) modifie aussi `ci.yml`. Il peut y avoir un conflit mineur à résoudre selon l'ordre de merge — les deux ajouts sont indépendants.

Closes #140