### PR TITLE
fix: validate unix_user format in deploy_key to prevent 500

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -11,6 +11,7 @@ import db
 import ssh
 
 _FP_RE = re.compile(r"^SHA256:[A-Za-z0-9+/=]+$")
+_UNIX_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 
 
 def _check_fingerprint(fp: str) -> None:
@@ -350,6 +351,11 @@ def deploy_key(
     Register public key in ssh_keys (if not exists), deploy via sam-add,
     create key_authorization ACTIVE with optional expiry.
     """
+    if not _UNIX_USER_RE.match(unix_user):
+        raise ValueError(
+            f"Nom d'utilisateur Unix invalide : '{unix_user}' "
+            "(minuscules, chiffres, _ et - uniquement, max 32 caractères)"
+        )
     parts = public_key.strip().split()
     if len(parts) < 2:
         raise ValueError("Format de clé invalide")

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -604,6 +604,47 @@ def test_actions_deploy_key_invalid_format():
         )
 
 
+def test_actions_deploy_key_invalid_unix_user_with_space():
+    with pytest.raises(ValueError, match="Nom d'utilisateur Unix invalide"):
+        actions.deploy_key(
+            public_key="ssh-ed25519 AAAA test",
+            unix_user="zoor dupont",
+            hostname="server",
+            expires_at=None,
+            justification="Test",
+            admin_id=ADMIN_ID,
+        )
+
+
+def test_actions_deploy_key_invalid_unix_user_uppercase():
+    with pytest.raises(ValueError, match="Nom d'utilisateur Unix invalide"):
+        actions.deploy_key(
+            public_key="ssh-ed25519 AAAA test",
+            unix_user="Alice",
+            hostname="server",
+            expires_at=None,
+            justification="Test",
+            admin_id=ADMIN_ID,
+        )
+
+
+def test_actions_deploy_key_valid_unix_user_passes_check(sample_server, sample_key):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.side_effect = [sample_server, {"id": KEY_ID}]
+        mock_db.execute.return_value = None
+        mock_ssh.ensure_scripts.return_value = None
+        mock_ssh.add_key_on_server.return_value = None
+        result = actions.deploy_key(
+            public_key=sample_key["public_key"],
+            unix_user="alice_01",
+            hostname="server-prod-01",
+            expires_at=None,
+            justification="Test",
+            admin_id=ADMIN_ID,
+        )
+        assert result["unix_user"] == "alice_01"
+
+
 # ---------------------------------------------------------------------------
 # Validation format fingerprint SHA256
 # ---------------------------------------------------------------------------

--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -32,6 +32,9 @@
           :placeholder="$t('deployKey.unixUserPlaceholder')"
           data-testid="input-unix-user"
         />
+        <span v-if="unixUser && !unixUserValid" class="field-error" data-testid="error-unix-user">
+          {{ $t('deployKey.error_unix_user') }}
+        </span>
       </div>
 
       <div class="field">
@@ -173,6 +176,8 @@ const minDate = computed(() => {
   return d.toISOString().slice(0, 16)
 })
 
+const unixUserValid = computed(() => /^[a-z_][a-z0-9_-]{0,31}$/.test(unixUser.value))
+
 const durationError = computed(() => {
   if (mode.value === 'unlimited') return ''
   if (mode.value === 'hours') {
@@ -193,7 +198,7 @@ const durationValid = computed(() => {
 
 const isValid = computed(
   () =>
-    unixUser.value.trim() !== '' &&
+    unixUserValid.value &&
     publicKey.value.trim() !== '' &&
     server.value.trim() !== '' &&
     durationValid.value &&

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -265,6 +265,7 @@
     "title": "SSH-Schlüssel bereitstellen",
     "unixUser": "Unix-Benutzer",
     "unixUserPlaceholder": "z.B. alice",
+    "error_unix_user": "Ungültiger Unix-Benutzername (nur Kleinbuchstaben, Ziffern, _ und -, max. 32 Zeichen)",
     "publicKey": "Öffentlicher Schlüssel",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Zielserver",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -265,6 +265,7 @@
     "title": "Deploy SSH Key",
     "unixUser": "Unix Username",
     "unixUserPlaceholder": "e.g. alice",
+    "error_unix_user": "Invalid Unix username (lowercase, digits, _ and - only, max 32 chars)",
     "publicKey": "Public Key",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Target Server",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -265,6 +265,7 @@
     "title": "Desplegar clave SSH",
     "unixUser": "Usuario Unix",
     "unixUserPlaceholder": "ej: alice",
+    "error_unix_user": "Nombre de usuario Unix inválido (minúsculas, dígitos, _ y - únicamente, máx. 32 caracteres)",
     "publicKey": "Clave pública",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Servidor destino",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -265,6 +265,7 @@
     "title": "Déployer une clé SSH",
     "unixUser": "Utilisateur Unix",
     "unixUserPlaceholder": "ex: alice",
+    "error_unix_user": "Nom d'utilisateur Unix invalide (minuscules, chiffres, _ et - uniquement, max 32 caractères)",
     "publicKey": "Clé publique",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Serveur cible",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -265,6 +265,7 @@
     "title": "Distribuire chiave SSH",
     "unixUser": "Utente Unix",
     "unixUserPlaceholder": "es: alice",
+    "error_unix_user": "Nome utente Unix non valido (solo minuscole, cifre, _ e -, max 32 caratteri)",
     "publicKey": "Chiave pubblica",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Server di destinazione",


### PR DESCRIPTION
## Problème

Un Unix username avec espace (ex: `zoor dupont`) passait la validation frontend, arrivait au backend, `sam-add` appelait `useradd` qui le rejetait → `RuntimeError` non catchée → 500.

## Fix

**Backend** (`actions.py`) :
- Regex `^[a-z_][a-z0-9_-]{0,31}$` validée avant tout traitement
- `ValueError` → API retourne 400 avec message explicite

**Frontend** (`DeployKeyForm.vue`) :
- Computed `unixUserValid` avec la même regex
- Message d'erreur inline sous le champ si invalide
- Bouton Submit désactivé tant que le nom est invalide

**i18n** : clé `deployKey.error_unix_user` ajoutée dans les 5 langues

## Tests

- 3 nouveaux tests `test_actions.py` : espace → ValueError, majuscule → ValueError, nom valide → succès
- Total : 226 tests Python, 89 vitest

Closes #179