### PR TITLE
feat: anomalies unix_user column and filter dropdowns

### DIFF
--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -251,7 +251,13 @@
     "load_error": "Schlüssel können nicht geladen werden: {error}",
     "key_validated": "Schlüssel validiert.",
     "key_revoked": "Schlüssel widerrufen.",
-    "filter_placeholder": "Fingerprint, Typ, Server suchen…",
+    "col_unix_user": "Unix-Benutzer",
+    "filter_placeholder": "Fingerprint, Typ, Server, Benutzer suchen…",
+    "filter_all_types": "Alle Typen",
+    "filter_all_servers": "Alle Server",
+    "filter_all_compliant": "Konformität",
+    "filter_compliant": "Konform",
+    "filter_non_compliant": "Nicht konform",
     "no_results": "Keine passenden Anomalien."
   },
   "settings": {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -251,7 +251,13 @@
     "load_error": "Unable to load keys: {error}",
     "key_validated": "Key validated.",
     "key_revoked": "Key revoked.",
-    "filter_placeholder": "Search fingerprint, type, server…",
+    "col_unix_user": "Unix user",
+    "filter_placeholder": "Search fingerprint, type, server, user…",
+    "filter_all_types": "All types",
+    "filter_all_servers": "All servers",
+    "filter_all_compliant": "Compliance",
+    "filter_compliant": "Compliant",
+    "filter_non_compliant": "Non-compliant",
     "no_results": "No matching anomalies."
   },
   "settings": {

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -251,7 +251,13 @@
     "load_error": "No se pueden cargar las claves: {error}",
     "key_validated": "Clave validada.",
     "key_revoked": "Clave revocada.",
-    "filter_placeholder": "Buscar fingerprint, tipo, servidor…",
+    "col_unix_user": "Usuario Unix",
+    "filter_placeholder": "Buscar fingerprint, tipo, servidor, usuario…",
+    "filter_all_types": "Todos los tipos",
+    "filter_all_servers": "Todos los servidores",
+    "filter_all_compliant": "Conformidad",
+    "filter_compliant": "Conforme",
+    "filter_non_compliant": "No conforme",
     "no_results": "No se encontraron anomalías."
   },
   "settings": {

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -251,7 +251,13 @@
     "load_error": "Impossible de charger les clés : {error}",
     "key_validated": "Clé validée.",
     "key_revoked": "Clé révoquée.",
-    "filter_placeholder": "Rechercher fingerprint, type, serveur…",
+    "col_unix_user": "Utilisateur Unix",
+    "filter_placeholder": "Rechercher fingerprint, type, serveur, utilisateur…",
+    "filter_all_types": "Tous les types",
+    "filter_all_servers": "Tous les serveurs",
+    "filter_all_compliant": "Conformité",
+    "filter_compliant": "Conforme",
+    "filter_non_compliant": "Non conforme",
     "no_results": "Aucune anomalie correspondante."
   },
   "settings": {

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -251,7 +251,13 @@
     "load_error": "Impossibile caricare le chiavi: {error}",
     "key_validated": "Chiave validata.",
     "key_revoked": "Chiave revocata.",
-    "filter_placeholder": "Cerca fingerprint, tipo, server…",
+    "col_unix_user": "Utente Unix",
+    "filter_placeholder": "Cerca fingerprint, tipo, server, utente…",
+    "filter_all_types": "Tutti i tipi",
+    "filter_all_servers": "Tutti i server",
+    "filter_all_compliant": "Conformità",
+    "filter_compliant": "Conforme",
+    "filter_non_compliant": "Non conforme",
     "no_results": "Nessuna anomalia corrispondente."
   },
   "settings": {

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -416,6 +416,7 @@ code {
 
 .actions {
   display: flex;
+  align-items: center;
   gap: 0.4rem;
 }
 .empty {

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -81,13 +81,15 @@
                 <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
                 <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
               </td>
-              <td class="actions">
-                <button class="btn-success" @click="validate(k)">
-                  {{ $t('anomalies.btn_validate') }}
-                </button>
-                <button class="btn-danger" @click="openRevoke(k)">
-                  {{ $t('anomalies.btn_revoke') }}
-                </button>
+              <td>
+                <div class="actions">
+                  <button class="btn-success" @click="validate(k)">
+                    {{ $t('anomalies.btn_validate') }}
+                  </button>
+                  <button class="btn-danger" @click="openRevoke(k)">
+                    {{ $t('anomalies.btn_revoke') }}
+                  </button>
+                </div>
               </td>
             </tr>
           </tbody>

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -16,6 +16,23 @@
           class="filter-input"
           data-testid="anomalies-filter-text"
         />
+        <select v-model="filterType" class="filter-select" data-testid="anomalies-filter-type">
+          <option value="">{{ $t('anomalies.filter_all_types') }}</option>
+          <option v-for="t in uniqueTypes" :key="t" :value="t">{{ t }}</option>
+        </select>
+        <select v-model="filterServer" class="filter-select" data-testid="anomalies-filter-server">
+          <option value="">{{ $t('anomalies.filter_all_servers') }}</option>
+          <option v-for="s in uniqueServers" :key="s" :value="s">{{ s }}</option>
+        </select>
+        <select
+          v-model="filterCompliant"
+          class="filter-select"
+          data-testid="anomalies-filter-compliant"
+        >
+          <option value="">{{ $t('anomalies.filter_all_compliant') }}</option>
+          <option value="yes">{{ $t('anomalies.filter_compliant') }}</option>
+          <option value="no">{{ $t('anomalies.filter_non_compliant') }}</option>
+        </select>
       </div>
 
       <!-- PENDING_REVIEW keys -->
@@ -32,6 +49,7 @@
               <th>{{ $t('anomalies.col_fingerprint') }}</th>
               <th>{{ $t('anomalies.col_type') }}</th>
               <th>{{ $t('anomalies.col_server') }}</th>
+              <th>{{ $t('anomalies.col_unix_user') }}</th>
               <th>{{ $t('anomalies.col_first_seen') }}</th>
               <th>{{ $t('anomalies.col_compliant') }}</th>
               <th>{{ $t('anomalies.col_actions') }}</th>
@@ -53,6 +71,10 @@
                 <router-link :to="`/servers/${k.server_hostname}`" class="server-link">
                   {{ k.server_hostname }}
                 </router-link>
+              </td>
+              <td>
+                <code v-if="k.unix_user">{{ k.unix_user }}</code>
+                <span v-else>—</span>
               </td>
               <td>{{ formatDate(k.first_seen) }}</td>
               <td>
@@ -93,6 +115,7 @@
               <th>{{ $t('anomalies.col_fingerprint') }}</th>
               <th>{{ $t('anomalies.col_type') }}</th>
               <th>{{ $t('anomalies.col_server') }}</th>
+              <th>{{ $t('anomalies.col_unix_user') }}</th>
               <th>{{ $t('anomalies.col_revoked_at') }}</th>
               <th>{{ $t('anomalies.col_details') }}</th>
             </tr>
@@ -113,6 +136,10 @@
                 <router-link :to="`/servers/${k.server_hostname}`" class="server-link">
                   {{ k.server_hostname }}
                 </router-link>
+              </td>
+              <td>
+                <code v-if="k.unix_user">{{ k.unix_user }}</code>
+                <span v-else>—</span>
               </td>
               <td>{{ formatDate(k.revoked_at) }}</td>
               <td>{{ k.revocation_justification || '—' }}</td>
@@ -169,19 +196,11 @@ const message = ref('')
 const revokeTarget = ref(null)
 const revokeReason = ref('')
 const filterText = ref('')
-
-function matchesFilter(k) {
-  const text = filterText.value.trim().toLowerCase()
-  if (!text) return true
-  return (
-    k.fingerprint.toLowerCase().includes(text) ||
-    k.key_type.toLowerCase().includes(text) ||
-    (k.server_hostname || '').toLowerCase().includes(text)
-  )
-}
+const filterType = ref('')
+const filterServer = ref('')
+const filterCompliant = ref('')
 
 const pendingAll = computed(() => allKeys.value.filter((k) => k.status === 'PENDING_REVIEW'))
-const pendingFiltered = computed(() => pendingAll.value.filter(matchesFilter))
 
 const outOfSystemAll = computed(() => {
   const cutoff = new Date()
@@ -194,6 +213,35 @@ const outOfSystemAll = computed(() => {
       new Date(k.revoked_at) >= cutoff
   )
 })
+
+const uniqueTypes = computed(() => {
+  const all = [...pendingAll.value, ...outOfSystemAll.value]
+  return [...new Set(all.map((k) => k.key_type).filter(Boolean))].sort()
+})
+
+const uniqueServers = computed(() => {
+  const all = [...pendingAll.value, ...outOfSystemAll.value]
+  return [...new Set(all.map((k) => k.server_hostname).filter(Boolean))].sort()
+})
+
+function matchesFilter(k) {
+  const text = filterText.value.trim().toLowerCase()
+  if (text) {
+    const match =
+      k.fingerprint.toLowerCase().includes(text) ||
+      k.key_type.toLowerCase().includes(text) ||
+      (k.server_hostname || '').toLowerCase().includes(text) ||
+      (k.unix_user || '').toLowerCase().includes(text)
+    if (!match) return false
+  }
+  if (filterType.value && k.key_type !== filterType.value) return false
+  if (filterServer.value && k.server_hostname !== filterServer.value) return false
+  if (filterCompliant.value === 'yes' && !k.is_compliant) return false
+  if (filterCompliant.value === 'no' && k.is_compliant) return false
+  return true
+}
+
+const pendingFiltered = computed(() => pendingAll.value.filter(matchesFilter))
 const outOfSystemFiltered = computed(() => outOfSystemAll.value.filter(matchesFilter))
 
 async function load() {

--- a/ui/tests/Anomalies.spec.js
+++ b/ui/tests/Anomalies.spec.js
@@ -6,12 +6,16 @@ import en from '../src/locales/en.json'
 import Anomalies from '../src/views/Anomalies.vue'
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
-const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div/>' } }] })
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div/>' } }],
+})
 
 function makePending(overrides = {}) {
   return {
     fingerprint: 'SHA256:aaaa',
     key_type: 'ssh-ed25519',
+    unix_user: 'alice',
     server_hostname: 'srv-prod',
     first_seen: '2026-01-01T00:00:00Z',
     is_compliant: true,
@@ -28,6 +32,7 @@ function makeRevoked(overrides = {}) {
   return {
     fingerprint: 'SHA256:bbbb',
     key_type: 'ssh-rsa',
+    unix_user: 'bob',
     server_hostname: 'srv-staging',
     first_seen: '2026-01-01T00:00:00Z',
     is_compliant: false,
@@ -51,7 +56,9 @@ async function mountView(keys) {
 }
 
 describe('Anomalies', () => {
-  beforeEach(() => { vi.clearAllMocks() })
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
 
   it('affiche une ligne dans la section pending', async () => {
     const w = await mountView([makePending()])
@@ -105,6 +112,17 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
+  it('filtre la section pending par unix_user', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', unix_user: 'alice' }),
+      makePending({ fingerprint: 'SHA256:bbbb', unix_user: 'bob' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-text"]').setValue('alice')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
+  })
+
   it('filtre la section revoked par fingerprint', async () => {
     const keys = [
       makeRevoked({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-a' }),
@@ -114,6 +132,50 @@ describe('Anomalies', () => {
     await w.find('[data-testid="anomalies-filter-text"]').setValue('bbbb')
     expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').exists()).toBe(true)
     expect(w.find('[data-testid="revoked-row-SHA256:cccc"]').exists()).toBe(false)
+  })
+
+  it('filtre par dropdown type', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', key_type: 'ssh-ed25519' }),
+      makePending({ fingerprint: 'SHA256:bbbb', key_type: 'ssh-rsa' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-type"]').setValue('ssh-ed25519')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
+  })
+
+  it('filtre par dropdown serveur', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-prod' }),
+      makePending({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-staging' }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-server"]').setValue('srv-prod')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
+  })
+
+  it('filtre par dropdown compliant=yes', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', is_compliant: true }),
+      makePending({ fingerprint: 'SHA256:bbbb', is_compliant: false }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-compliant"]').setValue('yes')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
+  })
+
+  it('filtre par dropdown compliant=no', async () => {
+    const keys = [
+      makePending({ fingerprint: 'SHA256:aaaa', is_compliant: true }),
+      makePending({ fingerprint: 'SHA256:bbbb', is_compliant: false }),
+    ]
+    const w = await mountView(keys)
+    await w.find('[data-testid="anomalies-filter-compliant"]').setValue('no')
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(false)
+    expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(true)
   })
 
   it('affiche no_results dans pending quand filtre masque tout', async () => {
@@ -149,5 +211,15 @@ describe('Anomalies', () => {
     await input.setValue('')
     expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(true)
+  })
+
+  it('affiche unix_user dans la section pending', async () => {
+    const w = await mountView([makePending({ unix_user: 'charlie' })])
+    expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').text()).toContain('charlie')
+  })
+
+  it('affiche unix_user dans la section revoked', async () => {
+    const w = await mountView([makeRevoked({ unix_user: 'diana' })])
+    expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').text()).toContain('diana')
   })
 })


### PR DESCRIPTION
## Summary

- Adds **Unix user** column to both Pending and Out-of-system revocations tables in Anomalies view
- Extends text search to include unix_user field
- Adds 3 new dropdowns in the filter bar: key type, server, compliant/non-compliant
- i18n keys updated in all 5 locales (EN/FR/ES/IT/DE)
- 7 new vitest tests covering dropdowns and unix_user display

Closes #195

## Test plan

- [x] `npm run format:check` — green
- [x] `vitest run` — 137 tests pass
- [x] `pytest` — 264 tests pass