### PR TITLE
fix: sync html lang attribute with selected locale for native browser UI

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -42,6 +42,7 @@ async function handleLogout() {
 function changeLang(lang) {
   locale.value = lang
   localStorage.setItem('lang', lang)
+  document.documentElement.lang = lang
 }
 </script>
 

--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -100,6 +100,7 @@
           v-else-if="mode === 'date'"
           v-model="date"
           type="datetime-local"
+          :lang="locale"
           :min="minDate"
           data-testid="input-date"
         />
@@ -140,7 +141,7 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const emit = defineEmits(['deployed'])
 
 const unixUser = ref('')

--- a/ui/src/components/ExpiryPicker.vue
+++ b/ui/src/components/ExpiryPicker.vue
@@ -39,6 +39,7 @@
         id="expiry-date"
         v-model="date"
         type="datetime-local"
+        :lang="locale"
         :min="minDate"
         data-testid="input-date"
         @input="emitValue"
@@ -52,6 +53,9 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const { locale } = useI18n()
 
 const emit = defineEmits(['update:modelValue'])
 

--- a/ui/src/i18n.js
+++ b/ui/src/i18n.js
@@ -17,6 +17,8 @@ const locale = supported.includes(savedLang)
     ? browserLang
     : 'en'
 
+document.documentElement.lang = locale
+
 export default createI18n({
   legacy: false,
   locale,

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -164,7 +164,7 @@
           min="1"
           :placeholder="$t('server_detail.expiry_hours_placeholder')"
         />
-        <input v-else v-model="expiryDate" type="datetime-local" />
+        <input v-else v-model="expiryDate" type="datetime-local" :lang="locale" />
         <div class="modal-actions">
           <button class="btn-primary" :disabled="!expiryValid" @click="confirmExpiry">
             {{ $t('server_detail.expiry_confirm') }}
@@ -182,7 +182,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import KeyTable from '../components/KeyTable.vue'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const hostname = route.params.hostname


### PR DESCRIPTION
## Summary

Closes #199

Le tooltip du datetime picker (et tous les contrôles natifs du navigateur) s'affichaient toujours en français car `<html lang="fr">` était codé en dur dans `index.html`.

**3 changements** :
- `index.html` : `lang="fr"` → `lang="en"` (fallback neutre)
- `i18n.js` : `document.documentElement.lang = locale` au démarrage (applique la langue détectée)
- `App.vue` `changeLang()` : `document.documentElement.lang = lang` à chaque changement de langue

## Test plan

- [x] `npm run format:check` — vert
- [x] `vitest run` — 137 tests passent
- [ ] Vérifier en IT/DE/ES : le tooltip du datetime picker s'affiche dans la bonne langue