### PR TITLE
fix: staging /home au lieu de /tmp, chemins mv exacts dans sudoers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -856,7 +856,8 @@ Internationalisation (issue #98) :
 # /etc/sudoers.d/audit-collector (chmod 440)
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/mv /tmp/sam-* /usr/local/bin/
+audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-collect /usr/local/bin/sam-collect
+audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -124,9 +124,7 @@ def _deploy_script(
     tmp_path: str,
 ) -> None:
     sftp.putfo(io.BytesIO(content), tmp_path)
-    name = os.path.basename(remote_path)
-    # sudoers rule uses directory as destination: /bin/mv /tmp/sam-* /usr/local/bin/
-    _run(client, f"sudo /bin/mv {tmp_path} /usr/local/bin/")
+    _run(client, f"sudo /bin/mv {tmp_path} {remote_path}")
     _run(client, f"sudo /bin/chown root:root {remote_path}")
     _run(client, f"sudo /bin/chmod 755 {remote_path}")
 
@@ -148,7 +146,7 @@ def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
             if remote_hash == local_hash:
                 continue
             name = os.path.basename(remote_path)
-            tmp_path = f"/tmp/{name}"
+            tmp_path = f"/home/{SSH_USER}/{name}"
             _deploy_script(client, sftp, content, remote_path, tmp_path)
             db.execute(
                 """

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -202,3 +202,56 @@ def test_ssh_sam_revoke_atomic_rewrite_only_when_changed():
     # The mv only happens if changed=1, otherwise the tmp is removed
     assert b"changed" in ssh.SAM_REVOKE
     assert b"rm -f" in ssh.SAM_REVOKE
+
+
+# ---------------------------------------------------------------------------
+# Sécurité déploiement — staging hors /tmp, destination exacte
+# ---------------------------------------------------------------------------
+
+def test_ssh_ensure_scripts_staging_not_in_tmp(sample_server):
+    """Le fichier staging doit être dans le home de l'utilisateur, pas /tmp."""
+    wrong_hash = "0" * 64
+    with patch("ssh._connect") as mock_connect, patch("ssh.db"):
+        client = MagicMock()
+        sftp = MagicMock()
+        mock_connect.return_value = client
+        client.open_sftp.return_value = sftp
+        stdout_wrong = MagicMock()
+        stdout_wrong.read.return_value = f"{wrong_hash}  /usr/local/bin/sam-collect\n".encode()
+        stdout_wrong.channel.recv_exit_status.return_value = 0
+        client.exec_command.return_value = (
+            MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
+        )
+
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+
+        staged_path = sftp.putfo.call_args[0][1]
+        assert not staged_path.startswith("/tmp"), "Staging ne doit pas utiliser /tmp (world-writable)"
+        assert "/home/" in staged_path
+
+
+def test_ssh_ensure_scripts_mv_uses_exact_destination(sample_server):
+    """sudo mv doit spécifier le chemin de destination exact, pas un répertoire."""
+    wrong_hash = "0" * 64
+    with patch("ssh._connect") as mock_connect, patch("ssh.db"):
+        client = MagicMock()
+        sftp = MagicMock()
+        mock_connect.return_value = client
+        client.open_sftp.return_value = sftp
+        stdout_wrong = MagicMock()
+        stdout_wrong.read.return_value = f"{wrong_hash}  /usr/local/bin/sam-collect\n".encode()
+        stdout_wrong.channel.recv_exit_status.return_value = 0
+        client.exec_command.return_value = (
+            MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
+        )
+
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+
+        commands = [c[0][0] for c in client.exec_command.call_args_list]
+        mv_cmds = [c for c in commands if "/bin/mv" in c]
+        assert mv_cmds, "Aucune commande mv trouvée"
+        for cmd in mv_cmds:
+            dest = cmd.split()[-1]
+            assert dest in ("/usr/local/bin/sam-collect", "/usr/local/bin/sam-revoke"), (
+                f"La destination mv doit être un chemin exact, pas un répertoire : {cmd}"
+            )

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -42,7 +42,8 @@ cat > "${SUDOERS_FILE}" << 'EOF'
 # ssh-access-manager — droits sudo pour audit-collector (chmod 440)
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/mv /tmp/sam-* /usr/local/bin/
+audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-collect /usr/local/bin/sam-collect
+audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect


### PR DESCRIPTION
## Summary

- **`ssh.py`** : tmp_path passe de `/tmp/{name}` à `/home/{SSH_USER}/{name}` — staging dans un répertoire owned 700 par audit-collector uniquement
- **`ssh.py`** : `sudo /bin/mv {tmp_path} /usr/local/bin/` → `sudo /bin/mv {tmp_path} {remote_path}` — destination explicite (chemin complet, pas un répertoire)
- **`provision-host.sh`** : remplace la règle wildcard `mv /tmp/sam-* /usr/local/bin/` par deux règles à chemins exacts source ET destination
- **`test_ssh.py`** : 2 nouveaux tests vérifient que le staging n'est pas dans /tmp et que sudo mv utilise un chemin exact

## Sécurité

| Avant | Après |
|---|---|
| Staging dans `/tmp` (world-writable, race condition) | Staging dans `/home/audit-collector/` (owned 700) |
| `mv /tmp/sam-* /usr/local/bin/` (wildcard, escalade possible) | `mv /home/audit-collector/sam-collect /usr/local/bin/sam-collect` (exact) |
| Destination = répertoire | Destination = chemin de fichier complet |

La mise à jour automatique par checksum SHA256 est conservée intacte.

## Test plan

- [ ] `pytest tests/test_ssh.py` — 12 tests passent
- [ ] `pytest tests/ --cov=actions --cov-fail-under=80` — couverture ≥ 80 %

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)