### PR TITLE
fix: remplacer heredoc par printf dans provision-host.sh

### DIFF
--- a/provision-host.sh
+++ b/provision-host.sh
@@ -38,17 +38,16 @@ chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "${AUTH_KEYS}"
 echo "[provision] Clé publique déployée dans ${AUTH_KEYS}."
 
 # 4. Créer le fichier sudoers
-cat > "${SUDOERS_FILE}" << 'EOF'
-# ssh-access-manager — droits sudo pour audit-collector (chmod 440)
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-collect /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-revoke
-EOF
+# printf avec \n explicite : résistant au \r\n introduit par sudo PTY lors d'un pipe
+printf '# ssh-access-manager — droits sudo pour audit-collector\n' > "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-collect /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/mv /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
 
 chmod 440 "${SUDOERS_FILE}"
 echo "[provision] Sudoers configuré dans ${SUDOERS_FILE}."


### PR DESCRIPTION
## Problème

Quand `provision-host.sh` est pipé à `bash -s` via SSH+sudo :

```bash
ssh root@host sudo bash -s "$PUBKEY" < <(cat provision-host.sh)
```

`sudo` alloue un PTY interne pour exécuter `bash`. Ce PTY convertit les `\n` en `\r\n` avant que bash ne lise le script. Le heredoc `<< 'EOF'` hérite des `\r`, et chaque ligne du fichier sudoers se termine par `\r` — caractère invalide pour visudo.

## Fix

Remplace le heredoc par des `printf 'ligne\n'` explicites. `\n` dans le format printf est un escape traité par printf lui-même, indépendant des fins de ligne du script — le fichier sudoers est toujours écrit avec des LF propres.

## Test plan

- [ ] Rejouer la commande `ssh root@ip sudo bash -s "$PUBKEY" < <(podman exec ... cat /app/provision-host.sh)` sans erreur visudo

Closes #159