### PR TITLE
docs: sync CLAUDE.md, DESIGN.md and README with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,7 +520,9 @@ Validation robustesse mot de passe (issue #62) :
 ## Logique métier — actions.py (fonctions complètes)
 
 ### Clés SSH
-- validate_key(fingerprint, admin_id, db)
+- validate_key(fingerprint, admin_id, unix_user=None, hostname=None)
+  ↳ sans unix_user+hostname : valide toutes les lignes PENDING_REVIEW pour ce fingerprint
+  ↳ avec unix_user+hostname : valide uniquement la ligne (fingerprint, server, unix_user) — fix issue #193
 - revoke_key(fingerprint, admin_id, reason, db)
   ↳ fonctionne sur ACTIVE et PENDING_REVIEW (issue #85)
 - handle_disappeared_key(key_id, server_id, db)    ← scénario 2
@@ -660,12 +662,13 @@ ui/tests/
     KeyActions.spec.js    ← modal confirmation révocation (17 tests)
     ExpiryPicker.spec.js  ← modes exclusifs heures/date (11 tests)
     ServerTable.spec.js   ← filtres hostname/IP/env, badges statut (15 tests)
-    KeyTable.spec.js      ← boutons par statut, owner, expires_at (18+ tests)
-    Admins.spec.js        ← modals enable/delete, garde-fous (15 tests)
-    Settings.spec.js      ← chargement, sauvegarde, validation, erreurs (7 tests)
-    DeployKeyForm.spec.js ← formulaire déploiement clé SSH (16 tests)
-    UserLockForm.spec.js  ← verrouillage/déverrouillage compte Unix (10 tests)
-    Anomalies.spec.js     ← filtres recherche, badges compteurs, no_results (13 tests)
+    KeyTable.spec.js           ← boutons par statut, owner, expires_at, barre de filtres texte + statut (30 tests)
+    Admins.spec.js             ← modals enable/delete, garde-fous (15 tests)
+    Settings.spec.js           ← chargement, sauvegarde, validation, erreurs (7 tests)
+    DeployKeyForm.spec.js      ← formulaire déploiement clé SSH (16 tests)
+    UserLockForm.spec.js       ← verrouillage/déverrouillage compte Unix (10 tests)
+    DeployedUsersTable.spec.js ← tableau utilisateurs déployés, filtres (10 tests)
+    Anomalies.spec.js          ← filtres texte + dropdowns type/serveur/conformité, unix_user, badges (20 tests)
 
 ### Ce qui n'est PAS testé unitairement
 
@@ -862,6 +865,7 @@ ui/src/views/
                           + boutons désactiver/réactiver/supprimer (issue #89)
                           + bandeau rouge si serveur désactivé (issue #91)
     Anomalies.vue       ← toutes anomalies actives + barre de recherche (issue #191)
+                          + colonne unix_user + dropdowns type/serveur/conformité (issue #195)
     AccessRequests.vue  ← déploiement de clé SSH (DeployKeyForm) + verrouillage compte Unix (UserLockForm)
     Audit.vue           ← historique filtrable
     Admins.vue          ← gestion administrateurs
@@ -879,8 +883,9 @@ ui/src/components/
                           + barre de filtres texte + dropdown statut (issue #189)
     KeyActions.vue      ← boutons valider/révoquer/expiry
     ExpiryPicker.vue    ← datepicker durée ou date précise
-    DeployKeyForm.vue   ← formulaire déploiement clé SSH (utilisé par AccessRequests.vue)
-    UserLockForm.vue    ← verrouillage/déverrouillage compte Unix (issue #181)
+    DeployKeyForm.vue        ← formulaire déploiement clé SSH (utilisé par AccessRequests.vue)
+    UserLockForm.vue         ← verrouillage/déverrouillage compte Unix (issue #181)
+    DeployedUsersTable.vue   ← tableau des utilisateurs Unix déployés avec filtres
 
 ui/src/
     i18n.js             ← configuration vue-i18n v9 (issue #98)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -704,6 +704,42 @@ Chaque action est tracée dans `audit_log` avec action `USER_LOCKED` ou
 Le workflow demande/approbation (`access request` / `access approve`) reste
 disponible via la CLI et l'API REST, mais n'est plus exposé dans l'interface web.
 
+### Vue Anomalies — filtres et colonne unix_user
+
+La vue `Anomalies.vue` affiche deux sections : clés en attente de validation
+(`PENDING_REVIEW`) et révocations hors système (30 derniers jours). Elle expose
+une barre de filtres combinés :
+
+- **Texte libre** : recherche sur fingerprint, type, serveur, unix_user
+- **Dropdown type** : filtre par algorithme de clé (ssh-ed25519, ssh-rsa, …)
+- **Dropdown serveur** : filtre par hostname de serveur
+- **Dropdown conformité** : filtre Conforme / Non conforme
+
+La colonne **Unix user** est affichée dans les deux tables. Les badges de compteur
+(`count-badge`) reflètent le total réel avant filtrage, pas le nombre de lignes
+visibles — ce qui permet à l'administrateur de savoir combien d'anomalies existent
+même si un filtre est actif.
+
+La fonction `validate()` transmet `unix_user` et `server_hostname` au corps de la
+requête POST `/api/keys/validate/<fp>`, garantissant que seule la ligne
+`(key_id, server_id, unix_user)` ciblée passe en `ACTIVE` (fix issue #193).
+
+### Validation scopée — validate_key (issue #193)
+
+La clé composite `(key_id, server_id, unix_user)` dans `key_authorizations` implique
+qu'une même clé SSH peut être autorisée pour plusieurs utilisateurs Unix sur un même
+serveur. La fonction `validate_key()` accepte des paramètres optionnels :
+
+```python
+def validate_key(fingerprint, admin_id, unix_user=None, hostname=None):
+    # sans params : valide toutes les lignes PENDING_REVIEW du fingerprint
+    # avec params  : valide uniquement la ligne (fingerprint, server, unix_user)
+```
+
+L'UI transmet toujours `unix_user` et `hostname` dans le corps JSON de la requête,
+garantissant que valider une clé pour `alice` ne valide pas automatiquement la même
+clé pour `bob` sur le même serveur.
+
 ### Composant ExpiryPicker — modes exclusifs
 
 `ExpiryPicker.vue` illustre la gestion de modes mutuellement exclusifs :
@@ -858,7 +894,7 @@ coûteuse en temps).
 | `test_manage.py` | 42+ | Toutes les commandes CLI, lock/unlock |
 | `test_collect.py` | 15 | 4 scénarios détection, RSA parsing |
 | `test_expire.py` | 12 | Anti-spam 24h, expiration auto |
-| Vue.js specs | 99 | KeyActions, ExpiryPicker, KeyTable, ServerTable, UserLockForm |
+| Vue.js specs | 137 | KeyActions, ExpiryPicker, KeyTable, ServerTable, UserLockForm, Anomalies, DeployedUsersTable |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ podman logs ssh-access-manager | grep -A1 "collector_key.pub"
 
 La clé publique est également visible directement dans l'interface web : **Dashboard > Clé publique collecteur**.
 
-L'interface est accessible sur `http://localhost:8080` (authentification Basic Auth : `NGINX_USER` / `NGINX_PASSWORD`).
+L'interface est accessible sur `http://localhost:8080`. Authentification par session Flask : utilisez les identifiants définis via `ADMIN_USERNAME` / `ADMIN_PASSWORD` au démarrage.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #197

Audit complet documentation vs code — corrections :

- **README.md** : suppression référence Basic Auth (issue #54 supprimée) → Flask session auth
- **CLAUDE.md** : signature `validate_key` corrigée avec `unix_user=None, hostname=None`
- **CLAUDE.md** : `Anomalies.vue` — ajout dropdowns type/serveur/conformité + colonne unix_user (issue #195)
- **CLAUDE.md** : `DeployedUsersTable.vue` et `DeployedUsersTable.spec.js` ajoutés
- **CLAUDE.md** : compteurs tests mis à jour (KeyTable 30, Anomalies 20)
- **DESIGN.md** : section validation scopée `validate_key` (issue #193)
- **DESIGN.md** : section dropdowns Anomalies et colonne unix_user
- **DESIGN.md** : compteur Vue.js specs 99 → 137

## Test plan

- [x] Aucun code modifié — documentation uniquement
- [x] Vérification manuelle cohérence avec le code source