### PR TITLE
feat: barre de filtres sur le tableau SSH Keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -875,6 +875,7 @@ ui/src/components/
                           + ligne grisée + badge rouge si désactivé (issue #91)
     KeyTable.vue        ← tableau clés avec actions + tooltip non-conformité (issue #99)
                           + bouton Illimité (remove-expiry) (issue #93)
+                          + barre de filtres texte + dropdown statut (issue #189)
     KeyActions.vue      ← boutons valider/révoquer/expiry
     ExpiryPicker.vue    ← datepicker durée ou date précise
     DeployKeyForm.vue   ← formulaire déploiement clé SSH (utilisé par AccessRequests.vue)

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -1,93 +1,138 @@
 <template>
-  <table>
-    <thead>
-      <tr>
-        <th>{{ $t('key_table.col_status') }}</th>
-        <th>{{ $t('key_table.col_type') }}</th>
-        <th>{{ $t('key_table.col_fingerprint') }}</th>
-        <th>{{ $t('key_table.col_unix_user') }}</th>
-        <th>{{ $t('key_table.col_comment') }}</th>
-        <th>{{ $t('key_table.col_owner') }}</th>
-        <th>{{ $t('key_table.col_expires') }}</th>
-        <th>{{ $t('key_table.col_compliant') }}</th>
-        <th>{{ $t('key_table.col_actions') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-if="keys.length === 0">
-        <td colspan="9" class="empty">{{ $t('key_table.empty') }}</td>
-      </tr>
-      <tr v-for="k in keys" :key="k.fingerprint + '|' + (k.unix_user || '')">
-        <td>
-          <span class="badge" :class="statusBadge(k.status)">{{ k.status }}</span>
-        </td>
-        <td>
-          <code>{{ k.key_type }}</code>
-        </td>
-        <td class="fp">
-          <code>{{ k.fingerprint }}</code>
-        </td>
-        <td>
-          <code v-if="k.unix_user">{{ k.unix_user }}</code>
-          <span v-else>—</span>
-        </td>
-        <td>{{ k.comment || '—' }}</td>
-        <td>{{ k.owner || '—' }}</td>
-        <td>{{ formatDate(k.expires_at) }}</td>
-        <td>
-          <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
-          <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
-        </td>
-        <td>
-          <div class="actions">
-            <button
-              v-if="k.status === 'PENDING_REVIEW'"
-              class="btn-success"
-              @click="$emit('validate', k.fingerprint)"
-            >
-              {{ $t('key_table.btn_validate') }}
-            </button>
-            <button
-              v-if="k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW'"
-              class="btn-danger"
-              @click="$emit('revoke', k)"
-            >
-              {{ $t('key_table.btn_revoke') }}
-            </button>
-            <button
-              v-if="!k.owner && k.status === 'ACTIVE'"
-              class="btn-primary"
-              @click="$emit('assign', k.fingerprint)"
-            >
-              {{ $t('key_table.btn_assign') }}
-            </button>
-            <button
-              v-if="k.status === 'ACTIVE'"
-              class="btn-warning"
-              @click="$emit('set-expiry', k)"
-            >
-              {{ $t('key_table.btn_expiry') }}
-            </button>
-            <button
-              v-if="k.status === 'ACTIVE' && k.expires_at"
-              class="btn-unlimited"
-              @click="$emit('remove-expiry', k.fingerprint)"
-            >
-              {{ $t('key_table.btn_unlimited') }}
-            </button>
-          </div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="keytable-wrapper">
+    <div v-if="keys.length > 0" class="filters" data-testid="keytable-filters">
+      <input
+        v-model="filterText"
+        type="text"
+        :placeholder="$t('key_table.filter_placeholder')"
+        class="filter-input"
+        data-testid="keytable-filter-text"
+      />
+      <select v-model="filterStatus" class="filter-select" data-testid="keytable-filter-status">
+        <option value="">{{ $t('key_table.filter_all_statuses') }}</option>
+        <option value="ACTIVE">ACTIVE</option>
+        <option value="PENDING_REVIEW">PENDING_REVIEW</option>
+        <option value="REVOKED">REVOKED</option>
+        <option value="EXPIRED">EXPIRED</option>
+        <option value="UNAUTHORIZED">UNAUTHORIZED</option>
+      </select>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>{{ $t('key_table.col_status') }}</th>
+          <th>{{ $t('key_table.col_type') }}</th>
+          <th>{{ $t('key_table.col_fingerprint') }}</th>
+          <th>{{ $t('key_table.col_unix_user') }}</th>
+          <th>{{ $t('key_table.col_comment') }}</th>
+          <th>{{ $t('key_table.col_owner') }}</th>
+          <th>{{ $t('key_table.col_expires') }}</th>
+          <th>{{ $t('key_table.col_compliant') }}</th>
+          <th>{{ $t('key_table.col_actions') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-if="keys.length === 0">
+          <td colspan="9" class="empty" data-testid="keytable-empty">
+            {{ $t('key_table.empty') }}
+          </td>
+        </tr>
+        <tr v-else-if="filteredKeys.length === 0">
+          <td colspan="9" class="empty" data-testid="keytable-no-results">
+            {{ $t('key_table.no_results') }}
+          </td>
+        </tr>
+        <tr v-for="k in filteredKeys" :key="k.fingerprint + '|' + (k.unix_user || '')">
+          <td>
+            <span class="badge" :class="statusBadge(k.status)">{{ k.status }}</span>
+          </td>
+          <td>
+            <code>{{ k.key_type }}</code>
+          </td>
+          <td class="fp">
+            <code>{{ k.fingerprint }}</code>
+          </td>
+          <td>
+            <code v-if="k.unix_user">{{ k.unix_user }}</code>
+            <span v-else>—</span>
+          </td>
+          <td>{{ k.comment || '—' }}</td>
+          <td>{{ k.owner || '—' }}</td>
+          <td>{{ formatDate(k.expires_at) }}</td>
+          <td>
+            <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
+            <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
+          </td>
+          <td>
+            <div class="actions">
+              <button
+                v-if="k.status === 'PENDING_REVIEW'"
+                class="btn-success"
+                @click="$emit('validate', k.fingerprint)"
+              >
+                {{ $t('key_table.btn_validate') }}
+              </button>
+              <button
+                v-if="k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW'"
+                class="btn-danger"
+                @click="$emit('revoke', k)"
+              >
+                {{ $t('key_table.btn_revoke') }}
+              </button>
+              <button
+                v-if="!k.owner && k.status === 'ACTIVE'"
+                class="btn-primary"
+                @click="$emit('assign', k.fingerprint)"
+              >
+                {{ $t('key_table.btn_assign') }}
+              </button>
+              <button
+                v-if="k.status === 'ACTIVE'"
+                class="btn-warning"
+                @click="$emit('set-expiry', k)"
+              >
+                {{ $t('key_table.btn_expiry') }}
+              </button>
+              <button
+                v-if="k.status === 'ACTIVE' && k.expires_at"
+                class="btn-unlimited"
+                @click="$emit('remove-expiry', k.fingerprint)"
+              >
+                {{ $t('key_table.btn_unlimited') }}
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </template>
 
 <script setup>
+import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 
-defineProps({ keys: { type: Array, default: () => [] } })
+const props = defineProps({ keys: { type: Array, default: () => [] } })
 defineEmits(['validate', 'revoke', 'set-expiry', 'remove-expiry', 'assign'])
+
+const filterText = ref('')
+const filterStatus = ref('')
+
+const filteredKeys = computed(() => {
+  const text = filterText.value.trim().toLowerCase()
+  return props.keys.filter((k) => {
+    if (filterStatus.value && k.status !== filterStatus.value) return false
+    if (!text) return true
+    return (
+      k.fingerprint.toLowerCase().includes(text) ||
+      (k.unix_user || '').toLowerCase().includes(text) ||
+      (k.comment || '').toLowerCase().includes(text) ||
+      (k.owner || '').toLowerCase().includes(text)
+    )
+  })
+})
 
 function complianceTooltip(k) {
   if (k.key_type === 'ssh-rsa') {
@@ -116,6 +161,35 @@ function formatDate(iso) {
 </script>
 
 <style scoped>
+.keytable-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.filter-input {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  flex: 1;
+  min-width: 200px;
+}
+
+.filter-select {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  min-width: 160px;
+}
+
 .fp {
   font-size: 0.75rem;
   max-width: 260px;

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -134,7 +134,10 @@
     "btn_revoke": "Widerrufen",
     "btn_assign": "Zuweisen",
     "btn_expiry": "Ablauf",
-    "btn_unlimited": "Unbegrenzt"
+    "btn_unlimited": "Unbegrenzt",
+    "filter_placeholder": "Fingerprint, Benutzer, Owner suchen…",
+    "filter_all_statuses": "Alle Status",
+    "no_results": "Keine passenden Schlüssel."
   },
   "access": {
     "title": "Temporärer Zugriff",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -134,7 +134,10 @@
     "btn_revoke": "Revoke",
     "btn_assign": "Assign",
     "btn_expiry": "Expiry",
-    "btn_unlimited": "Unlimited"
+    "btn_unlimited": "Unlimited",
+    "filter_placeholder": "Search fingerprint, user, owner…",
+    "filter_all_statuses": "All statuses",
+    "no_results": "No matching keys."
   },
   "access": {
     "title": "Temporary Access",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -134,7 +134,10 @@
     "btn_revoke": "Revocar",
     "btn_assign": "Asignar",
     "btn_expiry": "Expiración",
-    "btn_unlimited": "Ilimitado"
+    "btn_unlimited": "Ilimitado",
+    "filter_placeholder": "Buscar fingerprint, usuario, owner…",
+    "filter_all_statuses": "Todos los estados",
+    "no_results": "No se encontraron claves."
   },
   "access": {
     "title": "Acceso temporal",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -134,7 +134,10 @@
     "btn_revoke": "Révoquer",
     "btn_assign": "Assigner",
     "btn_expiry": "Expiration",
-    "btn_unlimited": "Illimité"
+    "btn_unlimited": "Illimité",
+    "filter_placeholder": "Rechercher fingerprint, utilisateur, owner…",
+    "filter_all_statuses": "Tous les statuts",
+    "no_results": "Aucune clé correspondante."
   },
   "access": {
     "title": "Accès temporaires",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -134,7 +134,10 @@
     "btn_revoke": "Revoca",
     "btn_assign": "Assegna",
     "btn_expiry": "Scadenza",
-    "btn_unlimited": "Illimitato"
+    "btn_unlimited": "Illimitato",
+    "filter_placeholder": "Cerca fingerprint, utente, owner…",
+    "filter_all_statuses": "Tutti gli stati",
+    "no_results": "Nessuna chiave corrispondente."
   },
   "access": {
     "title": "Accesso temporaneo",

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -15,6 +15,7 @@ function makeKey(overrides = {}) {
     key_size_bits: null,
     comment: 'user@host',
     owner: null,
+    unix_user: null,
     expires_at: null,
     status: 'ACTIVE',
     is_compliant: true,
@@ -33,13 +34,13 @@ describe('KeyTable', () => {
   it('affiche une ligne par clé', () => {
     const keys = [makeKey(), makeKey({ fingerprint: 'SHA256:other', status: 'REVOKED' })]
     const w = mountTable(keys)
-    const rows = w.findAll('tbody tr').filter(r => !r.classes('empty'))
+    const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
     expect(rows.length).toBe(2)
   })
 
   it('affiche le message vide quand aucune clé', () => {
     const w = mountTable([])
-    expect(w.find('.empty').exists()).toBe(true)
+    expect(w.find('[data-testid="keytable-empty"]').exists()).toBe(true)
   })
 
   it('PENDING_REVIEW affiche le bouton Valider (btn-success)', () => {
@@ -47,7 +48,7 @@ describe('KeyTable', () => {
     expect(w.find('.btn-success').exists()).toBe(true)
   })
 
-  it('ACTIVE n\'affiche pas le bouton Valider', () => {
+  it("ACTIVE n'affiche pas le bouton Valider", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     expect(w.find('.btn-success').exists()).toBe(false)
   })
@@ -62,7 +63,7 @@ describe('KeyTable', () => {
     expect(w.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('REVOKED n\'affiche pas le bouton Révoquer', () => {
+  it("REVOKED n'affiche pas le bouton Révoquer", () => {
     const w = mountTable([makeKey({ status: 'REVOKED' })])
     expect(w.find('.btn-danger').exists()).toBe(false)
   })
@@ -72,7 +73,7 @@ describe('KeyTable', () => {
     expect(w.find('.btn-warning').exists()).toBe(true)
   })
 
-  it('PENDING_REVIEW n\'affiche pas le bouton Expiration', () => {
+  it("PENDING_REVIEW n'affiche pas le bouton Expiration", () => {
     const w = mountTable([makeKey({ status: 'PENDING_REVIEW' })])
     expect(w.find('.btn-warning').exists()).toBe(false)
   })
@@ -82,7 +83,7 @@ describe('KeyTable', () => {
     expect(w.find('.btn-unlimited').exists()).toBe(true)
   })
 
-  it('ACTIVE sans expires_at n\'affiche pas le bouton Illimité', () => {
+  it("ACTIVE sans expires_at n'affiche pas le bouton Illimité", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', expires_at: null })])
     expect(w.find('.btn-unlimited').exists()).toBe(false)
   })
@@ -92,7 +93,7 @@ describe('KeyTable', () => {
     expect(w.find('.btn-primary').exists()).toBe(true)
   })
 
-  it('ACTIVE avec owner n\'affiche pas le bouton Assigner', () => {
+  it("ACTIVE avec owner n'affiche pas le bouton Assigner", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', owner: 'alice' })])
     expect(w.find('.btn-primary').exists()).toBe(false)
   })
@@ -125,7 +126,7 @@ describe('KeyTable', () => {
     expect(w.emitted('validate')[0][0]).toBe(FP)
   })
 
-  it('émet revoke avec l\'objet clé', async () => {
+  it("émet revoke avec l'objet clé", async () => {
     const key = makeKey({ status: 'ACTIVE' })
     const w = mountTable([key])
     await w.find('.btn-danger').trigger('click')
@@ -133,7 +134,7 @@ describe('KeyTable', () => {
     expect(w.emitted('revoke')[0][0].fingerprint).toBe(FP)
   })
 
-  it('émet set-expiry avec l\'objet clé', async () => {
+  it("émet set-expiry avec l'objet clé", async () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     await w.find('.btn-warning').trigger('click')
     expect(w.emitted('set-expiry')).toBeTruthy()
@@ -151,5 +152,82 @@ describe('KeyTable', () => {
     await w.find('.btn-primary').trigger('click')
     expect(w.emitted('assign')).toBeTruthy()
     expect(w.emitted('assign')[0][0]).toBe(FP)
+  })
+
+  // --- Filtres ---
+
+  it('affiche la barre de filtres quand il y a des clés', () => {
+    const w = mountTable([makeKey()])
+    expect(w.find('[data-testid="keytable-filters"]').exists()).toBe(true)
+  })
+
+  it("n'affiche pas la barre de filtres quand la liste est vide", () => {
+    const w = mountTable([])
+    expect(w.find('[data-testid="keytable-filters"]').exists()).toBe(false)
+  })
+
+  it('filtre par texte sur le fingerprint', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb' }),
+    ]
+    const w = mountTable(keys)
+    await w.find('[data-testid="keytable-filter-text"]').setValue('aaaaa')
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('SHA256:aaaaa')
+  })
+
+  it('filtre par texte sur unix_user', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa', unix_user: 'alice' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb', unix_user: 'bob' }),
+    ]
+    const w = mountTable(keys)
+    await w.find('[data-testid="keytable-filter-text"]').setValue('alice')
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows.length).toBe(1)
+  })
+
+  it('filtre par texte sur owner', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa', owner: 'alice@example.com' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb', owner: 'bob@example.com' }),
+    ]
+    const w = mountTable(keys)
+    await w.find('[data-testid="keytable-filter-text"]').setValue('alice')
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows.length).toBe(1)
+  })
+
+  it('filtre par statut', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa', status: 'ACTIVE' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb', status: 'REVOKED' }),
+    ]
+    const w = mountTable(keys)
+    await w.find('[data-testid="keytable-filter-status"]').setValue('ACTIVE')
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('SHA256:aaaaa')
+  })
+
+  it('affiche le message no_results quand le filtre ne correspond à rien', async () => {
+    const w = mountTable([makeKey()])
+    await w.find('[data-testid="keytable-filter-text"]').setValue('zzz_inexistant')
+    expect(w.find('[data-testid="keytable-no-results"]').exists()).toBe(true)
+  })
+
+  it('réinitialiser le filtre texte affiche toutes les clés', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb' }),
+    ]
+    const w = mountTable(keys)
+    const input = w.find('[data-testid="keytable-filter-text"]')
+    await input.setValue('aaaaa')
+    await input.setValue('')
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows.length).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary

- Filtre texte dans `KeyTable.vue` : recherche sur fingerprint, unix_user, comment, owner (case-insensitive)
- Dropdown statut : ALL / ACTIVE / PENDING_REVIEW / REVOKED / EXPIRED / UNAUTHORIZED
- Filtrage 100 % côté client — aucune requête supplémentaire
- Barre de filtres masquée quand la liste est vide
- Message "Aucune clé correspondante" si aucun résultat après filtrage
- 8 nouveaux tests Vitest (117 total, tous verts)
- Clés i18n dans les 5 langues (EN/FR/ES/IT/DE)

## Test plan

- [ ] Taper dans le champ texte filtre le tableau en temps réel
- [ ] Sélectionner un statut dans le dropdown filtre correctement
- [ ] Combiner les deux filtres fonctionne
- [ ] Message "no results" visible quand filtre ne correspond à rien
- [ ] Barre de filtres absente quand liste vide

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)