### PR TITLE
feat: barre de recherche sur la vue Anomalies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -665,6 +665,7 @@ ui/tests/
     Settings.spec.js      ← chargement, sauvegarde, validation, erreurs (7 tests)
     DeployKeyForm.spec.js ← formulaire déploiement clé SSH (16 tests)
     UserLockForm.spec.js  ← verrouillage/déverrouillage compte Unix (10 tests)
+    Anomalies.spec.js     ← filtres recherche, badges compteurs, no_results (13 tests)
 
 ### Ce qui n'est PAS testé unitairement
 
@@ -860,7 +861,7 @@ ui/src/views/
     ServerDetail.vue    ← détail serveur + clés + actions
                           + boutons désactiver/réactiver/supprimer (issue #89)
                           + bandeau rouge si serveur désactivé (issue #91)
-    Anomalies.vue       ← toutes anomalies actives
+    Anomalies.vue       ← toutes anomalies actives + barre de recherche (issue #191)
     AccessRequests.vue  ← déploiement de clé SSH (DeployKeyForm) + verrouillage compte Unix (UserLockForm)
     Audit.vue           ← historique filtrable
     Admins.vue          ← gestion administrateurs

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -250,7 +250,9 @@
     "btn_revoke_confirm": "Widerrufen",
     "load_error": "Schlüssel können nicht geladen werden: {error}",
     "key_validated": "Schlüssel validiert.",
-    "key_revoked": "Schlüssel widerrufen."
+    "key_revoked": "Schlüssel widerrufen.",
+    "filter_placeholder": "Fingerprint, Typ, Server suchen…",
+    "no_results": "Keine passenden Anomalien."
   },
   "settings": {
     "title": "Einstellungen",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -250,7 +250,9 @@
     "btn_revoke_confirm": "Revoke",
     "load_error": "Unable to load keys: {error}",
     "key_validated": "Key validated.",
-    "key_revoked": "Key revoked."
+    "key_revoked": "Key revoked.",
+    "filter_placeholder": "Search fingerprint, type, server…",
+    "no_results": "No matching anomalies."
   },
   "settings": {
     "title": "Settings",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -250,7 +250,9 @@
     "btn_revoke_confirm": "Revocar",
     "load_error": "No se pueden cargar las claves: {error}",
     "key_validated": "Clave validada.",
-    "key_revoked": "Clave revocada."
+    "key_revoked": "Clave revocada.",
+    "filter_placeholder": "Buscar fingerprint, tipo, servidor…",
+    "no_results": "No se encontraron anomalías."
   },
   "settings": {
     "title": "Ajustes",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -250,7 +250,9 @@
     "btn_revoke_confirm": "Révoquer",
     "load_error": "Impossible de charger les clés : {error}",
     "key_validated": "Clé validée.",
-    "key_revoked": "Clé révoquée."
+    "key_revoked": "Clé révoquée.",
+    "filter_placeholder": "Rechercher fingerprint, type, serveur…",
+    "no_results": "Aucune anomalie correspondante."
   },
   "settings": {
     "title": "Paramètres",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -250,7 +250,9 @@
     "btn_revoke_confirm": "Revoca",
     "load_error": "Impossibile caricare le chiavi: {error}",
     "key_validated": "Chiave validata.",
-    "key_revoked": "Chiave revocata."
+    "key_revoked": "Chiave revocata.",
+    "filter_placeholder": "Cerca fingerprint, tipo, server…",
+    "no_results": "Nessuna anomalia corrispondente."
   },
   "settings": {
     "title": "Impostazioni",

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -8,15 +8,25 @@
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
 
     <template v-else>
+      <div v-if="allKeys.length > 0" class="filters" data-testid="anomalies-filters">
+        <input
+          v-model="filterText"
+          type="text"
+          :placeholder="$t('anomalies.filter_placeholder')"
+          class="filter-input"
+          data-testid="anomalies-filter-text"
+        />
+      </div>
+
       <!-- PENDING_REVIEW keys -->
       <section class="card">
         <h2>
           {{ $t('anomalies.section_pending') }}
-          <span class="count-badge" :class="pending.length ? 'count-warn' : 'count-ok'">
-            {{ pending.length }}
+          <span class="count-badge" :class="pendingAll.length ? 'count-warn' : 'count-ok'">
+            {{ pendingAll.length }}
           </span>
         </h2>
-        <table v-if="pending.length">
+        <table v-if="pendingFiltered.length">
           <thead>
             <tr>
               <th>{{ $t('anomalies.col_fingerprint') }}</th>
@@ -28,7 +38,11 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="k in pending" :key="k.fingerprint + k.server_hostname">
+            <tr
+              v-for="k in pendingFiltered"
+              :key="k.fingerprint + k.server_hostname"
+              :data-testid="`pending-row-${k.fingerprint}`"
+            >
               <td class="fp">
                 <code>{{ k.fingerprint }}</code>
               </td>
@@ -56,19 +70,24 @@
             </tr>
           </tbody>
         </table>
-        <p v-else class="empty">{{ $t('anomalies.no_pending') }}</p>
+        <p v-else-if="pendingAll.length === 0" class="empty" data-testid="pending-empty">
+          {{ $t('anomalies.no_pending') }}
+        </p>
+        <p v-else class="empty" data-testid="pending-no-results">
+          {{ $t('anomalies.no_results') }}
+        </p>
       </section>
 
       <!-- Out-of-system revocations (last 30 days) -->
       <section class="card">
         <h2>
           {{ $t('anomalies.section_revoked') }}
-          <span class="count-badge" :class="outOfSystem.length ? 'count-danger' : 'count-ok'">
-            {{ outOfSystem.length }}
+          <span class="count-badge" :class="outOfSystemAll.length ? 'count-danger' : 'count-ok'">
+            {{ outOfSystemAll.length }}
           </span>
           <span class="subtitle">{{ $t('anomalies.subtitle_revoked') }}</span>
         </h2>
-        <table v-if="outOfSystem.length">
+        <table v-if="outOfSystemFiltered.length">
           <thead>
             <tr>
               <th>{{ $t('anomalies.col_fingerprint') }}</th>
@@ -79,7 +98,11 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="k in outOfSystem" :key="k.fingerprint + k.server_hostname">
+            <tr
+              v-for="k in outOfSystemFiltered"
+              :key="k.fingerprint + k.server_hostname"
+              :data-testid="`revoked-row-${k.fingerprint}`"
+            >
               <td class="fp">
                 <code>{{ k.fingerprint }}</code>
               </td>
@@ -96,7 +119,12 @@
             </tr>
           </tbody>
         </table>
-        <p v-else class="empty">{{ $t('anomalies.no_revoked') }}</p>
+        <p v-else-if="outOfSystemAll.length === 0" class="empty" data-testid="revoked-empty">
+          {{ $t('anomalies.no_revoked') }}
+        </p>
+        <p v-else class="empty" data-testid="revoked-no-results">
+          {{ $t('anomalies.no_results') }}
+        </p>
       </section>
     </template>
 
@@ -140,10 +168,22 @@ const error = ref('')
 const message = ref('')
 const revokeTarget = ref(null)
 const revokeReason = ref('')
+const filterText = ref('')
 
-const pending = computed(() => allKeys.value.filter((k) => k.status === 'PENDING_REVIEW'))
+function matchesFilter(k) {
+  const text = filterText.value.trim().toLowerCase()
+  if (!text) return true
+  return (
+    k.fingerprint.toLowerCase().includes(text) ||
+    k.key_type.toLowerCase().includes(text) ||
+    (k.server_hostname || '').toLowerCase().includes(text)
+  )
+}
 
-const outOfSystem = computed(() => {
+const pendingAll = computed(() => allKeys.value.filter((k) => k.status === 'PENDING_REVIEW'))
+const pendingFiltered = computed(() => pendingAll.value.filter(matchesFilter))
+
+const outOfSystemAll = computed(() => {
   const cutoff = new Date()
   cutoff.setDate(cutoff.getDate() - 30)
   return allKeys.value.filter(
@@ -154,6 +194,7 @@ const outOfSystem = computed(() => {
       new Date(k.revoked_at) >= cutoff
   )
 })
+const outOfSystemFiltered = computed(() => outOfSystemAll.value.filter(matchesFilter))
 
 async function load() {
   loading.value = true
@@ -240,6 +281,21 @@ h2 {
 }
 .non-compliant {
   cursor: help;
+}
+
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.filter-input {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  flex: 1;
+  max-width: 400px;
 }
 
 .card {

--- a/ui/tests/Anomalies.spec.js
+++ b/ui/tests/Anomalies.spec.js
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import en from '../src/locales/en.json'
+import Anomalies from '../src/views/Anomalies.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div/>' } }] })
+
+function makePending(overrides = {}) {
+  return {
+    fingerprint: 'SHA256:aaaa',
+    key_type: 'ssh-ed25519',
+    server_hostname: 'srv-prod',
+    first_seen: '2026-01-01T00:00:00Z',
+    is_compliant: true,
+    status: 'PENDING_REVIEW',
+    revoked_at: null,
+    revoked_automatically: false,
+    revoked_by: null,
+    revocation_justification: null,
+    ...overrides,
+  }
+}
+
+function makeRevoked(overrides = {}) {
+  return {
+    fingerprint: 'SHA256:bbbb',
+    key_type: 'ssh-rsa',
+    server_hostname: 'srv-staging',
+    first_seen: '2026-01-01T00:00:00Z',
+    is_compliant: false,
+    status: 'REVOKED',
+    revoked_at: new Date().toISOString(),
+    revoked_automatically: true,
+    revoked_by: null,
+    revocation_justification: 'auto',
+    ...overrides,
+  }
+}
+
+async function mountView(keys) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => keys,
+  })
+  const w = mount(Anomalies, { global: { plugins: [i18n, router] } })
+  await flushPromises()
+  return w
+}
+
+describe('Anomalies', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('affiche une ligne dans la section pending', async () => {
+    const w = await mountView([makePending()])
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+  })
+
+  it('affiche une ligne dans la section revoked hors système', async () => {
+    const w = await mountView([makeRevoked()])
+    expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').exists()).toBe(true)
+  })
+
+  it('affiche le message vide pending quand aucune clé PENDING_REVIEW', async () => {
+    const w = await mountView([])
+    expect(w.find('[data-testid="pending-empty"]').exists()).toBe(true)
+  })
+
+  it('affiche le message vide revoked quand aucune révocation hors système', async () => {
+    const w = await mountView([])
+    expect(w.find('[data-testid="revoked-empty"]').exists()).toBe(true)
+  })
+
+  it('affiche la barre de filtres quand il y a des clés', async () => {
+    const w = await mountView([makePending()])
+    expect(w.find('[data-testid="anomalies-filters"]').exists()).toBe(true)
+  })
+
+  it("n'affiche pas la barre de filtres quand la liste est vide", async () => {
+    const w = await mountView([])
+    expect(w.find('[data-testid="anomalies-filters"]').exists()).toBe(false)
+  })
+
+  it('filtre la section pending par fingerprint', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-a' }),
+      makePending({ fingerprint: 'SHA256:zzzz', server_hostname: 'srv-b' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('aaaa')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:zzzz"]').exists()).toBe(false)
+  })
+
+  it('filtre la section pending par serveur', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-prod' }),
+      makePending({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-staging' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('prod')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
+  })
+
+  it('filtre la section revoked par fingerprint', async () => {
+    const keys = [
+      makeRevoked({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-a' }),
+      makeRevoked({ fingerprint: 'SHA256:cccc', server_hostname: 'srv-b' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('bbbb')
+    expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').exists()).toBe(true)
+    expect(w.find('[data-testid="revoked-row-SHA256:cccc"]').exists()).toBe(false)
+  })
+
+  it('affiche no_results dans pending quand filtre masque tout', async () => {
+    const w = await mountView([makePending()])
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('zzz_inexistant')
+    expect(w.find('[data-testid="pending-no-results"]').exists()).toBe(true)
+  })
+
+  it('affiche no_results dans revoked quand filtre masque tout', async () => {
+    const w = await mountView([makeRevoked()])
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('zzz_inexistant')
+    expect(w.find('[data-testid="revoked-no-results"]').exists()).toBe(true)
+  })
+
+  it('le badge de compteur affiche le total réel (pas le filtré)', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa' }),
+      makePending({ fingerprint: 'SHA256:bbbb' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('aaaa')
+    expect(w.find('.count-badge').text()).toBe('2')
+  })
+
+  it('vider le filtre réaffiche toutes les clés', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa' }),
+      makePending({ fingerprint: 'SHA256:bbbb' }),
+    ]
+    const w = await mountView(keys)
+    const input = w.find('[data-testid="anomalies-filter-text"]')
+    await input.setValue('aaaa')
+    await input.setValue('')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Filtre texte global dans `Anomalies.vue` : recherche sur fingerprint, type, serveur
- Appliqué aux deux sections (PENDING_REVIEW + révocations hors système)
- Badge compteur affiche le **total réel** (pas le compte filtré)
- Message "Aucune anomalie correspondante" si filtre masque tout
- Barre de filtres masquée quand aucune clé chargée
- Nouveau fichier `Anomalies.spec.js` — 13 tests (130 total, tous verts)
- Clés i18n dans les 5 langues

## Test plan

- [ ] Taper dans le champ filtre les deux sections en temps réel
- [ ] Badge de compteur reste au total réel pendant le filtrage
- [ ] Message "no results" visible par section quand filtre ne correspond à rien
- [ ] Barre absente si aucune clé

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)