### PR TITLE
fix: appeler ensure_scripts avant add_key_on_server dans deploy_key

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -398,6 +398,7 @@ def deploy_key(
     )
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
 
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
     ssh.add_key_on_server(hostname, unix_user, public_key.strip(), server["ip_address"])
 
     db.execute(


### PR DESCRIPTION
## Problème

`deploy_key()` appelait `add_key_on_server()` directement sans s'assurer que `sam-add` était présent sur le host. Si le serveur n'avait jamais été scanné (ou après un rebuild du container), le script n'existait pas → `sudo: /usr/local/bin/sam-add: command not found` → 500.

## Correction

Un appel à `ensure_scripts()` avant `add_key_on_server()` déploie `sam-add` (et `sam-collect`, `sam-revoke`) si absents ou outdatés, exactement comme le fait le scan.

## Test plan

- [x] 217 tests Python, tous verts
- [ ] Test end-to-end : déployer une clé sur un host non encore scanné