### PR TITLE
fix: validation ciblée par unix_user — une seule autorisation validée

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -23,20 +23,43 @@ def _check_fingerprint(fp: str) -> None:
 # Cles SSH
 # ---------------------------------------------------------------------------
 
-def validate_key(fingerprint: str, admin_id: str) -> dict:
-    """PENDING_REVIEW → ACTIVE. Logs KEY_ADDED for each authorization."""
+def validate_key(
+    fingerprint: str,
+    admin_id: str,
+    unix_user: str = None,
+    hostname: str = None,
+) -> dict:
+    """PENDING_REVIEW → ACTIVE. Logs KEY_ADDED for each authorization.
+
+    Si unix_user ET hostname sont fournis : validation ciblée — une seule
+    autorisation (key_id, server_id, unix_user). Sinon : toutes les
+    autorisations PENDING_REVIEW du fingerprint (usage CLI).
+    """
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
 
-    rows = db.query(
-        """
-        SELECT key_id, server_id, unix_user FROM key_authorizations
-        WHERE key_id = %s AND status = 'PENDING_REVIEW'
-        """,
-        (key["id"],),
-    )
+    if unix_user is not None and hostname is not None:
+        server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+        if not server:
+            raise ValueError(f"Server not found: {hostname}")
+        rows = db.query(
+            """
+            SELECT key_id, server_id, unix_user FROM key_authorizations
+            WHERE key_id = %s AND server_id = %s AND unix_user = %s
+              AND status = 'PENDING_REVIEW'
+            """,
+            (key["id"], server["id"], unix_user),
+        )
+    else:
+        rows = db.query(
+            """
+            SELECT key_id, server_id, unix_user FROM key_authorizations
+            WHERE key_id = %s AND status = 'PENDING_REVIEW'
+            """,
+            (key["id"],),
+        )
     if not rows:
         raise ValueError(f"No PENDING_REVIEW authorization for key: {fingerprint}")
 

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -863,3 +863,31 @@ def test_actions_validate_key_includes_unix_user_in_update(sample_key):
         for call in update_calls:
             sql = call[0][0]
             assert "unix_user" in sql
+
+
+def test_actions_validate_key_scoped_only_validates_target_unix_user(sample_key):
+    """Avec unix_user+hostname, seule l'autorisation ciblée est validée."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},          # ssh_keys
+            {"id": SERVER_ID},        # servers
+        ]
+        mock_db.query.return_value = [
+            {"key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice"},
+        ]
+        actions.validate_key(sample_key["fingerprint"], ADMIN_ID, unix_user="alice", hostname="server-01")
+        # 1 UPDATE + 1 audit INSERT
+        assert mock_db.execute.call_count == 2
+        update_sql = mock_db.execute.call_args_list[0][0][0]
+        assert "UPDATE" in update_sql
+
+
+def test_actions_validate_key_scoped_raises_if_server_not_found(sample_key):
+    """Avec hostname inconnu, ValueError levée."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},  # ssh_keys found
+            None,            # server not found
+        ]
+        with pytest.raises(ValueError, match="Server not found"):
+            actions.validate_key(sample_key["fingerprint"], ADMIN_ID, unix_user="alice", hostname="unknown")

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -130,6 +130,38 @@ def test_web_get_keys_sql_includes_revocation_and_server_fields(auth_client):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/keys/validate/<fp> — 200 si authentifié, 401 sinon, scoped
+# ---------------------------------------------------------------------------
+
+def test_web_validate_key_returns_200_if_authenticated(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/validate/{FINGERPRINT}",
+            json={"unix_user": "alice", "hostname": "server-01"},
+        )
+        assert resp.status_code == 200
+        mock_actions.validate_key.assert_called_once_with(
+            FINGERPRINT, ADMIN_ID, unix_user="alice", hostname="server-01"
+        )
+
+
+def test_web_validate_key_returns_401_if_not_authenticated(client):
+    resp = client.post(f"/api/keys/validate/{FINGERPRINT}", json={})
+    assert resp.status_code == 401
+
+
+def test_web_validate_key_passes_none_when_fields_absent(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(f"/api/keys/validate/{FINGERPRINT}", json={})
+        assert resp.status_code == 200
+        mock_actions.validate_key.assert_called_once_with(
+            FINGERPRINT, ADMIN_ID, unix_user=None, hostname=None
+        )
+
+
+# ---------------------------------------------------------------------------
 # POST /api/keys/revoke/<fp> — fingerprint malformé rejeté avec 400
 # ---------------------------------------------------------------------------
 

--- a/app/web.py
+++ b/app/web.py
@@ -233,8 +233,11 @@ def get_key(fingerprint):
 @app.route("/api/keys/validate/<path:fingerprint>", methods=["POST"])
 @require_auth
 def validate_key(fingerprint):
+    data = request.get_json(silent=True) or {}
+    unix_user = data.get("unix_user") or None
+    hostname = data.get("hostname") or None
     try:
-        actions.validate_key(fingerprint, g.admin_id)
+        actions.validate_key(fingerprint, g.admin_id, unix_user=unix_user, hostname=hostname)
         return jsonify({"status": "validated"})
     except ValueError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -69,7 +69,7 @@
               <button
                 v-if="k.status === 'PENDING_REVIEW'"
                 class="btn-success"
-                @click="$emit('validate', k.fingerprint)"
+                @click="$emit('validate', k)"
               >
                 {{ $t('key_table.btn_validate') }}
               </button>

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -60,7 +60,7 @@
                 <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
               </td>
               <td class="actions">
-                <button class="btn-success" @click="validate(k.fingerprint)">
+                <button class="btn-success" @click="validate(k)">
                   {{ $t('anomalies.btn_validate') }}
                 </button>
                 <button class="btn-danger" @click="openRevoke(k)">
@@ -212,8 +212,12 @@ async function load() {
 
 const efp = (fp) => encodeURIComponent(fp)
 
-async function validate(fingerprint) {
-  await apiAction(`/api/keys/validate/${efp(fingerprint)}`, {}, t('anomalies.key_validated'))
+async function validate(key) {
+  await apiAction(
+    `/api/keys/validate/${efp(key.fingerprint)}`,
+    { unix_user: key.unix_user || null, hostname: key.server_hostname || null },
+    t('anomalies.key_validated')
+  )
 }
 
 function openRevoke(key) {

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -280,10 +280,10 @@ async function scanServer() {
 
 const efp = (fp) => encodeURIComponent(fp)
 
-async function validateKey(fingerprint) {
+async function validateKey(key) {
   await apiAction(
-    `/api/keys/validate/${efp(fingerprint)}`,
-    {},
+    `/api/keys/validate/${efp(key.fingerprint)}`,
+    { unix_user: key.unix_user || null, hostname },
     'POST',
     t('server_detail.key_validated')
   )

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -119,11 +119,12 @@ describe('KeyTable', () => {
     expect(w.find('.non-compliant').exists()).toBe(true)
   })
 
-  it('émet validate avec le fingerprint', async () => {
-    const w = mountTable([makeKey({ status: 'PENDING_REVIEW' })])
+  it("émet validate avec l'objet clé", async () => {
+    const key = makeKey({ status: 'PENDING_REVIEW' })
+    const w = mountTable([key])
     await w.find('.btn-success').trigger('click')
     expect(w.emitted('validate')).toBeTruthy()
-    expect(w.emitted('validate')[0][0]).toBe(FP)
+    expect(w.emitted('validate')[0][0].fingerprint).toBe(FP)
   })
 
   it("émet revoke avec l'objet clé", async () => {


### PR DESCRIPTION
## Bug

Valider une clé PENDING_REVIEW passait **toutes** les autorisations du même fingerprint en ACTIVE, même celles d'autres unix_users.

## Cause

`validate_key()` bouclait sur toutes les lignes `PENDING_REVIEW` pour un `key_id` sans filtrer par `unix_user`, malgré la PK `(key_id, server_id, unix_user)` ajoutée en #185.

## Fix

- `actions.py` : `validate_key(fingerprint, admin_id, unix_user=None, hostname=None)` — si `unix_user` + `hostname` fournis, ne valide que cette autorisation ; sinon comportement global (rétrocompat CLI)
- `web.py` : lit `unix_user` et `hostname` depuis le body JSON
- `KeyTable.vue` : émet le key object entier (comme `revoke`) au lieu du fingerprint seul
- `ServerDetail.vue` : passe `unix_user` + `hostname` à la requête validate
- `Anomalies.vue` : passe `unix_user` + `server_hostname` à la requête validate
- 5 nouveaux tests (264 pytest + 130 Vitest, tous verts)

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)