### PR TITLE
fix: add revoked_automatically, revoked_by, server_hostname to GET /api/keys

### DIFF
--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -116,6 +116,19 @@ def test_web_get_keys_owner_is_none_when_unassigned(auth_client):
         assert data[0].get("owner") is None
 
 
+def test_web_get_keys_sql_includes_revocation_and_server_fields(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = []
+        auth_client.get("/api/keys")
+        sql = mock_db.query.call_args[0][0]
+        assert "revoked_automatically" in sql
+        assert "revoked_by" in sql
+        assert "revoked_at" in sql
+        assert "revocation_justification" in sql
+        assert "server_hostname" in sql
+
+
 # ---------------------------------------------------------------------------
 # POST /api/keys/revoke/<fp> — 200 si authentifie, 401 si non authentifie
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -182,7 +182,9 @@ def list_keys():
     status = request.args.get("status")
     server = request.args.get("server")
     sql = """
-        SELECT sk.*, ka.status AS status, ka.server_id, ka.expires_at
+        SELECT sk.*, ka.status AS status, ka.server_id, ka.expires_at,
+               ka.revoked_automatically, ka.revoked_by, ka.revoked_at,
+               ka.revocation_justification, s.hostname AS server_hostname
         FROM ssh_keys sk
         LEFT JOIN key_authorizations ka ON ka.key_id = sk.id
         LEFT JOIN servers s ON s.id = ka.server_id


### PR DESCRIPTION
## Summary

- `GET /api/keys` ne retournait pas `revoked_automatically`, `revoked_by`, `revoked_at`, `revocation_justification` ni `server_hostname`
- Le filtre « Out-of-system revocations » dans `Anomalies.vue` testait `k.revoked_automatically === true` mais le champ était toujours `undefined` → section toujours vide
- La colonne SERVER dans la page Anomalies était toujours vide (`k.server_hostname` manquant)

## Fix

Ajout des champs manquants dans le SELECT de `list_keys()` + test vérifiant leur présence dans la requête SQL.

Closes #173

## Test plan

- [ ] pytest 218 tests verts
- [ ] Page Anomalies : colonne SERVER affiche le hostname
- [ ] Clé ACTIVE supprimée du serveur → réapparaît dans « Out-of-system revocations » après scan