### PR TITLE
feat: sam-lock-user / sam-unlock-user — verrouillage compte Unix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,13 @@ Développeur : Stéphane de Labrusse.
 Stack habituelle : Python/Bash, Podman, PostgreSQL, Nginx, Alpine,
 Vue.js 3.
 
-## État du projet — toutes issues fermées (47/47)
+## État du projet — toutes issues fermées (48/48)
 
 Milestone 1 (Issues 1–4) ✅  
 Milestone 2 (Issues 5–13) ✅  
 Milestone 3 (Issues 14–21) ✅  
 Milestone 4 (Issues 22–24) ✅  
-Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148) ✅
+Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181) ✅
 
 ## Stack vérifiée et figée
 
@@ -299,7 +299,9 @@ CREATE TABLE audit_log (
                         'ADMIN_ADDED',
                         'ADMIN_DISABLED',
                         'ADMIN_ENABLED',
-                        'ADMIN_DELETED'
+                        'ADMIN_DELETED',
+                        'USER_LOCKED',
+                        'USER_UNLOCKED'
                     )),
     performed_by    UUID REFERENCES administrators(id),
     target_key      UUID REFERENCES ssh_keys(id),
@@ -310,12 +312,16 @@ CREATE TABLE audit_log (
 
 -- ADMIN_ENABLED et ADMIN_DELETED ajoutés via migration 003
 -- (sql/migrations/003_admin_enable_delete.sql — issue #116)
+-- USER_LOCKED et USER_UNLOCKED ajoutés via migration 004
+-- (sql/migrations/004_user_lock_unlock.sql — issue #181)
 
 ## Migrations SQL
 
 sql/migrations/
     003_admin_enable_delete.sql  ← étend le CHECK de audit_log.action
                                     pour ADMIN_ENABLED et ADMIN_DELETED
+    004_user_lock_unlock.sql     ← étend le CHECK de audit_log.action
+                                    pour USER_LOCKED et USER_UNLOCKED
 
 Bootstrap applique les migrations dans l'ordre lexicographique
 après schema.sql au premier démarrage.
@@ -358,7 +364,7 @@ app/
     ├── servers.py     ← parsing servers.yml + sync BDD
     │                     + ssh-keyscan known_hosts
     ├── ssh.py         ← connexion paramiko + ensure_scripts
-    │                     + revoke_on_server
+    │                     + revoke_on_server + lock/unlock_user_on_server
     ├── actions.py     ← logique métier pure (partagée)
     ├── collect.py     ← orchestration scan complet
     ├── expire.py      ← warn J-7/J-2 + révocation auto
@@ -402,6 +408,16 @@ Crée ~/.ssh/ si absent (chmod 700, chown user:user).
 Ajoute la clé publique dans authorized_keys si absente (idempotent).
 Fixe les permissions (chmod 600, chown user:user).
 Utilisé par deploy_key() dans actions.py (issue #164).
+
+SAM_LOCK_USER — /usr/local/bin/sam-lock-user <unix_user> (root, 755)
+usermod -L -s /sbin/nologin <unix_user>
+Bloque le mot de passe ET le shell — connexion SSH impossible même avec une clé valide.
+Utilisé par lock_user() dans actions.py (issue #181).
+
+SAM_UNLOCK_USER — /usr/local/bin/sam-unlock-user <unix_user> (root, 755)
+usermod -U -s /bin/bash <unix_user>
+Rétablit le mot de passe et le shell /bin/bash.
+Utilisé par unlock_user() dans actions.py (issue #181).
 
 ## Logique métier — known_hosts
 
@@ -516,6 +532,10 @@ Validation robustesse mot de passe (issue #62) :
 - revoke_request(request_id, admin_id, db)
 - deploy_key(public_key, unix_user, hostname, expires_at, justification, admin_id)
   ↳ parse + fingerprint, INSERT ssh_keys, sam-add sur serveur, key_authorization ACTIVE (issue #164)
+- lock_user(unix_user, hostname, admin_id)
+  ↳ valide username POSIX, sam-lock-user sur serveur, audit_log USER_LOCKED (issue #181)
+- unlock_user(unix_user, hostname, admin_id)
+  ↳ valide username POSIX, sam-unlock-user sur serveur, audit_log USER_UNLOCKED (issue #181)
 
 ### Serveurs
 - add_server(hostname, ip, env, os_family, db)
@@ -541,8 +561,8 @@ app/tests/
     conftest.py        ← fixtures partagées (DB, SSH mock, msmtp mock)
     test_db.py         ← helpers connexion, transactions (7 tests)
     test_servers.py    ← parsing servers.yml, sync BDD (6 tests)
-    test_ssh.py        ← mock paramiko, RejectPolicy, ensure_scripts (11 tests)
-    test_actions.py    ← toutes les fonctions actions.py (52 tests)
+    test_ssh.py        ← mock paramiko, RejectPolicy, ensure_scripts (15 tests)
+    test_actions.py    ← toutes les fonctions actions.py (62 tests)
     test_collect.py    ← mock scan complet, 4 scénarios détection (18 tests)
     test_expire.py     ← warn J-7/J-2, anti-spam 24h, expiration auto (9 tests)
     test_alerts.py     ← mock msmtp, niveaux CRITIQUE/WARNING/INFO (12 tests)
@@ -591,6 +611,9 @@ test_actions.py :
 - Anti-spam EXPIRY_WARNING : second appel dans 24h ne renvoie pas d'email
 - enable_server, delete_server, enable_admin, delete_admin
 - _validate_password_strength : valide et invalide
+- deploy_key : username invalide (espace, majuscule) → ValueError
+- lock_user : succès, username invalide, serveur introuvable
+- unlock_user : succès, username invalide
 
 test_expire.py :
 - expire : scénario 4 (expiration programmée → sam-revoke)
@@ -602,15 +625,27 @@ test_ssh.py :
 - ensure_scripts ne redéploie pas si hash identique
 - revoke_on_server appelle sam-revoke avec bon fingerprint
 - SAM_REVOKE et SAM_COLLECT sont de type bytes
+- SAM_LOCK_USER et SAM_UNLOCK_USER sont de type bytes
+- lock_user_on_server appelle sam-lock-user avec le bon username
+- unlock_user_on_server appelle sam-unlock-user avec le bon username
 
 test_web.py :
-- GET /api/keys retourne 200 + liste JSON
+- GET /api/keys retourne 200 + liste JSON (inclut revoked_automatically, server_hostname)
 - POST /api/keys/revoke/<fp> retourne 200 si admin authentifié
 - POST /api/keys/revoke/<fp> retourne 401 si non authentifié
+- POST /api/keys/revoke/<fp> retourne 400 si fingerprint format invalide
 - POST /api/access/grant retourne 201 avec expires_at calculé
+- POST /api/access/deploy retourne 400 si hours hors plage (0, -1, 8761)
+- POST /api/access/deploy retourne 400 si hours non entier
+- POST /api/keys/set-expiry retourne 200 avec format datetime-local (sans secondes)
 - POST /api/auth/login retourne 200 + session
 - PUT /api/servers/<hostname>/enable retourne 200
 - DELETE /api/servers/<hostname> retourne 200
+- POST /api/access/lock-user retourne 200 si admin authentifié
+- POST /api/access/lock-user retourne 401 si non authentifié
+- POST /api/access/lock-user retourne 400 si champs manquants
+- POST /api/access/unlock-user retourne 200 si admin authentifié
+- POST /api/access/unlock-user retourne 401 si non authentifié
 
 ### Tests frontend — Vitest
 
@@ -622,6 +657,7 @@ ui/tests/
     Admins.spec.js        ← modals enable/delete, garde-fous (15 tests)
     Settings.spec.js      ← chargement, sauvegarde, validation, erreurs (7 tests)
     DeployKeyForm.spec.js ← formulaire déploiement clé SSH (16 tests)
+    UserLockForm.spec.js  ← verrouillage/déverrouillage compte Unix (10 tests)
 
 ### Ce qui n'est PAS testé unitairement
 
@@ -724,6 +760,8 @@ access request --key FP --server HOST --hours N --reason TEXT
 access approve <id>
 access reject <id>
 access revoke <id>
+access lock-user --user USER --server HOST
+access unlock-user --user USER --server HOST
 
 ### Administrateurs
 admin list
@@ -780,6 +818,8 @@ GET  /api/access/<id>
 POST /api/access/grant
 POST /api/access/request
 POST /api/access/deploy
+POST /api/access/lock-user
+POST /api/access/unlock-user
 POST /api/access/<id>/approve
 POST /api/access/<id>/reject
 POST /api/access/<id>/revoke
@@ -814,7 +854,7 @@ ui/src/views/
                           + boutons désactiver/réactiver/supprimer (issue #89)
                           + bandeau rouge si serveur désactivé (issue #91)
     Anomalies.vue       ← toutes anomalies actives
-    AccessRequests.vue  ← déploiement de clé SSH (formulaire DeployKeyForm uniquement)
+    AccessRequests.vue  ← déploiement de clé SSH (DeployKeyForm) + verrouillage compte Unix (UserLockForm)
     Audit.vue           ← historique filtrable
     Admins.vue          ← gestion administrateurs
                           + modals enable/delete + garde-fou self (issue #116)
@@ -831,6 +871,7 @@ ui/src/components/
     KeyActions.vue      ← boutons valider/révoquer/expiry
     ExpiryPicker.vue    ← datepicker durée ou date précise
     DeployKeyForm.vue   ← formulaire déploiement clé SSH (utilisé par AccessRequests.vue)
+    UserLockForm.vue    ← verrouillage/déverrouillage compte Unix (issue #181)
 
 ui/src/
     i18n.js             ← configuration vue-i18n v9 (issue #98)
@@ -865,16 +906,21 @@ Internationalisation (issue #98) :
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-add
+audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user
+audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user
 audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-collect /usr/local/bin/sam-collect
 audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke
 audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-add /usr/local/bin/sam-add
+audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-lock-user /usr/local/bin/sam-lock-user
+audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-unlock-user /usr/local/bin/sam-unlock-user
 
 # Note : install remplace mv+chmod+chown (3 appels) — évite le ":" dans
 # les restrictions d'arguments sudoers qui cause des erreurs visudo sur
 # certaines versions (RHEL/CentOS).
-# sam-add sans restriction d'arguments : la pubkey et le username sont variables
-# (impossible à restreindre dans sudoers). La sécurité repose sur le contenu
-# du script, déployé et vérifié par hash SHA256 par le container SAM.
+# sam-add/sam-lock-user/sam-unlock-user sans restriction d'arguments :
+# le username est variable (impossible à restreindre dans sudoers).
+# La sécurité repose sur le contenu du script, déployé et vérifié par
+# hash SHA256 par le container SAM.
 
 ## provision-host.sh
 
@@ -967,7 +1013,8 @@ ssh-access-manager/
     ├── sql/
     │   ├── schema.sql
     │   └── migrations/
-    │       └── 003_admin_enable_delete.sql
+    │       ├── 003_admin_enable_delete.sql
+    │       └── 004_user_lock_unlock.sql
     ├── app/
     │   ├── db.py
     │   ├── servers.py
@@ -1000,7 +1047,8 @@ ssh-access-manager/
         │   ├── KeyTable.spec.js
         │   ├── Admins.spec.js
         │   ├── Settings.spec.js
-        │   └── DeployKeyForm.spec.js
+        │   ├── DeployKeyForm.spec.js
+        │   └── UserLockForm.spec.js
         └── src/
             ├── App.vue
             ├── main.js
@@ -1029,4 +1077,5 @@ ssh-access-manager/
                 ├── KeyTable.vue
                 ├── KeyActions.vue
                 ├── ExpiryPicker.vue
-                └── DeployKeyForm.vue
+                ├── DeployKeyForm.vue
+                └── UserLockForm.vue

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,16 +302,23 @@ clés 2048 bits et 4096 bits construites manuellement en wire format.
 
 ### 6.5 Scripts distants versionnés et hash-déployés
 
-`SAM_COLLECT` et `SAM_REVOKE` sont des constantes Python `bytes` dans `ssh.py`.
-Avant chaque déploiement SFTP, leur hash SHA256 est comparé à celui présent sur le
-serveur distant :
+`SAM_COLLECT`, `SAM_REVOKE`, `SAM_ADD`, `SAM_LOCK_USER` et `SAM_UNLOCK_USER` sont
+des constantes Python `bytes` dans `ssh.py`. Avant chaque déploiement SFTP, leur
+hash SHA256 est comparé à celui présent sur le serveur distant :
 
 ```python
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 def ensure_scripts(hostname, server_id, ip):
-    for content, remote_path in ((SAM_COLLECT, SAM_COLLECT_PATH), (SAM_REVOKE, SAM_REVOKE_PATH)):
+    scripts = (
+        (SAM_COLLECT, SAM_COLLECT_PATH),
+        (SAM_REVOKE, SAM_REVOKE_PATH),
+        (SAM_ADD, SAM_ADD_PATH),
+        (SAM_LOCK_USER, SAM_LOCK_USER_PATH),
+        (SAM_UNLOCK_USER, SAM_UNLOCK_USER_PATH),
+    )
+    for content, remote_path in scripts:
         remote_hash = _remote_sha256(client, remote_path)
         if remote_hash != _sha256(content):
             tmp_path = f"/home/{SSH_USER}/{os.path.basename(remote_path)}"
@@ -671,17 +678,27 @@ Ce guard est non-bloquant : si `fetchMe()` échoue (session expirée), la
 redirection vers Login est automatique. Aucune vue protégée n'est rendue sans
 authentification valide.
 
-### Vue AccessRequests — formulaire DeployKeyForm
+### Vue AccessRequests — formulaires DeployKeyForm et UserLockForm
 
-La vue `AccessRequests.vue` expose uniquement le formulaire `DeployKeyForm` pour
-déployer une clé SSH sur un serveur distant depuis l'interface web.
-Le formulaire collecte : utilisateur Unix, clé publique, serveur cible (dropdown
-des serveurs actifs via `GET /api/servers`, filtré `is_active === true`), durée
-(heures / date précise / illimité) et justification.
+La vue `AccessRequests.vue` expose deux formulaires :
 
+**DeployKeyForm** : déploiement d'une clé SSH sur un serveur distant.
+Collecte : utilisateur Unix, clé publique, serveur cible (dropdown des serveurs
+actifs via `GET /api/servers`, filtré `is_active === true`), durée (heures / date
+précise / illimité) et justification.
 À la soumission, `POST /api/access/deploy` appelle `actions.deploy_key()` :
 exécution de `sam-add` sur le serveur distant, enregistrement de la clé avec
 statut `ACTIVE` et expiration choisie.
+
+**UserLockForm** : verrouillage / déverrouillage d'un compte Unix (issue #181).
+Collecte : utilisateur Unix (regex POSIX strict — pas d'espaces, pas de majuscules),
+serveur cible. Deux boutons distincts : « Bloquer » (POST /api/access/lock-user)
+et « Débloquer » (POST /api/access/unlock-user).
+`sam-lock-user` exécute `usermod -L -s /sbin/nologin <user>` — bloque à la fois
+le mot de passe et le shell, rendant toute connexion SSH impossible même avec une
+clé valide. `sam-unlock-user` rétablit avec `usermod -U -s /bin/bash <user>`.
+Chaque action est tracée dans `audit_log` avec action `USER_LOCKED` ou
+`USER_UNLOCKED`.
 
 Le workflow demande/approbation (`access request` / `access approve`) reste
 disponible via la CLI et l'API REST, mais n'est plus exposé dans l'interface web.
@@ -834,13 +851,13 @@ coûteuse en temps).
 
 | Module | Tests | Couverture |
 |---|---|---|
-| `actions.py` | 60+ | ≥ 80 % (imposé CI) |
-| `test_ssh.py` | 12 | RejectPolicy, ensure_scripts (install), revoke, SAM_REVOKE content, staging path |
-| `test_web.py` | 16 | Toutes les routes critiques, auth 401/200 |
-| `test_manage.py` | 25 | Toutes les commandes CLI |
+| `actions.py` | 62+ | ≥ 80 % (imposé CI) |
+| `test_ssh.py` | 15 | RejectPolicy, ensure_scripts (5 scripts), revoke, lock/unlock, SAM bytes |
+| `test_web.py` | 50+ | Toutes les routes critiques, auth 401/200, lock/unlock routes |
+| `test_manage.py` | 42+ | Toutes les commandes CLI, lock/unlock |
 | `test_collect.py` | 15 | 4 scénarios détection, RSA parsing |
 | `test_expire.py` | 12 | Anti-spam 24h, expiration auto |
-| Vue.js specs | 52 | KeyActions, ExpiryPicker, KeyTable, ServerTable |
+| Vue.js specs | 99 | KeyActions, ExpiryPicker, KeyTable, ServerTable, UserLockForm |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,25 @@ Depuis la vue détail d'un serveur, les actions disponibles sur chaque clé ACTI
 
 ---
 
+## Workflow — Verrouiller / Déverrouiller un compte Unix
+
+Après révocation d'une clé, le compte Unix existe toujours sur le serveur. Pour bloquer **toute** connexion SSH (y compris avec une autre clé valide) :
+
+**Via l'interface web** : Accès → section **Verrouiller / Déverrouiller un compte Unix**.
+
+| Action | Commande distante | Effet |
+|---|---|---|
+| **Verrouiller** | `usermod -L -s /sbin/nologin <user>` | Bloque le mot de passe et interdit le shell — connexion SSH impossible même avec une clé valide |
+| **Déverrouiller** | `usermod -U -s /bin/bash <user>` | Rétablit le compte — connexion SSH de nouveau possible avec une clé valide |
+
+**Via la CLI** :
+```bash
+$EXEC access lock-user --user alice --server server-prod-01
+$EXEC access unlock-user --user alice --server server-prod-01
+```
+
+---
+
 ## Workflow — Déployer une clé SSH
 
 Pour donner accès à un utilisateur sur un serveur depuis l'interface :
@@ -287,6 +306,8 @@ $EXEC access grant --key SHA256:... --server HOST --hours 8 --reason "Motif"
 $EXEC access approve <id>
 $EXEC access reject <id>
 $EXEC access revoke <id>
+$EXEC access lock-user --user USER --server HOST
+$EXEC access unlock-user --user USER --server HOST
 
 # Administrateurs
 $EXEC admin list

--- a/app/actions.py
+++ b/app/actions.py
@@ -736,3 +736,47 @@ def delete_admin(username: str, admin_id: str | None = None) -> None:
         (admin_id, json.dumps({"username": username})),
     )
     db.execute("DELETE FROM administrators WHERE id = %s", (admin["id"],))
+
+
+# ---------------------------------------------------------------------------
+# Gestion des comptes Unix
+# ---------------------------------------------------------------------------
+
+def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
+    """Lock a Unix user account on a remote server."""
+    if not _UNIX_USER_RE.match(unix_user):
+        raise ValueError(f"Nom d'utilisateur Unix invalide : '{unix_user}'")
+    server = db.query_one(
+        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        (hostname,)
+    )
+    if not server:
+        raise ValueError(f"Serveur introuvable ou inactif: {hostname}")
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
+    ssh.lock_user_on_server(hostname, unix_user, server["ip_address"])
+    db.execute(
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('USER_LOCKED', %s, %s, %s::jsonb)""",
+        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "hostname": hostname}))
+    )
+    return {"unix_user": unix_user, "hostname": hostname, "status": "locked"}
+
+
+def unlock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
+    """Unlock a Unix user account on a remote server."""
+    if not _UNIX_USER_RE.match(unix_user):
+        raise ValueError(f"Nom d'utilisateur Unix invalide : '{unix_user}'")
+    server = db.query_one(
+        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        (hostname,)
+    )
+    if not server:
+        raise ValueError(f"Serveur introuvable ou inactif: {hostname}")
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
+    ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"])
+    db.execute(
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('USER_UNLOCKED', %s, %s, %s::jsonb)""",
+        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "hostname": hostname}))
+    )
+    return {"unix_user": unix_user, "hostname": hostname, "status": "unlocked"}

--- a/app/manage.py
+++ b/app/manage.py
@@ -370,6 +370,32 @@ def access_revoke(request_id):
         raise click.ClickException(str(e))
 
 
+@access.command("lock-user")
+@click.option("--user", required=True, help="Unix username")
+@click.option("--server", required=True, help="Server hostname")
+def access_lock_user(user, server):
+    """Lock a Unix user account on a remote server."""
+    admin_id = _require_admin()
+    try:
+        result = actions.lock_user(user, server, admin_id)
+        click.echo(f"User '{result['unix_user']}' locked on {result['hostname']}")
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
+
+@access.command("unlock-user")
+@click.option("--user", required=True, help="Unix username")
+@click.option("--server", required=True, help="Server hostname")
+def access_unlock_user(user, server):
+    """Unlock a Unix user account on a remote server."""
+    admin_id = _require_admin()
+    try:
+        result = actions.unlock_user(user, server, admin_id)
+        click.echo(f"User '{result['unix_user']}' unlocked on {result['hostname']}")
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
+
 # ---------------------------------------------------------------------------
 # admin
 # ---------------------------------------------------------------------------

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -14,6 +14,8 @@ SSH_USER = os.environ.get("SSH_USER", "audit-collector")
 SAM_COLLECT_PATH = "/usr/local/bin/sam-collect"
 SAM_REVOKE_PATH = "/usr/local/bin/sam-revoke"
 SAM_ADD_PATH = "/usr/local/bin/sam-add"
+SAM_LOCK_USER_PATH = "/usr/local/bin/sam-lock-user"
+SAM_UNLOCK_USER_PATH = "/usr/local/bin/sam-unlock-user"
 
 # ---------------------------------------------------------------------------
 # Remote scripts — versioned as Python constants.
@@ -127,6 +129,28 @@ chmod 600 "$auth_keys"
 chown "${TARGET_USER}:${TARGET_USER}" "$auth_keys"
 """
 
+SAM_LOCK_USER = b"""#!/bin/sh
+# sam-lock-user <username> - lock Unix user account
+set -e
+USER="$1"
+if [ -z "$USER" ]; then
+    echo "Usage: sam-lock-user <username>" >&2
+    exit 1
+fi
+usermod -L -s /sbin/nologin "$USER"
+"""
+
+SAM_UNLOCK_USER = b"""#!/bin/sh
+# sam-unlock-user <username> - unlock Unix user account
+set -e
+USER="$1"
+if [ -z "$USER" ]; then
+    echo "Usage: sam-unlock-user <username>" >&2
+    exit 1
+fi
+usermod -U -s /bin/bash "$USER"
+"""
+
 
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
@@ -168,7 +192,7 @@ def _deploy_script(
 
 def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
     """
-    Deploy SAM_COLLECT, SAM_REVOKE, and SAM_ADD on the remote host if absent or outdated.
+    Deploy SAM_COLLECT, SAM_REVOKE, SAM_ADD, SAM_LOCK_USER, and SAM_UNLOCK_USER on the remote host if absent or outdated.
     Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
     """
     client = _connect(ip)
@@ -178,6 +202,8 @@ def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
             (SAM_COLLECT, SAM_COLLECT_PATH),
             (SAM_REVOKE, SAM_REVOKE_PATH),
             (SAM_ADD, SAM_ADD_PATH),
+            (SAM_LOCK_USER, SAM_LOCK_USER_PATH),
+            (SAM_UNLOCK_USER, SAM_UNLOCK_USER_PATH),
         ):
             local_hash = _sha256(content)
             remote_hash = _remote_sha256(client, remote_path)
@@ -239,5 +265,33 @@ def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str) -
         )
         if rc != 0:
             raise RuntimeError(f"sam-add failed on {hostname} (rc={rc}): {err}")
+    finally:
+        client.close()
+
+
+def lock_user_on_server(hostname: str, unix_user: str, ip: str) -> None:
+    """Run sam-lock-user on the remote host to lock a Unix user account."""
+    import shlex
+    client = _connect(ip)
+    try:
+        _, err, rc = _run(
+            client, f"sudo {SAM_LOCK_USER_PATH} {shlex.quote(unix_user)}"
+        )
+        if rc != 0:
+            raise RuntimeError(f"sam-lock-user failed on {hostname} (rc={rc}): {err}")
+    finally:
+        client.close()
+
+
+def unlock_user_on_server(hostname: str, unix_user: str, ip: str) -> None:
+    """Run sam-unlock-user on the remote host to unlock a Unix user account."""
+    import shlex
+    client = _connect(ip)
+    try:
+        _, err, rc = _run(
+            client, f"sudo {SAM_UNLOCK_USER_PATH} {shlex.quote(unix_user)}"
+        )
+        if rc != 0:
+            raise RuntimeError(f"sam-unlock-user failed on {hostname} (rc={rc}): {err}")
     finally:
         client.close()

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -679,3 +679,50 @@ def test_actions_fingerprint_valid_format_passes_check():
     """Un fingerprint SHA256 valide ne lève pas d'exception au niveau du format."""
     import actions as act
     act._check_fingerprint("SHA256:abc123+/=ABCXYZ")
+
+
+# ---------------------------------------------------------------------------
+# lock_user / unlock_user
+# ---------------------------------------------------------------------------
+
+def test_actions_lock_user_success():
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        result = actions.lock_user("alice", "server-test-01", ADMIN_ID)
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10")
+        mock_ssh.lock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10")
+        assert result["unix_user"] == "alice"
+        assert result["hostname"] == "server-test-01"
+        assert result["status"] == "locked"
+        audit_call = mock_db.execute.call_args[0]
+        assert "USER_LOCKED" in audit_call[0]
+
+
+def test_actions_lock_user_invalid_username():
+    with pytest.raises(ValueError, match="Nom d'utilisateur Unix invalide"):
+        actions.lock_user("bad user", "server-test-01", ADMIN_ID)
+
+
+def test_actions_lock_user_server_not_found():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = None
+        with pytest.raises(ValueError, match="Serveur introuvable ou inactif"):
+            actions.lock_user("alice", "unknown-server", ADMIN_ID)
+
+
+def test_actions_unlock_user_success():
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        result = actions.unlock_user("alice", "server-test-01", ADMIN_ID)
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10")
+        mock_ssh.unlock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10")
+        assert result["unix_user"] == "alice"
+        assert result["hostname"] == "server-test-01"
+        assert result["status"] == "unlocked"
+        audit_call = mock_db.execute.call_args[0]
+        assert "USER_UNLOCKED" in audit_call[0]
+
+
+def test_actions_unlock_user_invalid_username():
+    with pytest.raises(ValueError, match="Nom d'utilisateur Unix invalide"):
+        actions.unlock_user("bad@user", "server-test-01", ADMIN_ID)

--- a/app/tests/test_manage.py
+++ b/app/tests/test_manage.py
@@ -322,3 +322,41 @@ def test_manage_servers_help(runner):
 def test_manage_keys_help(runner):
     result = runner.invoke(manage.cli, ["keys", "--help"])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# access lock-user / unlock-user
+# ---------------------------------------------------------------------------
+
+def test_manage_access_lock_user(runner):
+    with patch("manage.db") as mock_db, patch("manage.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin()
+        mock_actions.lock_user.return_value = {
+            "unix_user": "alice",
+            "hostname": "server-test-01",
+            "status": "locked"
+        }
+        result = runner.invoke(manage.cli, [
+            "access", "lock-user",
+            "--user", "alice",
+            "--server", "server-test-01"
+        ])
+        assert result.exit_code == 0
+        assert "locked" in result.output
+
+
+def test_manage_access_unlock_user(runner):
+    with patch("manage.db") as mock_db, patch("manage.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin()
+        mock_actions.unlock_user.return_value = {
+            "unix_user": "alice",
+            "hostname": "server-test-01",
+            "status": "unlocked"
+        }
+        result = runner.invoke(manage.cli, [
+            "access", "unlock-user",
+            "--user", "alice",
+            "--server", "server-test-01"
+        ])
+        assert result.exit_code == 0
+        assert "unlocked" in result.output

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -109,6 +109,8 @@ def test_ssh_ensure_scripts_skips_when_hash_identical(sample_server):
     local_hash_collect = ssh._sha256(ssh.SAM_COLLECT)
     local_hash_revoke = ssh._sha256(ssh.SAM_REVOKE)
     local_hash_add = ssh._sha256(ssh.SAM_ADD)
+    local_hash_lock = ssh._sha256(ssh.SAM_LOCK_USER)
+    local_hash_unlock = ssh._sha256(ssh.SAM_UNLOCK_USER)
 
     with patch("ssh._connect") as mock_connect, \
          patch("ssh.db") as mock_db:
@@ -118,11 +120,11 @@ def test_ssh_ensure_scripts_skips_when_hash_identical(sample_server):
         client.open_sftp.return_value = sftp
 
         call_count = [0]
-        hashes = [local_hash_collect, local_hash_revoke, local_hash_add]
+        hashes = [local_hash_collect, local_hash_revoke, local_hash_add, local_hash_lock, local_hash_unlock]
 
         def exec_side_effect(cmd):
             stdout = MagicMock()
-            h = hashes[call_count[0] % 3]
+            h = hashes[call_count[0] % 5]
             stdout.read.return_value = f"{h}  path\n".encode()
             stdout.channel.recv_exit_status.return_value = 0
             call_count[0] += 1
@@ -255,6 +257,8 @@ def test_ssh_ensure_scripts_install_uses_exact_destination(sample_server):
             "/usr/local/bin/sam-collect",
             "/usr/local/bin/sam-revoke",
             "/usr/local/bin/sam-add",
+            "/usr/local/bin/sam-lock-user",
+            "/usr/local/bin/sam-unlock-user",
         )
         for cmd in install_cmds:
             dest = cmd.split()[-1]
@@ -356,3 +360,59 @@ def test_ssh_ensure_scripts_audit_details_valid_json(sample_server):
         parsed = json.loads(details_arg)
         assert parsed["hostname"] == hostile_server["hostname"]
         assert "injected" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# SAM_LOCK_USER et SAM_UNLOCK_USER — vérifications de contenu
+# ---------------------------------------------------------------------------
+
+def test_ssh_sam_lock_user_is_bytes():
+    assert isinstance(ssh.SAM_LOCK_USER, bytes)
+    assert b"#!/bin/sh" in ssh.SAM_LOCK_USER
+    assert b"usermod" in ssh.SAM_LOCK_USER
+    assert b"-L" in ssh.SAM_LOCK_USER
+    assert b"/sbin/nologin" in ssh.SAM_LOCK_USER
+
+
+def test_ssh_sam_unlock_user_is_bytes():
+    assert isinstance(ssh.SAM_UNLOCK_USER, bytes)
+    assert b"#!/bin/sh" in ssh.SAM_UNLOCK_USER
+    assert b"usermod" in ssh.SAM_UNLOCK_USER
+    assert b"-U" in ssh.SAM_UNLOCK_USER
+    assert b"/bin/bash" in ssh.SAM_UNLOCK_USER
+
+
+def test_ssh_lock_user_on_server_calls_sam_lock_user(sample_server):
+    with patch("ssh._connect") as mock_connect:
+        client = MagicMock()
+        mock_connect.return_value = client
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 0
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+        ssh.lock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"])
+
+        cmd = client.exec_command.call_args[0][0]
+        assert "sam-lock-user" in cmd
+        assert "alice" in cmd
+
+
+def test_ssh_unlock_user_on_server_calls_sam_unlock_user(sample_server):
+    with patch("ssh._connect") as mock_connect:
+        client = MagicMock()
+        mock_connect.return_value = client
+        stdout = MagicMock()
+        stdout.read.return_value = b""
+        stdout.channel.recv_exit_status.return_value = 0
+        stderr = MagicMock()
+        stderr.read.return_value = b""
+        client.exec_command.return_value = (MagicMock(), stdout, stderr)
+
+        ssh.unlock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"])
+
+        cmd = client.exec_command.call_args[0][0]
+        assert "sam-unlock-user" in cmd
+        assert "alice" in cmd

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -599,3 +599,64 @@ def test_web_list_admins_does_not_expose_password_hash(auth_client):
         sql = mock_db.query.call_args[0][0]
         assert "password_hash" not in sql
         assert "SELECT *" not in sql
+
+
+# ---------------------------------------------------------------------------
+# lock-user / unlock-user
+# ---------------------------------------------------------------------------
+
+def test_web_lock_user_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.lock_user.return_value = {
+            "unix_user": "alice",
+            "hostname": "server-test-01",
+            "status": "locked"
+        }
+        resp = auth_client.post("/api/access/lock-user", json={
+            "unix_user": "alice",
+            "hostname": "server-test-01"
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "locked"
+
+
+def test_web_lock_user_returns_401_unauthenticated(client):
+    resp = client.post("/api/access/lock-user", json={
+        "unix_user": "alice",
+        "hostname": "server-test-01"
+    })
+    assert resp.status_code == 401
+
+
+def test_web_lock_user_returns_400_missing_fields(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/access/lock-user", json={"unix_user": "alice"})
+        assert resp.status_code == 400
+
+
+def test_web_unlock_user_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.unlock_user.return_value = {
+            "unix_user": "alice",
+            "hostname": "server-test-01",
+            "status": "unlocked"
+        }
+        resp = auth_client.post("/api/access/unlock-user", json={
+            "unix_user": "alice",
+            "hostname": "server-test-01"
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "unlocked"
+
+
+def test_web_unlock_user_returns_401_unauthenticated(client):
+    resp = client.post("/api/access/unlock-user", json={
+        "unix_user": "alice",
+        "hostname": "server-test-01"
+    })
+    assert resp.status_code == 401

--- a/app/web.py
+++ b/app/web.py
@@ -392,6 +392,44 @@ def api_deploy_key():
         return jsonify({"error": "internal server error"}), 500
 
 
+@app.route("/api/access/lock-user", methods=["POST"])
+@require_auth
+def api_lock_user():
+    data = request.json or {}
+    unix_user = (data.get("unix_user") or "").strip()
+    hostname = (data.get("hostname") or "").strip()
+    if not unix_user or not hostname:
+        return jsonify({"error": "unix_user and hostname required"}), 400
+    try:
+        result = actions.lock_user(unix_user, hostname, g.admin_id)
+        return jsonify(result), 200
+    except ValueError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logging.exception("lock_user failed")
+        return jsonify({"error": "internal server error"}), 500
+
+
+@app.route("/api/access/unlock-user", methods=["POST"])
+@require_auth
+def api_unlock_user():
+    data = request.json or {}
+    unix_user = (data.get("unix_user") or "").strip()
+    hostname = (data.get("hostname") or "").strip()
+    if not unix_user or not hostname:
+        return jsonify({"error": "unix_user and hostname required"}), 400
+    try:
+        result = actions.unlock_user(unix_user, hostname, g.admin_id)
+        return jsonify(result), 200
+    except ValueError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logging.exception("unlock_user failed")
+        return jsonify({"error": "internal server error"}), 500
+
+
 @app.route("/api/access/request", methods=["POST"])
 @require_auth
 def request_access():

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -43,9 +43,13 @@ printf '# ssh-access-manager — droits sudo pour audit-collector\n' > "${SUDOER
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-add\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user\n' >> "${SUDOERS_FILE}"
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-collect /usr/local/bin/sam-collect\n' >> "${SUDOERS_FILE}"
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-revoke /usr/local/bin/sam-revoke\n' >> "${SUDOERS_FILE}"
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-add /usr/local/bin/sam-add\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-lock-user /usr/local/bin/sam-lock-user\n' >> "${SUDOERS_FILE}"
+printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-unlock-user /usr/local/bin/sam-unlock-user\n' >> "${SUDOERS_FILE}"
 
 chmod 440 "${SUDOERS_FILE}"
 echo "[provision] Sudoers configuré dans ${SUDOERS_FILE}."

--- a/sql/migrations/004_user_lock_unlock.sql
+++ b/sql/migrations/004_user_lock_unlock.sql
@@ -1,0 +1,23 @@
+-- Migration 004 — add USER_LOCKED and USER_UNLOCKED to audit_log CHECK constraint
+ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check;
+
+ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check CHECK (action IN (
+    'KEY_ADDED',
+    'KEY_REVOKED',
+    'KEY_EXPIRED',
+    'EXPIRY_WARNING',
+    'REQUEST_APPROVED',
+    'REQUEST_REJECTED',
+    'ANOMALY_DETECTED',
+    'SCAN_COMPLETED',
+    'SCAN_FAILED',
+    'SCRIPT_DEPLOYED',
+    'SERVER_ADDED',
+    'SERVER_DISABLED',
+    'ADMIN_ADDED',
+    'ADMIN_DISABLED',
+    'ADMIN_ENABLED',
+    'ADMIN_DELETED',
+    'USER_LOCKED',
+    'USER_UNLOCKED'
+));

--- a/ui/src/components/UserLockForm.vue
+++ b/ui/src/components/UserLockForm.vue
@@ -1,0 +1,237 @@
+<template>
+  <form class="user-lock-form" @submit.prevent>
+    <div v-if="error" class="alert-error" data-testid="error-msg">{{ error }}</div>
+    <div v-if="success" class="success-panel" data-testid="success-msg">
+      {{ success }}
+    </div>
+
+    <div class="field">
+      <label for="ul-user"
+        >{{ $t('userLock.unixUser') }}
+        <span class="required">{{ $t('common.required') }}</span></label
+      >
+      <input
+        id="ul-user"
+        v-model="unixUser"
+        type="text"
+        :placeholder="$t('userLock.unixUserPlaceholder')"
+        data-testid="input-unix-user"
+      />
+      <span v-if="unixUser && !unixUserValid" class="field-error" data-testid="error-unix-user">
+        {{ $t('userLock.error_unix_user') }}
+      </span>
+    </div>
+
+    <div class="field">
+      <label for="ul-server"
+        >{{ $t('userLock.server') }}
+        <span class="required">{{ $t('common.required') }}</span></label
+      >
+      <select id="ul-server" v-model="server" data-testid="select-server">
+        <option value="" disabled>
+          {{
+            serversLoading
+              ? $t('access_form.server_loading')
+              : servers.length === 0
+                ? $t('access_form.server_empty')
+                : $t('access_form.server_placeholder')
+          }}
+        </option>
+        <option v-for="s in servers" :key="s.hostname" :value="s.hostname">
+          {{ s.hostname }}
+        </option>
+      </select>
+    </div>
+
+    <div class="form-actions">
+      <button
+        type="button"
+        class="btn-danger"
+        :disabled="!isValid || submitting"
+        data-testid="btn-lock"
+        @click="lockUser"
+      >
+        {{ submitting ? $t('common.loading') : $t('userLock.btnLock') }}
+      </button>
+      <button
+        type="button"
+        class="btn-success"
+        :disabled="!isValid || submitting"
+        data-testid="btn-unlock"
+        @click="unlockUser"
+      >
+        {{ submitting ? $t('common.loading') : $t('userLock.btnUnlock') }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+const unixUser = ref('')
+const server = ref('')
+
+const servers = ref([])
+const serversLoading = ref(false)
+const submitting = ref(false)
+const error = ref('')
+const success = ref('')
+
+onMounted(async () => {
+  serversLoading.value = true
+  try {
+    const res = await fetch('/api/servers')
+    if (res.ok) {
+      const data = await res.json()
+      servers.value = data.filter((s) => s.is_active)
+    }
+  } finally {
+    serversLoading.value = false
+  }
+})
+
+const unixUserValid = computed(() => /^[a-z_][a-z0-9_-]{0,31}$/.test(unixUser.value))
+
+const isValid = computed(() => unixUserValid.value && server.value.trim() !== '')
+
+async function lockUser() {
+  await performAction('/api/access/lock-user', 'locked')
+}
+
+async function unlockUser() {
+  await performAction('/api/access/unlock-user', 'unlocked')
+}
+
+async function performAction(endpoint, action) {
+  if (!isValid.value || submitting.value) return
+
+  error.value = ''
+  success.value = ''
+  submitting.value = true
+
+  const payload = {
+    unix_user: unixUser.value.trim(),
+    hostname: server.value.trim(),
+  }
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+
+    const result = await res.json()
+    const msgKey = action === 'locked' ? 'success_locked' : 'success_unlocked'
+    success.value = t(`userLock.${msgKey}`, {
+      user: result.unix_user,
+      server: result.hostname,
+    })
+
+    // Reset form after 3s
+    setTimeout(() => {
+      unixUser.value = ''
+      server.value = ''
+      success.value = ''
+    }, 3000)
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.user-lock-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.required {
+  color: #dc3545;
+}
+
+input[type='text'],
+select {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.field-error {
+  font-size: 0.8rem;
+  color: #dc3545;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn-danger {
+  background: #dc3545;
+  color: white;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: #c82333;
+}
+
+.btn-success {
+  background: #28a745;
+  color: white;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-success:hover:not(:disabled) {
+  background: #218838;
+}
+
+.alert-error {
+  background: #f8d7da;
+  color: #721c24;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.success-panel {
+  background: #d4edda;
+  color: #155724;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+</style>

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -144,7 +144,9 @@
   "access": {
     "title": "Temporärer Zugriff",
     "info_deploy": "Das folgende Formular stellt einen SSH-Schlüssel auf einem Zielserver bereit. Falls der Unix-Benutzer nicht existiert, wird er automatisch erstellt.",
-    "info_no_sudo": "Der Benutzer wird ohne Administratorrechte erstellt (kein sudo/wheel). Um erhöhte Rechte zu erteilen, greifen Sie manuell auf den Server zu."
+    "info_no_sudo": "Der Benutzer wird ohne Administratorrechte erstellt (kein sudo/wheel). Um erhöhte Rechte zu erteilen, greifen Sie manuell auf den Server zu.",
+    "lock_title": "Unix-Konto sperren / entsperren",
+    "lock_info": "Sperrt ein Unix-Konto, um alle SSH-Verbindungen zu blockieren (auch mit gültigem Schlüssel). Entsperren, um den Zugang wiederherzustellen."
   },
   "access_form": {
     "duration_label": "Zugriffsdauer",
@@ -280,5 +282,15 @@
     "unlimited": "Unbegrenzt",
     "errorMissingFields": "Alle Felder sind erforderlich",
     "newDeploy": "Neue Bereitstellung"
+  },
+  "userLock": {
+    "unixUser": "Unix-Benutzer",
+    "unixUserPlaceholder": "z.B. alice",
+    "server": "Zielserver",
+    "btnLock": "Sperren",
+    "btnUnlock": "Entsperren",
+    "error_unix_user": "Ungültiger Unix-Benutzername (nur Kleinbuchstaben, Ziffern, _ und -, max. 32 Zeichen)",
+    "success_locked": "Konto '{user}' gesperrt auf {server}",
+    "success_unlocked": "Konto '{user}' entsperrt auf {server}"
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -144,7 +144,9 @@
   "access": {
     "title": "Temporary Access",
     "info_deploy": "The form below deploys an SSH key on a target server. If the Unix user does not exist, it will be created automatically.",
-    "info_no_sudo": "The user is created without administrative rights (no sudo/wheel). To grant elevated privileges, intervene manually on the server."
+    "info_no_sudo": "The user is created without administrative rights (no sudo/wheel). To grant elevated privileges, intervene manually on the server.",
+    "lock_title": "Lock / Unlock Unix Account",
+    "lock_info": "Lock a Unix account to prevent all SSH connections (even with a valid key). Unlock to restore access."
   },
   "access_form": {
     "duration_label": "Access duration",
@@ -280,5 +282,15 @@
     "unlimited": "Unlimited",
     "errorMissingFields": "All fields are required",
     "newDeploy": "New deployment"
+  },
+  "userLock": {
+    "unixUser": "Unix Username",
+    "unixUserPlaceholder": "e.g. alice",
+    "server": "Target Server",
+    "btnLock": "Lock",
+    "btnUnlock": "Unlock",
+    "error_unix_user": "Invalid Unix username (lowercase, digits, _ and - only, max 32 chars)",
+    "success_locked": "Account '{user}' locked on {server}",
+    "success_unlocked": "Account '{user}' unlocked on {server}"
   }
 }

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -144,7 +144,9 @@
   "access": {
     "title": "Acceso temporal",
     "info_deploy": "El formulario a continuación despliega una clave SSH en un servidor destino. Si el usuario Unix no existe, se creará automáticamente.",
-    "info_no_sudo": "El usuario se crea sin derechos de administración (sin sudo/wheel). Para otorgar privilegios elevados, intervenga manualmente en el servidor."
+    "info_no_sudo": "El usuario se crea sin derechos de administración (sin sudo/wheel). Para otorgar privilegios elevados, intervenga manualmente en el servidor.",
+    "lock_title": "Bloquear / Desbloquear cuenta Unix",
+    "lock_info": "Bloquea una cuenta Unix para impedir todas las conexiones SSH (incluso con clave válida). Desbloquear para restaurar el acceso."
   },
   "access_form": {
     "duration_label": "Duración del acceso",
@@ -280,5 +282,15 @@
     "unlimited": "Ilimitado",
     "errorMissingFields": "Todos los campos son obligatorios",
     "newDeploy": "Nuevo despliegue"
+  },
+  "userLock": {
+    "unixUser": "Usuario Unix",
+    "unixUserPlaceholder": "ej: alice",
+    "server": "Servidor destino",
+    "btnLock": "Bloquear",
+    "btnUnlock": "Desbloquear",
+    "error_unix_user": "Nombre de usuario Unix inválido (minúsculas, dígitos, _ y - únicamente, máx. 32 caracteres)",
+    "success_locked": "Cuenta '{user}' bloqueada en {server}",
+    "success_unlocked": "Cuenta '{user}' desbloqueada en {server}"
   }
 }

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -144,7 +144,9 @@
   "access": {
     "title": "Accès temporaires",
     "info_deploy": "Le formulaire ci-dessous déploie une clé SSH sur un serveur cible. Si l'utilisateur Unix n'existe pas, il sera créé automatiquement.",
-    "info_no_sudo": "L'utilisateur est créé sans droits d'administration (pas de sudo/wheel). Pour accorder des privilèges élevés, intervenez manuellement sur le serveur."
+    "info_no_sudo": "L'utilisateur est créé sans droits d'administration (pas de sudo/wheel). Pour accorder des privilèges élevés, intervenez manuellement sur le serveur.",
+    "lock_title": "Verrouiller / Déverrouiller un compte Unix",
+    "lock_info": "Verrouille un compte Unix pour bloquer toutes les connexions SSH (même avec une clé valide). Déverrouiller pour rétablir l'accès."
   },
   "access_form": {
     "duration_label": "Durée d'accès",
@@ -280,5 +282,15 @@
     "unlimited": "Illimité",
     "errorMissingFields": "Tous les champs sont requis",
     "newDeploy": "Nouveau déploiement"
+  },
+  "userLock": {
+    "unixUser": "Utilisateur Unix",
+    "unixUserPlaceholder": "ex: alice",
+    "server": "Serveur cible",
+    "btnLock": "Verrouiller",
+    "btnUnlock": "Déverrouiller",
+    "error_unix_user": "Nom d'utilisateur Unix invalide (minuscules, chiffres, _ et - uniquement, max 32 caractères)",
+    "success_locked": "Compte '{user}' verrouillé sur {server}",
+    "success_unlocked": "Compte '{user}' déverrouillé sur {server}"
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -144,7 +144,9 @@
   "access": {
     "title": "Accesso temporaneo",
     "info_deploy": "Il modulo seguente distribuisce una chiave SSH su un server di destinazione. Se l'utente Unix non esiste, verrà creato automaticamente.",
-    "info_no_sudo": "L'utente viene creato senza diritti di amministrazione (nessun sudo/wheel). Per concedere privilegi elevati, intervenire manualmente sul server."
+    "info_no_sudo": "L'utente viene creato senza diritti di amministrazione (nessun sudo/wheel). Per concedere privilegi elevati, intervenire manualmente sul server.",
+    "lock_title": "Bloccare / Sbloccare account Unix",
+    "lock_info": "Blocca un account Unix per impedire tutte le connessioni SSH (anche con chiave valida). Sbloccare per ripristinare l'accesso."
   },
   "access_form": {
     "duration_label": "Durata accesso",
@@ -280,5 +282,15 @@
     "unlimited": "Illimitato",
     "errorMissingFields": "Tutti i campi sono obbligatori",
     "newDeploy": "Nuovo deploy"
+  },
+  "userLock": {
+    "unixUser": "Utente Unix",
+    "unixUserPlaceholder": "es: alice",
+    "server": "Server di destinazione",
+    "btnLock": "Bloccare",
+    "btnUnlock": "Sbloccare",
+    "error_unix_user": "Nome utente Unix non valido (solo minuscole, cifre, _ e -, max 32 caratteri)",
+    "success_locked": "Account '{user}' bloccato su {server}",
+    "success_unlocked": "Account '{user}' sbloccato su {server}"
   }
 }

--- a/ui/src/views/AccessRequests.vue
+++ b/ui/src/views/AccessRequests.vue
@@ -6,11 +6,18 @@
       <p>{{ $t('access.info_no_sudo') }}</p>
     </div>
     <DeployKeyForm />
+
+    <section class="card">
+      <h2>{{ $t('access.lock_title') }}</h2>
+      <p class="info-text">{{ $t('access.lock_info') }}</p>
+      <UserLockForm />
+    </section>
   </div>
 </template>
 
 <script setup>
 import DeployKeyForm from '../components/DeployKeyForm.vue'
+import UserLockForm from '../components/UserLockForm.vue'
 </script>
 
 <style scoped>
@@ -35,5 +42,23 @@ h1 {
 }
 .info-box p:last-child {
   margin-bottom: 0;
+}
+
+.card {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  padding: 1.5rem;
+  margin-top: 2rem;
+}
+.card h2 {
+  font-size: 1.2rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+.info-text {
+  color: #555;
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/ui/tests/UserLockForm.spec.js
+++ b/ui/tests/UserLockForm.spec.js
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
+import UserLockForm from '../src/components/UserLockForm.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+const MOCK_SERVERS = [
+  { hostname: 'prod-01', ip_address: '10.0.0.1', is_active: true },
+  { hostname: 'staging-01', ip_address: '10.0.0.2', is_active: true },
+  { hostname: 'disabled-01', ip_address: '10.0.0.3', is_active: false },
+]
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SERVERS),
+    })
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('UserLockForm', () => {
+  it('se monte sans erreur', async () => {
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    expect(w.find('[data-testid="input-unix-user"]').exists()).toBe(true)
+    expect(w.find('[data-testid="select-server"]').exists()).toBe(true)
+    expect(w.find('[data-testid="btn-lock"]').exists()).toBe(true)
+    expect(w.find('[data-testid="btn-unlock"]').exists()).toBe(true)
+  })
+
+  it('charge les serveurs depuis /api/servers', async () => {
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    const options = w.findAll('[data-testid="select-server"] option')
+    expect(options.length).toBe(3) // 1 placeholder + 2 actifs
+    expect(options[1].text()).toBe('prod-01')
+    expect(options[2].text()).toBe('staging-01')
+  })
+
+  it('les boutons Lock et Unlock sont désactivés si le formulaire est vide', async () => {
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    expect(w.find('[data-testid="btn-lock"]').attributes('disabled')).toBeDefined()
+    expect(w.find('[data-testid="btn-unlock"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('affiche une erreur de validation pour un username invalide avec espace', async () => {
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice bob')
+    expect(w.find('[data-testid="error-unix-user"]').exists()).toBe(true)
+  })
+
+  it('active les boutons avec un username valide + serveur sélectionné', async () => {
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    expect(w.find('[data-testid="btn-lock"]').attributes('disabled')).toBeUndefined()
+    expect(w.find('[data-testid="btn-unlock"]').attributes('disabled')).toBeUndefined()
+  })
+
+  it('clic sur Lock envoie POST /api/access/lock-user avec le bon payload', async () => {
+    let capturedUrl = null
+    let capturedPayload = null
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url.includes('/api/servers')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/access/lock-user') {
+        capturedUrl = url
+        capturedPayload = JSON.parse(opts.body)
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              status: 'locked',
+            }),
+        })
+      }
+    })
+
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    await w.find('[data-testid="btn-lock"]').trigger('click')
+    await flushPromises()
+
+    expect(capturedUrl).toBe('/api/access/lock-user')
+    expect(capturedPayload).toEqual({
+      unix_user: 'alice',
+      hostname: 'prod-01',
+    })
+  })
+
+  it('clic sur Unlock envoie POST /api/access/unlock-user avec le bon payload', async () => {
+    let capturedUrl = null
+    let capturedPayload = null
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url.includes('/api/servers')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/access/unlock-user') {
+        capturedUrl = url
+        capturedPayload = JSON.parse(opts.body)
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              status: 'unlocked',
+            }),
+        })
+      }
+    })
+
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    await w.find('[data-testid="btn-unlock"]').trigger('click')
+    await flushPromises()
+
+    expect(capturedUrl).toBe('/api/access/unlock-user')
+    expect(capturedPayload).toEqual({
+      unix_user: 'alice',
+      hostname: 'prod-01',
+    })
+  })
+
+  it('succès Lock affiche le message de succès', async () => {
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url.includes('/api/servers')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/access/lock-user') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              status: 'locked',
+            }),
+        })
+      }
+    })
+
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    await w.find('[data-testid="btn-lock"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="success-msg"]').exists()).toBe(true)
+    expect(w.find('[data-testid="success-msg"]').text()).toContain('alice')
+    expect(w.find('[data-testid="success-msg"]').text()).toContain('prod-01')
+  })
+
+  it('succès Unlock affiche le message de succès', async () => {
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url.includes('/api/servers')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/access/unlock-user') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              status: 'unlocked',
+            }),
+        })
+      }
+    })
+
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    await w.find('[data-testid="btn-unlock"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="success-msg"]').exists()).toBe(true)
+    expect(w.find('[data-testid="success-msg"]').text()).toContain('alice')
+    expect(w.find('[data-testid="success-msg"]').text()).toContain('prod-01')
+  })
+
+  it('erreur API affiche le message d\'erreur', async () => {
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url.includes('/api/servers')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/access/lock-user') {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          json: () => Promise.resolve({ error: 'User not found' }),
+        })
+      }
+    })
+
+    const w = mount(UserLockForm, { global: { plugins: [i18n] } })
+    await flushPromises()
+    await w.find('[data-testid="input-unix-user"]').setValue('alice')
+    await w.find('[data-testid="select-server"]').setValue('prod-01')
+    await w.find('[data-testid="btn-lock"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="error-msg"]').exists()).toBe(true)
+    expect(w.find('[data-testid="error-msg"]').text()).toBe('User not found')
+  })
+})


### PR DESCRIPTION
## Summary

- Nouveaux scripts SAM déployés sur les hôtes distants : `sam-lock-user` (`usermod -L -s /sbin/nologin`) et `sam-unlock-user` (`usermod -U -s /bin/bash`) — bloque toute connexion SSH même avec une clé valide
- Backend : `lock_user()` / `unlock_user()` dans `actions.py`, 2 nouvelles routes Flask (`POST /api/access/lock-user`, `/unlock-user`), 2 nouvelles commandes CLI (`access lock-user`, `access unlock-user`)
- Migration SQL `004_user_lock_unlock.sql` : étend le CHECK de `audit_log.action` avec `USER_LOCKED` et `USER_UNLOCKED`
- Frontend : `UserLockForm.vue` (validation POSIX username, boutons Bloquer/Débloquer), intégré dans `AccessRequests.vue`, i18n 5 langues
- `provision-host.sh` mis à jour avec 4 nouvelles règles sudoers
- 242 pytest (dont 16 nouveaux) + 99 vitest (dont 10 nouveaux)

## Test plan

- [ ] `pytest app/tests/ -q` → 242 passed
- [ ] `cd ui && npm run test -- --run` → 99 passed
- [ ] `npm run format:check` → aucune erreur Prettier
- [ ] Rebuild container + déployer sur hôte de test
- [ ] Vérifier que `access lock-user --user alice --server prod` empêche la connexion SSH
- [ ] Vérifier que `access unlock-user --user alice --server prod` restaure l'accès
- [ ] Vérifier les entrées `USER_LOCKED` / `USER_UNLOCKED` dans la page Audit

Closes #181