### PR TITLE
fix: corrections de sécurité — 20 vulnérabilités corrigées

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -99,6 +99,11 @@ def revoke_key(
     tous les utilisateurs Unix (comportement historique).
     """
     _check_fingerprint(fingerprint)
+    if unix_user and not _UNIX_USER_RE.match(unix_user):
+        raise ValueError(
+            f"Nom d'utilisateur Unix invalide : '{unix_user}' "
+            "(minuscules, chiffres, _ et - uniquement, max 32 caractères)"
+        )
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise ValueError(f"Key not found: {fingerprint}")
@@ -406,7 +411,7 @@ def grant_access(
         """
         INSERT INTO key_authorizations (key_id, server_id, authorized_by, status, expires_at)
         VALUES (%s, %s, %s, 'ACTIVE', %s)
-        ON CONFLICT (key_id, server_id) DO UPDATE SET
+        ON CONFLICT (key_id, server_id, unix_user) DO UPDATE SET
             status = 'ACTIVE',
             authorized_by = EXCLUDED.authorized_by,
             authorized_at = now(),
@@ -619,6 +624,18 @@ def revoke_request(request_id: str, admin_id: str) -> None:
     db.execute(
         "UPDATE access_requests SET status = 'EXPIRED' WHERE id = %s",
         (request_id,),
+    )
+    db.execute(
+        """
+        INSERT INTO audit_log (action, performed_by, target_key, target_server, details)
+        VALUES ('KEY_REVOKED', %s, %s, %s, %s::jsonb)
+        """,
+        (
+            admin_id,
+            req["key_id"],
+            req["server_id"],
+            json.dumps({"request_id": request_id, "reason": "request_revoked"}),
+        ),
     )
 
 

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -160,7 +160,7 @@ if [ -z "$USER" ]; then
     echo "Usage: sam-unlock-user <username>" >&2
     exit 1
 fi
-usermod -s /bin/bash "$USER"
+usermod -U -s /bin/bash "$USER"
 """
 
 
@@ -172,7 +172,14 @@ def _connect(ip: str) -> paramiko.SSHClient:
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.RejectPolicy())
     client.load_host_keys(KNOWN_HOSTS)
-    client.connect(hostname=ip, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
+    client.connect(
+        hostname=ip,
+        username=SSH_USER,
+        key_filename=COLLECTOR_KEY,
+        look_for_keys=False,
+        allow_agent=False,
+        timeout=15,
+    )
     return client
 
 
@@ -185,7 +192,7 @@ def _run(client: paramiko.SSHClient, cmd: str) -> tuple[str, str, int]:
 
 
 def _remote_sha256(client: paramiko.SSHClient, remote_path: str) -> str | None:
-    out, _, rc = _run(client, f"sha256sum {remote_path} 2>/dev/null")
+    out, _, rc = _run(client, f"sha256sum '{remote_path}' 2>/dev/null")
     if rc != 0 or not out.strip():
         return None
     return out.split()[0]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,10 +1,14 @@
 import base64
 import hashlib
+import os
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Définir FLASK_SECRET_KEY avant tout import de web.py
+os.environ.setdefault("FLASK_SECRET_KEY", "pytest-test-secret-key-not-for-production")
 
 
 def _compute_fingerprint(key_b64: str) -> str:

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -395,6 +395,20 @@ def test_actions_revoke_request_calls_sam_revoke():
         )
 
 
+def test_actions_revoke_request_logs_audit():
+    req = {"key_id": KEY_ID, "server_id": SERVER_ID}
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.side_effect = [
+            req,
+            {"fingerprint": "SHA256:abc"},
+            {"hostname": "server-test-01", "ip_address": "192.168.1.10"},
+        ]
+        actions.revoke_request(REQUEST_ID, ADMIN_ID)
+        executed_sqls = [c[0][0] for c in mock_db.execute.call_args_list]
+        assert any("KEY_REVOKED" in sql for sql in executed_sqls), \
+            "revoke_request must insert KEY_REVOKED into audit_log"
+
+
 # ---------------------------------------------------------------------------
 # add_server / disable_server
 # ---------------------------------------------------------------------------
@@ -688,6 +702,12 @@ def test_actions_validate_key_rejects_invalid_fingerprint_format():
 def test_actions_revoke_key_rejects_invalid_fingerprint_format():
     with pytest.raises(ValueError, match="Format de fingerprint invalide"):
         actions.revoke_key("INVALID:abc", ADMIN_ID, "test")
+
+
+def test_actions_revoke_key_rejects_invalid_unix_user():
+    """revoke_key doit valider unix_user si fourni (sécurité — évite la corruption de BDD)."""
+    with pytest.raises(ValueError, match="Nom d'utilisateur Unix invalide"):
+        actions.revoke_key("SHA256:abc123", ADMIN_ID, "test", hostname="server", unix_user="Bad User!")
 
 
 def test_actions_assign_key_rejects_invalid_fingerprint_format():

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -74,6 +74,22 @@ def test_ssh_connect_never_uses_auto_add_policy():
             assert not isinstance(c[0][0], type), "AutoAddPolicy should never be used"
 
 
+def test_ssh_connect_disables_agent_and_key_lookup():
+    """_connect doit passer look_for_keys=False et allow_agent=False pour éviter
+    l'utilisation d'autres clés du système."""
+    with patch("ssh.paramiko.SSHClient") as mock_cls:
+        client_instance = MagicMock()
+        mock_cls.return_value = client_instance
+        client_instance.connect.side_effect = Exception("stop")
+        try:
+            ssh._connect("192.168.1.10")
+        except Exception:
+            pass
+        call_kwargs = client_instance.connect.call_args[1]
+        assert call_kwargs.get("look_for_keys") is False, "look_for_keys must be False"
+        assert call_kwargs.get("allow_agent") is False, "allow_agent must be False"
+
+
 # ---------------------------------------------------------------------------
 # ensure_scripts — déploie si hash différent
 # ---------------------------------------------------------------------------
@@ -403,6 +419,7 @@ def test_ssh_sam_unlock_user_is_bytes():
     assert b"#!/bin/sh" in ssh.SAM_UNLOCK_USER
     assert b"usermod" in ssh.SAM_UNLOCK_USER
     assert b"-s /bin/bash" in ssh.SAM_UNLOCK_USER
+    assert b"-U" in ssh.SAM_UNLOCK_USER, "sam-unlock-user doit appeler usermod -U pour déverrouiller le mot de passe"
 
 
 def test_ssh_lock_user_on_server_calls_sam_lock_user(sample_server):

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -649,6 +649,25 @@ def test_web_list_admins_does_not_expose_password_hash(auth_client):
 
 
 # ---------------------------------------------------------------------------
+# PUT /api/admins/<username>/password — restreint au self-change
+# ---------------------------------------------------------------------------
+
+def test_web_change_password_self_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.put("/api/admins/admin/password", json={"password": "NewP@ss1"})
+        assert resp.status_code == 200
+
+
+def test_web_change_password_other_admin_returns_403(auth_client):
+    """Un admin ne peut pas changer le mot de passe d'un autre admin."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.put("/api/admins/other_admin/password", json={"password": "NewP@ss1"})
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
 # lock-user / unlock-user
 # ---------------------------------------------------------------------------
 

--- a/app/web.py
+++ b/app/web.py
@@ -5,7 +5,7 @@ Importe actions.py pour la logique metier — jamais de duplication.
 """
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 
 from flask import Flask, g, jsonify, request, session
@@ -16,12 +16,20 @@ import collect as collect_mod
 import db
 
 app = Flask(__name__)
-_flask_secret = os.environ.get("FLASK_SECRET_KEY")
-if not _flask_secret:
-    import warnings
-    warnings.warn("FLASK_SECRET_KEY not set — sessions are insecure", RuntimeWarning, stacklevel=1)
-    _flask_secret = "changeme"
+
+_flask_secret = os.environ.get("FLASK_SECRET_KEY", "")
+if not _flask_secret or _flask_secret == "changeme":
+    raise RuntimeError(
+        "FLASK_SECRET_KEY must be set to a strong random value "
+        "(e.g. openssl rand -hex 32). Refusing to start with insecure default."
+    )
 app.secret_key = _flask_secret
+
+# Session security
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"] = os.environ.get("SESSION_COOKIE_SECURE", "false").lower() == "true"
+app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(hours=8)
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +74,7 @@ def auth_login():
     if not check_password_hash(admin["password_hash"], password):
         return jsonify({"error": "Identifiants invalides"}), 401
     session.clear()
+    session.permanent = True
     session["admin_id"] = str(admin["id"])
     session["admin_username"] = admin["username"]
     return jsonify({"username": admin["username"]}), 200
@@ -559,6 +568,8 @@ def add_admin():
 @app.route("/api/admins/<username>/password", methods=["PUT"])
 @require_auth
 def change_admin_password(username):
+    if username != g.admin_username:
+        return jsonify({"error": "Vous ne pouvez changer que votre propre mot de passe"}), 403
     data = request.get_json(force=True) or {}
     password = data.get("password", "").strip()
     if not password:
@@ -721,6 +732,4 @@ def update_config():
 
 
 if __name__ == "__main__":
-    if not os.environ.get("FLASK_SECRET_KEY"):
-        raise RuntimeError("FLASK_SECRET_KEY environment variable is required")
     app.run(host="127.0.0.1", port=5000)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2,6 +2,31 @@
 set -e
 
 # ---------------------------------------------------------------------------
+# Validation des secrets critiques — refus de démarrage si valeurs par défaut
+# ---------------------------------------------------------------------------
+_validate_secrets() {
+    local errors=0
+    if [ "${FLASK_SECRET_KEY:-changeme}" = "changeme" ]; then
+        echo "[bootstrap] ERREUR : FLASK_SECRET_KEY non définie ou égale à 'changeme'." >&2
+        echo "[bootstrap]   Générez une valeur forte : openssl rand -hex 32" >&2
+        errors=1
+    fi
+    if [ "${POSTGRES_PASSWORD:-changeme}" = "changeme" ]; then
+        echo "[bootstrap] ERREUR : POSTGRES_PASSWORD non définie ou égale à 'changeme'." >&2
+        errors=1
+    fi
+    if [ "${ADMIN_PASSWORD:-changeme}" = "changeme" ]; then
+        echo "[bootstrap] ERREUR : ADMIN_PASSWORD non définie ou égale à 'changeme'." >&2
+        errors=1
+    fi
+    if [ "$errors" -ne 0 ]; then
+        echo "[bootstrap] Arrêt — corrigez les variables d'environnement avant de démarrer." >&2
+        exit 1
+    fi
+}
+_validate_secrets
+
+# ---------------------------------------------------------------------------
 # Génération nginx.conf depuis template + ENV
 # ---------------------------------------------------------------------------
 generate_nginx_conf() {
@@ -59,7 +84,7 @@ if [ ! -f /data/pg/PG_VERSION ]; then
     # 4. Créer known_hosts vide
     touch /data/keys/known_hosts
     chown nobody:nobody /data/keys/known_hosts
-    chmod 644 /data/keys/known_hosts
+    chmod 600 /data/keys/known_hosts
 
     # 5. Initialiser le cluster PostgreSQL
     su -s /bin/sh postgres -c "initdb -D /data/pg --encoding=UTF8 --locale=C"
@@ -67,15 +92,51 @@ if [ ! -f /data/pg/PG_VERSION ]; then
     # 6. Démarrer PostgreSQL temporairement (socket locale uniquement)
     su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' start -w"
 
-    # 7. Créer la base et l'utilisateur depuis ENV
-    # CREATE DATABASE ne peut pas s'exécuter dans une transaction : deux appels séparés
-    su -s /bin/sh postgres -c "psql -h /tmp -c \"CREATE USER ${POSTGRES_USER:-ssh_manager} WITH PASSWORD '${POSTGRES_PASSWORD:-changeme}';\""
-    su -s /bin/sh postgres -c "psql -h /tmp -c \"CREATE DATABASE ${POSTGRES_DB:-ssh_manager} OWNER ${POSTGRES_USER:-ssh_manager};\""
+    # 7. Créer la base et l'utilisateur depuis ENV via Python (évite l'injection shell)
+    # CREATE DATABASE ne peut pas s'exécuter dans une transaction : autocommit requis
+    python3 << 'PYEOF'
+import os
+import psycopg2
+from psycopg2 import sql as pgsql
 
-    # 8. Appliquer le schéma SQL
-    su -s /bin/sh postgres -c \
-        "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} \
-         -f /app/sql/schema.sql"
+pg_user = os.environ.get("POSTGRES_USER", "ssh_manager")
+pg_password = os.environ.get("POSTGRES_PASSWORD", "changeme")
+pg_db = os.environ.get("POSTGRES_DB", "ssh_manager")
+
+conn = psycopg2.connect(host="/tmp", user="postgres")
+conn.autocommit = True
+cur = conn.cursor()
+cur.execute(
+    pgsql.SQL("CREATE USER {} WITH PASSWORD %s").format(pgsql.Identifier(pg_user)),
+    (pg_password,),
+)
+cur.execute(
+    pgsql.SQL("CREATE DATABASE {} OWNER {}").format(
+        pgsql.Identifier(pg_db), pgsql.Identifier(pg_user)
+    )
+)
+conn.close()
+print("[bootstrap] Utilisateur et base de données créés.")
+PYEOF
+
+    # 8. Appliquer le schéma SQL via Python (évite l'injection shell des ENV vars)
+    python3 << 'PYEOF'
+import os
+import psycopg2
+
+conn = psycopg2.connect(
+    host="/tmp",
+    dbname=os.environ.get("POSTGRES_DB", "ssh_manager"),
+    user=os.environ.get("POSTGRES_USER", "ssh_manager"),
+    password=os.environ.get("POSTGRES_PASSWORD", "changeme"),
+)
+conn.autocommit = True
+cur = conn.cursor()
+with open("/app/sql/schema.sql", "r") as f:
+    cur.execute(f.read())
+conn.close()
+print("[bootstrap] Schéma SQL appliqué.")
+PYEOF
 
     # 9. Insérer l'administrateur initial depuis ENV
     # Utilise Python+psycopg2 pour éviter l'interpolation shell du hash ($...)

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -12,9 +12,32 @@ http {
     access_log    /dev/stdout;
     sendfile      on;
 
+    # Rate limiting — protection brute force sur /api/auth/login
+    limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+
     server {
         listen {{NGINX_PORT}};
         server_name _;
+
+        # Headers de sécurité HTTP
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none';" always;
+        add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+
+        # Masquer la version nginx
+        server_tokens off;
+
+        # Endpoint de login — rate limité (5 req/min par IP, burst 10)
+        location = /api/auth/login {
+            limit_req zone=login burst=10 nodelay;
+            limit_req_status 429;
+            proxy_pass         http://127.0.0.1:5000;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
 
         # API Flask — proxy vers 127.0.0.1:5000
         location /api/ {

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -12,9 +12,9 @@ if [ -z "${COLLECTOR_PUBKEY}" ]; then
     exit 1
 fi
 
-# 1. Créer l'utilisateur système (sans shell interactif)
+# 1. Créer l'utilisateur système sans shell interactif
 if ! id "${COLLECTOR_USER}" >/dev/null 2>&1; then
-    useradd -r -m -s /bin/bash "${COLLECTOR_USER}"
+    useradd -r -m -s /usr/sbin/nologin "${COLLECTOR_USER}"
     echo "[provision] Utilisateur ${COLLECTOR_USER} créé."
 else
     echo "[provision] Utilisateur ${COLLECTOR_USER} existe déjà."
@@ -52,6 +52,12 @@ printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g 
 printf 'audit-collector ALL=(root) NOPASSWD: /usr/bin/install -m 755 -o root -g root /home/audit-collector/sam-unlock-user /usr/local/bin/sam-unlock-user\n' >> "${SUDOERS_FILE}"
 
 chmod 440 "${SUDOERS_FILE}"
+# Valider la syntaxe sudoers — supprimer le fichier en cas d'erreur
+if ! visudo -c -f "${SUDOERS_FILE}" >/dev/null 2>&1; then
+    rm -f "${SUDOERS_FILE}"
+    echo "[provision] ERREUR : fichier sudoers invalide — supprimé." >&2
+    exit 1
+fi
 echo "[provision] Sudoers configuré dans ${SUDOERS_FILE}."
 
 echo "[provision] Hôte prêt pour la collecte SSH par ${COLLECTOR_USER}."

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -35,6 +35,7 @@ stderr_logfile_maxbytes=0
 
 [program:crond]
 command=crond -f -l 8
+user=nobody
 autorestart=true
 priority=4
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Closes #206

## Résumé

Revue de sécurité complète — correction de 20 vulnérabilités réparties sur 11 fichiers.

## Changements

### `app/web.py`
- `RuntimeError` immédiat si `FLASK_SECRET_KEY` absente ou `"changeme"` (niveau module, pas seulement `__main__`)
- `SESSION_COOKIE_HTTPONLY = True`, `SESSION_COOKIE_SAMESITE = "Lax"`, `SESSION_COOKIE_SECURE` opt-in via ENV, `PERMANENT_SESSION_LIFETIME = 8h`
- `session.permanent = True` dans `auth_login()`
- `PUT /api/admins/<username>/password` → retourne `403` si la cible n'est pas l'admin courant

### `bootstrap.sh`
- Validation des secrets critiques au démarrage (`FLASK_SECRET_KEY`, `POSTGRES_PASSWORD`, `ADMIN_PASSWORD`)
- Remplacement des commandes `psql` shell par Python + `psycopg2.sql.Identifier` (injection shell éliminée)
- `chmod 600 /data/keys/known_hosts` (était `644`)

### `nginx.conf.template`
- Headers : `X-Frame-Options`, `X-Content-Type-Options`, `Content-Security-Policy`, `Referrer-Policy`, `Permissions-Policy`
- `server_tokens off`
- Rate limiting `/api/auth/login` : 5 req/min par IP, burst 10

### `supervisord.conf`
- `[program:crond]` : ajout de `user=nobody`

### `provision-host.sh`
- `audit-collector` créé avec `/usr/sbin/nologin` (plus `/bin/bash`)
- `visudo -c -f` validation du fichier sudoers après écriture

### `app/ssh.py`
- `SAM_UNLOCK_USER` : `usermod -U -s /bin/bash` (le `-L` n'était pas reversé)
- `_connect()` : `look_for_keys=False, allow_agent=False`
- `_remote_sha256` : guillemets autour du `remote_path`

### `app/actions.py`
- `revoke_request()` : ajout de `INSERT INTO audit_log` (`KEY_REVOKED`)
- `revoke_key()` : validation `_UNIX_USER_RE` sur `unix_user` si fourni
- `grant_access()` : `ON CONFLICT (key_id, server_id, unix_user)` (PK composite complète)

### Tests (269 passent, +5 nouveaux)
- `conftest.py` : `FLASK_SECRET_KEY` définie avant tout import de `web.py`
- `test_actions.py` : `revoke_request` trace dans `audit_log` + `unix_user` invalide dans `revoke_key`
- `test_ssh.py` : `look_for_keys/allow_agent` désactivés + `-U` dans `SAM_UNLOCK_USER`
- `test_web.py` : self-change MDP `200` + cross-change MDP `403`

## ⚠️ Non corrigé dans cette PR

**TLS/HTTPS** : nécessite une décision d'architecture (certificats, reverse proxy). Recommandation : déployer derrière un reverse proxy gérant TLS (Traefik, nginx externe). Fera l'objet d'une issue séparée.
