### PR TITLE
ci: upgrade codeql-action v3 → v4

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
           category: trivy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,12 +20,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: python


### PR DESCRIPTION
## Summary

- Met à jour `github/codeql-action/init`, `analyze` et `upload-sarif` de `@v3` à `@v4` dans `codeql.yml` et `build-pr.yml`
- Supprime les deux warnings Node.js 20 / codeql-action v3 dépréciés

## Test plan

- [ ] Vérifier que les checks CI passent (Build & push, Analyze Python (CodeQL))
- [ ] Vérifier l'absence de warnings dans les annotations de la PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)