### PR TITLE
fix: _parse_datetime accept datetime-local format without seconds

### DIFF
--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -214,6 +214,31 @@ def test_web_grant_access_returns_400_without_expiry(auth_client):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/keys/set-expiry — datetime-local format (sans secondes)
+# ---------------------------------------------------------------------------
+
+def test_web_set_expiry_accepts_datetime_local_format(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/set-expiry/{FINGERPRINT}",
+            json={"date": "2099-12-31T23:59"},
+        )
+        assert resp.status_code == 200
+        mock_actions.set_key_expiry.assert_called_once()
+
+
+def test_web_set_expiry_rejects_no_date_or_hours(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/set-expiry/{FINGERPRINT}",
+            json={},
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
 # GET /api/servers
 # ---------------------------------------------------------------------------
 

--- a/app/web.py
+++ b/app/web.py
@@ -94,7 +94,7 @@ def auth_me():
 def _parse_datetime(value: str | None) -> datetime | None:
     if not value:
         return None
-    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+    for fmt in ("%Y-%m-%dT%H:%M", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
         try:
             return datetime.strptime(value, fmt).replace(tzinfo=timezone.utc)
         except ValueError:


### PR DESCRIPTION
## Problème

Le sélecteur de date HTML (`type="datetime-local"`) envoie `"2026-04-26T15:30"` sans secondes.

`_parse_datetime` n'essayait que `%Y-%m-%dT%H:%M:**S**` → retournait `None` → réponse 400 `"hours or date required"`.

## Fix

Ajout de `"%Y-%m-%dT%H:%M"` comme premier format à tester dans `_parse_datetime`.

## Tests

- `test_web_set_expiry_accepts_datetime_local_format` : vérifie que `2099-12-31T23:59` est accepté
- `test_web_set_expiry_rejects_no_date_or_hours` : vérifie que le payload vide retourne 400
- Total : 223 tests Python

Closes #177