### PR TITLE
fix: ajouter tooltips conformite dans la vue Anomalies

### DIFF
--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -41,7 +41,10 @@
                 </router-link>
               </td>
               <td>{{ formatDate(k.first_seen) }}</td>
-              <td>{{ k.is_compliant ? '✅' : '⚠️' }}</td>
+              <td>
+                <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
+                <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
+              </td>
               <td class="actions">
                 <button class="btn-success" @click="validate(k.fingerprint)">
                   {{ $t('anomalies.btn_validate') }}
@@ -212,6 +215,14 @@ function formatDate(iso) {
   return new Date(iso).toLocaleString('fr-FR', { dateStyle: 'short', timeStyle: 'short' })
 }
 
+function complianceTooltip(k) {
+  if (k.key_type === 'ssh-rsa') {
+    const bits = k.key_size_bits
+    return bits ? t('key_table.non_compliant_rsa_bits', { bits }) : t('key_table.non_compliant_rsa')
+  }
+  return t('key_table.non_compliant_type')
+}
+
 onMounted(load)
 </script>
 
@@ -226,6 +237,9 @@ h2 {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+.non-compliant {
+  cursor: help;
 }
 
 .card {


### PR DESCRIPTION
## Problème

La colonne "Conforme" dans `Anomalies.vue` affichait ✅ ou ⚠️ sans tooltip, contrairement à `KeyTable.vue`.

## Correction

- ✅ → `<span :title="$t('key_table.compliant_ok')">` — "Clé conforme"
- ⚠️ → `<span :title="complianceTooltip(k)">` — détail du problème (RSA bits, type non supporté)
- Réutilisation des clés i18n `key_table.*` déjà existantes (pas de nouvelles clés)
- Style `.non-compliant { cursor: help }` pour indiquer visuellement le tooltip

## Test plan

- [x] 89 tests Vitest, tous verts
- [x] Prettier OK