### PR TITLE
ci: renovate — mises à jour automatiques npm/pip/Docker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Milestone 1 (Issues 1–4) ✅
 Milestone 2 (Issues 5–13) ✅  
 Milestone 3 (Issues 14–21) ✅  
 Milestone 4 (Issues 22–24) ✅  
-Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137) ✅
+Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148) ✅
 
 ## Stack vérifiée et figée
 
@@ -649,6 +649,23 @@ freezegun           ← pour mocker datetime dans expire.py
 Protection branche main :
     PR obligatoire, 5 checks requis, force push bloqué, enforce_admins=true
 
+## Renovate (issue #148)
+
+renovate.json à la racine du projet.
+Renovate GitHub App activé sur le compte.
+
+Périmètre :
+- npm (ui/package.json)
+- pip (requirements-test.txt)
+- Dockerfile (FROM lines)
+
+Comportement :
+- Planning : lundi avant 9h, TZ Europe/Paris
+- Label automatique : dependencies
+- npm patch : automerge si CI vert
+- npm minor/major : PR manuelle
+- pip + Docker : PR groupées, merge manuel
+
 ## Formatage — Prettier (issue #139)
 
 Configuration : `.prettierrc` à la racine du projet.
@@ -910,6 +927,7 @@ ssh-access-manager/
     ├── docker-compose.yml
     ├── .env.example
     ├── requirements-test.txt
+    ├── renovate.json           ← config Renovate (npm + pip + Docker)
     ├── supervisord.conf
     ├── bootstrap.sh
     ├── crontab
@@ -918,8 +936,13 @@ ssh-access-manager/
     ├── provision-host.sh
     ├── .github/
     │   └── workflows/
-    │       ├── ci.yml          ← pytest + vitest + coverage ≥ 80%
-    │       └── build-pr.yml    ← build + push image Docker GHCR
+    │       ├── ci.yml              ← pytest + vitest + prettier + commitlint
+    │       ├── pr-title.yml        ← validation titre PR (shell grep -P)
+    │       ├── build-pr.yml        ← build + push image Docker GHCR + Trivy
+    │       ├── build-main.yml      ← build + push :main sur GHCR
+    │       ├── publish-release.yml ← build + push :vX.Y.Z (+ :latest)
+    │       ├── cleanup-pr.yml      ← suppression image pr-{N}
+    │       └── codeql.yml          ← analyse statique sécurité Python
     ├── docs/
     │   └── erd.md              ← diagramme ERD Mermaid 6 tables
     ├── sql/

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -842,7 +842,7 @@ coûteuse en temps).
 
 ## 13. CI/CD — GitHub Actions
 
-### 7 workflows et leur rôle
+### 8 workflows et leur rôle
 
 ```
 .github/workflows/
@@ -958,6 +958,21 @@ Le workflow se déclenche sur trois événements :
 Les résultats sont visibles dans l'onglet **Security → Code scanning** du dépôt
 GitHub. La query suite `security-extended` couvre un périmètre plus large que
 la suite par défaut.
+
+### Mises à jour automatiques — Renovate (`renovate.json`)
+
+Renovate ouvre des PRs de mise à jour chaque lundi avant 9h (TZ Europe/Paris) :
+
+| Périmètre | Comportement |
+|---|---|
+| npm `ui/package.json` — patch | PR automerge si CI vert |
+| npm `ui/package.json` — minor/major | PR groupée, merge manuel |
+| pip `requirements-test.txt` | PR groupée, merge manuel |
+| Docker `FROM` lines | PR groupée, merge manuel |
+
+Les PRs Renovate reçoivent automatiquement le label `dependencies`. Les PRs
+automerge (patch npm) attendent que les 5 checks CI soient verts — le même
+garde-fou que pour les PRs manuelles.
 
 ### Cache pip avec requirements-test.txt
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,20 @@ Deux checks CI valident cette convention :
 - Force push bloqué
 - Règle appliquée aux administrateurs du dépôt
 
+### Sécurité — Trivy + CodeQL
+
+**Trivy** scanne chaque image Docker de PR à la recherche de CVE CRITICAL et HIGH (Alpine packages, pip, npm). Les résultats sont uploadés dans l'onglet **Security > Code scanning** de GitHub.
+
+**CodeQL** analyse le code Python avec les requêtes `security-extended` à chaque PR, merge sur `main`, et chaque lundi matin. Les alertes apparaissent dans **Security > Code scanning**.
+
+### Mises à jour automatiques — Renovate
+
+Renovate est configuré via `renovate.json` (racine du projet). Il ouvre des PRs chaque lundi avant 9h pour :
+
+- **npm** (`ui/package.json`) — mises à jour groupées ; patch automerge si CI vert
+- **pip** (`requirements-test.txt`) — PR groupée, merge manuel
+- **Docker** (lignes `FROM` du Dockerfile) — PR groupée, merge manuel
+
 ### Formatage du code Vue.js
 
 Prettier est configuré dans `.prettierrc` (racine du projet) :

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Europe/Paris",
+  "schedule": ["before 9am on Monday"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "npm dependencies",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "matchManagers": ["pip_requirements"],
+      "groupName": "pip dependencies"
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "groupName": "Docker base images"
+    }
+  ],
+  "pip_requirements": {
+    "fileMatch": ["requirements-test\\.txt$"]
+  }
+}


### PR DESCRIPTION
## Summary

- Ajoute `renovate.json` à la racine du projet
- Configure Renovate pour gérer npm (ui/package.json), pip (requirements-test.txt) et les images Docker (FROM lines)
- Patch npm : automerge si CI vert ; minor/major/pip/Docker : PR manuelle
- Planning : lundi avant 9h (TZ Europe/Paris), label `dependencies` automatique
- Met à jour CLAUDE.md, README.md et DESIGN.md avec la documentation Renovate, Trivy et CodeQL

## Test plan

- [ ] Vérifier que la PR passe tous les checks CI (pytest, vitest, prettier, commitlint, pr-title)
- [ ] Vérifier que Renovate ouvre une PR de test après merge (peut prendre jusqu'au prochain lundi)
- [ ] Vérifier la présence de `renovate.json` dans l'onglet Renovate de l'app GitHub

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)