### PR TITLE
ci: supprimer le trigger push/main redondant de codeql.yml et ajouter build-pr comme required check

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
   pull_request:
   schedule:
     - cron: '0 6 * * 1'


### PR DESCRIPTION
## Résumé

- Supprime le trigger `push: branches: [main]` de `codeql.yml` — CodeQL tournait deux fois sur le même code à chaque merge de PR
- Le scan hebdomadaire (schedule) suffit pour rescanner `main` sur nouvelles CVE sans code change

## Action manuelle requise après merge

Ajouter le job **`Build & push pr-N`** (`build-pr.yml`) comme **required check** dans la protection de branche `main` :

> GitHub → Settings → Branches → main → Edit → Required status checks → rechercher `Build & push pr-`

Avec `exit-code: '1'` sur Trivy CRITICAL/HIGH, ce check bloquera les PR contenant des CVE critiques.

## Test plan

- [ ] CI verte sur cette PR (CodeQL tourne une seule fois via `pull_request`)
- [ ] Vérifier après merge que CodeQL ne se déclenche PAS sur `push: main`
- [ ] Ajouter `build` de `build-pr.yml` comme required check (manuel, Settings GitHub)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)