### PR TITLE
ci: trivy — scan CVE image Docker dans build-pr.yml

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -8,6 +8,7 @@ env:
 
 permissions:
   packages: write
+  security-events: write
 
 jobs:
   build:
@@ -23,3 +24,19 @@ jobs:
         run: |
           docker build -t ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }} .
           docker push ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
+
+      - name: Trivy — scan CVE image
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+
+      - name: Upload Trivy results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,7 +26,7 @@ jobs:
           docker push ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
 
       - name: Trivy — scan CVE image
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
           format: sarif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,7 +640,7 @@ freezegun           ← pour mocker datetime dans expire.py
 .github/workflows/
     ci.yml              ← PR : pytest ≥ 80% + vitest + prettier + commitlint
     pr-title.yml        ← PR : validation titre (Conventional Commits, script shell)
-    build-pr.yml        ← PR : build + push image pr-{N} sur GHCR
+    build-pr.yml        ← PR : build + push image pr-{N} + scan Trivy CVE (issue #147)
     build-main.yml      ← merge main : build + push image :main sur GHCR
     publish-release.yml ← tag git : build + push :vX.Y.Z (+ :latest si stable)
     cleanup-pr.yml      ← fermeture PR : suppression image pr-{N} sur GHCR

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -848,7 +848,7 @@ coûteuse en temps).
 .github/workflows/
   ci.yml              ← 4 jobs qualité sur chaque PR
   pr-title.yml        ← Validation titre PR (Conventional Commits)
-  build-pr.yml        ← Image Docker pr-{N} sur GHCR
+  build-pr.yml        ← Image Docker pr-{N} sur GHCR + scan Trivy CVE
   build-main.yml      ← Image Docker :main à chaque merge
   publish-release.yml ← Image semver stable/beta sur tag git
   cleanup-pr.yml      ← Suppression image pr-{N} à fermeture PR
@@ -912,6 +912,22 @@ Les tags pre-release (`1.0.0-dev.1`, `1.0.0-rc.1`) ne mettent jamais à jour
 l'API GitHub Packages (`gh api --method DELETE`). Cela évite l'accumulation
 d'images orphelines dans le registre. Si l'image n'existe pas (PR sans push),
 le workflow se termine silencieusement.
+
+### Trivy — scan CVE image Docker (`build-pr.yml`)
+
+Trivy (Aqua Security) scanne l'image buildée sur chaque PR après le push sur
+GHCR. Il analyse trois couches :
+
+- **Packages Alpine** (`apk`) : openssl, musl, libssl, nginx…
+- **Packages Python** (`pip`) : paramiko, psycopg2, flask, werkzeug…
+- **Packages npm** du stage build node:24-alpine
+
+Seuil de blocage : `CRITICAL` et `HIGH` uniquement — les vulnérabilités `MEDIUM`
+et `LOW` sont rapportées sans bloquer la PR. Les résultats sont uploadés en
+format SARIF dans **Security → Code scanning** du repo pour traçabilité.
+
+Le step `upload-sarif` est conditionné par `if: always()` pour que les résultats
+soient visibles même quand Trivy fait échouer la CI.
 
 ### Protection de `main`
 

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ cd ui && npx vitest run
 |---|---|---|
 | `ci.yml` | Chaque PR | Tests Python (pytest ≥ 80%), Tests Vue.js (vitest), Prettier, Commitlint |
 | `pr-title.yml` | Ouverture / édition de PR | Validation du titre (Conventional Commits) |
-| `build-pr.yml` | Chaque PR | Build + push image `pr-{N}` sur GHCR |
+| `build-pr.yml` | Chaque PR | Build + push image `pr-{N}` + scan Trivy CVE (CRITICAL/HIGH) |
 | `build-main.yml` | Merge sur `main` | Build + push image `:main` sur GHCR |
 | `publish-release.yml` | Push d'un tag git | Build + push image `:vX.Y.Z` (+ `:latest` si stable) |
 | `cleanup-pr.yml` | Fermeture de PR | Suppression de l'image `pr-{N}` sur GHCR |


### PR DESCRIPTION
## Résumé

Trivy scanne l'image Docker après chaque build de PR. Analyse les packages Alpine, Python (pip) et npm du stage build.

**Seuil :** fail CI sur `CRITICAL` et `HIGH` uniquement.
**Résultats :** uploadés en SARIF dans Security → Code scanning (`if: always()` pour visibilité même en cas d'échec).

Closes #147