### PR TITLE
fix: corrections securite — log injection, password_hash expose, validation fingerprint

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -3,11 +3,19 @@ actions.py — logique metier partagee entre web.py (API) et manage.py (CLI).
 Jamais de duplication entre les deux consommateurs.
 """
 import json
+import re
 from datetime import datetime, timedelta, timezone
 
 import alerts
 import db
 import ssh
+
+_FP_RE = re.compile(r"^SHA256:[A-Za-z0-9+/=]+$")
+
+
+def _check_fingerprint(fp: str) -> None:
+    if not _FP_RE.match(fp):
+        raise ValueError(f"Format de fingerprint invalide : {fp}")
 
 
 # ---------------------------------------------------------------------------
@@ -16,6 +24,7 @@ import ssh
 
 def validate_key(fingerprint: str, admin_id: str) -> dict:
     """PENDING_REVIEW → ACTIVE. Logs KEY_ADDED for each authorization."""
+    _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
@@ -54,6 +63,7 @@ def revoke_key(fingerprint: str, admin_id: str, reason: str) -> None:
     Scenario 1 — revocation via le systeme.
     Calls sam-revoke on each active server, sets REVOKED, logs KEY_REVOKED.
     """
+    _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
@@ -250,6 +260,7 @@ def warn_expiring_key(key_id: str, server_id: str, expires_at: datetime) -> dict
 
 def assign_key(fingerprint: str, owner_name: str) -> None:
     """Set the free-text owner of a key."""
+    _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
@@ -261,6 +272,7 @@ def assign_key(fingerprint: str, owner_name: str) -> None:
 
 def set_key_expiry(fingerprint: str, expires_at: datetime) -> None:
     """Set expiration on all ACTIVE authorizations for a key."""
+    _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
@@ -272,6 +284,7 @@ def set_key_expiry(fingerprint: str, expires_at: datetime) -> None:
 
 def remove_key_expiry(fingerprint: str) -> None:
     """Remove expiration from all ACTIVE authorizations for a key."""
+    _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import json
 import os
 
 import paramiko
@@ -193,7 +194,7 @@ def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
                 (
                     "SCRIPT_DEPLOYED",
                     server_id,
-                    f'{{"script": "{name}", "hostname": "{hostname}"}}',
+                    json.dumps({"script": name, "hostname": hostname}),
                 ),
             )
         sftp.close()

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -602,3 +602,39 @@ def test_actions_deploy_key_invalid_format():
             justification="Test",
             admin_id=ADMIN_ID,
         )
+
+
+# ---------------------------------------------------------------------------
+# Validation format fingerprint SHA256
+# ---------------------------------------------------------------------------
+
+def test_actions_validate_key_rejects_invalid_fingerprint_format():
+    with pytest.raises(ValueError, match="Format de fingerprint invalide"):
+        actions.validate_key("not-a-fingerprint", ADMIN_ID)
+
+
+def test_actions_revoke_key_rejects_invalid_fingerprint_format():
+    with pytest.raises(ValueError, match="Format de fingerprint invalide"):
+        actions.revoke_key("INVALID:abc", ADMIN_ID, "test")
+
+
+def test_actions_assign_key_rejects_invalid_fingerprint_format():
+    with pytest.raises(ValueError, match="Format de fingerprint invalide"):
+        actions.assign_key("sha256:lowercase", "alice")
+
+
+def test_actions_set_expiry_rejects_invalid_fingerprint_format():
+    from datetime import datetime, timezone
+    with pytest.raises(ValueError, match="Format de fingerprint invalide"):
+        actions.set_key_expiry("bad\nfingerprint", datetime.now(tz=timezone.utc))
+
+
+def test_actions_remove_expiry_rejects_invalid_fingerprint_format():
+    with pytest.raises(ValueError, match="Format de fingerprint invalide"):
+        actions.remove_key_expiry("SHA256:bad/char!")
+
+
+def test_actions_fingerprint_valid_format_passes_check():
+    """Un fingerprint SHA256 valide ne lève pas d'exception au niveau du format."""
+    import actions as act
+    act._check_fingerprint("SHA256:abc123+/=ABCXYZ")

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -324,3 +324,35 @@ def test_ssh_add_key_on_server_raises_on_nonzero_exit(sample_server):
                 "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test",
                 sample_server["ip_address"],
             )
+
+
+# ---------------------------------------------------------------------------
+# Sécurité — JSON injection : audit_log.details sérialisé avec json.dumps
+# ---------------------------------------------------------------------------
+
+def test_ssh_ensure_scripts_audit_details_valid_json(sample_server):
+    """audit_log.details doit être du JSON valide même avec des caractères spéciaux."""
+    import json
+    hostile_server = dict(sample_server)
+    hostile_server["hostname"] = 'server"}, "injected": "true'
+
+    wrong_hash = "0" * 64
+    with patch("ssh._connect") as mock_connect, patch("ssh.db") as mock_db:
+        client = MagicMock()
+        sftp = MagicMock()
+        mock_connect.return_value = client
+        client.open_sftp.return_value = sftp
+        stdout_wrong = MagicMock()
+        stdout_wrong.read.return_value = f"{wrong_hash}  /usr/local/bin/sam-collect\n".encode()
+        stdout_wrong.channel.recv_exit_status.return_value = 0
+        client.exec_command.return_value = (
+            MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
+        )
+
+        ssh.ensure_scripts(hostile_server["hostname"], hostile_server["id"], hostile_server["ip_address"])
+
+        assert mock_db.execute.called
+        details_arg = mock_db.execute.call_args[0][1][2]
+        parsed = json.loads(details_arg)
+        assert parsed["hostname"] == hostile_server["hostname"]
+        assert "injected" not in parsed

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -457,3 +457,44 @@ def test_web_deploy_key_returns_400_missing_fields(auth_client):
             json={"public_key": "ssh-ed25519 AAAA test"},
         )
         assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Sécurité — log injection : newlines sanitisées avant logging
+# ---------------------------------------------------------------------------
+
+def test_web_log_injection_newlines_sanitized_in_warning(auth_client):
+    """Une ValueError avec \\n ne doit pas produire de fausses lignes de log."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
+         patch("web.logging") as mock_logging:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.revoke_key.side_effect = ValueError(
+            "Key not found: SHA256:test\nWARNING:root:FAKE_ALERT"
+        )
+        resp = auth_client.post(
+            f"/api/keys/revoke/{FINGERPRINT}",
+            json={"reason": "x"},
+        )
+        assert resp.status_code == 404
+        assert mock_logging.warning.called
+        logged_msg = mock_logging.warning.call_args[0][1]
+        assert "\n" not in logged_msg
+        assert "\\n" in logged_msg
+
+
+def test_web_log_injection_carriage_return_sanitized(auth_client):
+    """Une ValueError avec \\r ne doit pas produire de fausses lignes de log."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
+         patch("web.logging") as mock_logging:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.revoke_key.side_effect = ValueError(
+            "Key not found: SHA256:test\rINJECTED"
+        )
+        resp = auth_client.post(
+            f"/api/keys/revoke/{FINGERPRINT}",
+            json={"reason": "x"},
+        )
+        assert resp.status_code == 404
+        logged_msg = mock_logging.warning.call_args[0][1]
+        assert "\r" not in logged_msg
+        assert "\\r" in logged_msg

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -498,3 +498,18 @@ def test_web_log_injection_carriage_return_sanitized(auth_client):
         logged_msg = mock_logging.warning.call_args[0][1]
         assert "\r" not in logged_msg
         assert "\\r" in logged_msg
+
+
+# ---------------------------------------------------------------------------
+# Sécurité — GET /api/admins ne doit pas exposer password_hash
+# ---------------------------------------------------------------------------
+
+def test_web_list_admins_does_not_expose_password_hash(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = []
+        resp = auth_client.get("/api/admins")
+        assert resp.status_code == 200
+        sql = mock_db.query.call_args[0][0]
+        assert "password_hash" not in sql
+        assert "SELECT *" not in sql

--- a/app/web.py
+++ b/app/web.py
@@ -449,7 +449,9 @@ def revoke_request(request_id):
 @app.route("/api/admins", methods=["GET"])
 @require_auth
 def list_admins():
-    return jsonify(db.query("SELECT * FROM administrators ORDER BY username"))
+    return jsonify(db.query(
+        "SELECT id, username, email, role, is_active, created_at FROM administrators ORDER BY username"
+    ))
 
 
 @app.route("/api/admins", methods=["POST"])

--- a/app/web.py
+++ b/app/web.py
@@ -128,7 +128,7 @@ def add_server():
         )
         return jsonify(server), 201
     except (KeyError, ValueError) as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 
@@ -139,7 +139,7 @@ def disable_server(hostname):
         actions.disable_server(hostname, g.admin_id)
         return jsonify({"status": "disabled"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -150,7 +150,7 @@ def enable_server(hostname):
         actions.enable_server(hostname, g.admin_id)
         return jsonify({"status": "enabled"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -161,7 +161,7 @@ def delete_server(hostname):
         actions.delete_server(hostname, g.admin_id)
         return jsonify({"status": "deleted"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -230,7 +230,7 @@ def validate_key(fingerprint):
         actions.validate_key(fingerprint, g.admin_id)
         return jsonify({"status": "validated"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -243,7 +243,7 @@ def revoke_key(fingerprint):
         actions.revoke_key(fingerprint, g.admin_id, reason)
         return jsonify({"status": "revoked"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -255,7 +255,7 @@ def assign_key(fingerprint):
         actions.assign_key(fingerprint, data["owner_name"])
         return jsonify({"status": "assigned"})
     except (KeyError, ValueError) as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 
@@ -273,7 +273,7 @@ def set_key_expiry(fingerprint):
         actions.set_key_expiry(fingerprint, expires_at)
         return jsonify({"status": "expiry set", "expires_at": expires_at.isoformat()})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -284,7 +284,7 @@ def remove_key_expiry(fingerprint):
         actions.remove_key_expiry(fingerprint)
         return jsonify({"status": "expiry removed"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -334,7 +334,7 @@ def grant_access():
         result["expires_at"] = result["expires_at"].isoformat()
         return jsonify(result), 201
     except (KeyError, ValueError) as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 
@@ -370,7 +370,7 @@ def api_deploy_key():
         )
         return jsonify(result), 201
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
     except Exception as e:
         logging.exception("deploy_key failed")
@@ -405,7 +405,7 @@ def request_access():
         )
         return jsonify({"status": "requested"}), 201
     except (KeyError, Exception) as e:
-        logging.exception(str(e))
+        logging.exception("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 
@@ -416,7 +416,7 @@ def approve_request(request_id):
         actions.approve_request(request_id, g.admin_id)
         return jsonify({"status": "approved"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -427,7 +427,7 @@ def reject_request(request_id):
         actions.reject_request(request_id, g.admin_id)
         return jsonify({"status": "rejected"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -438,7 +438,7 @@ def revoke_request(request_id):
         actions.revoke_request(request_id, g.admin_id)
         return jsonify({"status": "revoked"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -460,7 +460,7 @@ def add_admin():
         admin = actions.add_admin(data["username"], data.get("email", ""), data["password"], g.admin_id)
         return jsonify(admin), 201
     except (KeyError, Exception) as e:
-        logging.exception(str(e))
+        logging.exception("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 
@@ -475,7 +475,7 @@ def change_admin_password(username):
         actions.change_password(username, password)
         return jsonify({"status": "updated"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -494,7 +494,7 @@ def disable_admin(username):
         actions.disable_admin(username, g.admin_id)
         return jsonify({"status": "disabled"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -507,7 +507,7 @@ def enable_admin(username):
         actions.enable_admin(username, g.admin_id)
         return jsonify({"status": "enabled"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
 
@@ -520,7 +520,7 @@ def delete_admin(username):
         actions.delete_admin(username, g.admin_id)
         return jsonify({"status": "deleted"})
     except ValueError as e:
-        logging.warning(str(e))
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
 


### PR DESCRIPTION
## Problème

Trois vulnérabilités identifiées par la revue de sécurité sur le code en production :

1. `logging.warning(str(e))` avec des données utilisateur permettait d'injecter de fausses lignes de log via des `\n` dans un fingerprint ou un hostname
2. `GET /api/admins` retournait `SELECT *` et exposait le `password_hash` des administrateurs à tout admin connecté
3. `ssh.py` construisait le JSON de `audit_log.details` avec une f-string — un hostname avec des guillemets cassait la sérialisation JSONB

En bonus : validation stricte du format des fingerprints SHA256 en entrée des fonctions `actions.py` avant tout appel SSH (defense in depth).

## Changements

- `web.py` — sanitisation `\n`/`\r` dans tous les `logging.warning/exception`
- `web.py` — `GET /api/admins` : `SELECT *` → colonnes explicites sans `password_hash`
- `ssh.py` — f-string `audit_log.details` → `json.dumps()`
- `actions.py` — regex `^SHA256:[A-Za-z0-9+/=]+$` en entrée de `validate_key`, `revoke_key`, `assign_key`, `set_key_expiry`, `remove_key_expiry`

## Tests

10 nouveaux tests, 217 au total.

Closes #167
Closes #169