### PR TITLE
ci: fix Node.js 20 warnings — build-main et publish-release

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -13,16 +13,12 @@ jobs:
     name: Build & push main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/stephdl/ssh-access-manager:main
+      - name: Build and push
+        run: |
+          docker build -t ghcr.io/stephdl/ssh-access-manager:main .
+          docker push ghcr.io/stephdl/ssh-access-manager:main

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -13,15 +13,12 @@ jobs:
     name: Build & push ${{ github.ref_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build & push image
+      - name: Build and push
         shell: bash
         run: |
           TAG="${{ github.ref_name }}"


### PR DESCRIPTION
## Résumé

`build-main.yml` et `publish-release.yml` utilisaient `docker/login-action@v3` et `docker/build-push-action@v5` qui déclarent Node.js 20 (déprécié). Remplacés par des commandes shell directes, identiques à ce qui est déjà fait dans `build-pr.yml`.

Closes #145