### PR TITLE
feat: add close button (×) to all modals

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -232,20 +232,35 @@ button:disabled {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 1rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e9ecef;
+  margin-bottom: 1.25rem;
+}
+.modal-header h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin: 0;
 }
 .modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.8rem;
+  height: 1.8rem;
   background: none;
   border: none;
-  font-size: 1.25rem;
-  line-height: 1;
+  font-size: 1rem;
   cursor: pointer;
-  padding: 0.1rem 0.4rem;
-  color: #888;
-  border-radius: 4px;
+  color: #999;
+  border-radius: 50%;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 .modal-close:hover {
   color: #333;
-  background: #eee;
+  background: #f0f0f0;
 }
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -227,4 +227,25 @@ button:disabled {
 .btn-warning:hover:not(:disabled) {
   background: #e0a800;
 }
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+.modal-close {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.1rem 0.4rem;
+  color: #888;
+  border-radius: 4px;
+}
+.modal-close:hover {
+  color: #333;
+  background: #eee;
+}
 </style>

--- a/ui/src/components/KeyActions.vue
+++ b/ui/src/components/KeyActions.vue
@@ -15,7 +15,12 @@
     <!-- Revoke confirmation modal -->
     <div v-if="confirming" class="modal-overlay" @click.self="confirming = false">
       <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-        <h3 id="modal-title">{{ $t('server_detail.revoke_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3 id="modal-title">{{ $t('server_detail.revoke_modal_title') }}</h3>
+          <button class="modal-close" @click="confirming = false" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="fp-display">
           <code>{{ fingerprint }}</code>
         </p>
@@ -101,11 +106,6 @@ function confirmRevoke() {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-
-.modal h3 {
-  font-size: 1.1rem;
-  margin: 0;
 }
 
 .fp-display {

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -221,7 +221,12 @@
     <!-- Disable confirmation modal -->
     <div v-if="disableTarget" class="modal-overlay" @click.self="disableTarget = null">
       <div class="modal">
-        <h3>{{ $t('admins.disable_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('admins.disable_modal_title') }}</h3>
+          <button class="modal-close" @click="disableTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p>{{ $t('admins.disable_modal_text', { username: disableTarget }) }}</p>
         <div class="modal-actions">
           <button class="btn-danger" @click="confirmDisable">
@@ -235,7 +240,12 @@
     <!-- Enable confirmation modal -->
     <div v-if="enableTarget" class="modal-overlay" @click.self="enableTarget = null">
       <div class="modal">
-        <h3>{{ $t('admins.enable_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('admins.enable_modal_title') }}</h3>
+          <button class="modal-close" @click="enableTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p>{{ $t('admins.enable_modal_text', { username: enableTarget }) }}</p>
         <div class="modal-actions">
           <button class="btn-success" @click="confirmEnable">
@@ -249,7 +259,12 @@
     <!-- Delete confirmation modal -->
     <div v-if="deleteTarget" class="modal-overlay" @click.self="deleteTarget = null">
       <div class="modal">
-        <h3>{{ $t('admins.delete_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('admins.delete_modal_title') }}</h3>
+          <button class="modal-close" @click="deleteTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p>{{ $t('admins.delete_modal_text', { username: deleteTarget }) }}</p>
         <div class="modal-actions">
           <button class="btn-danger" @click="confirmDelete">
@@ -263,7 +278,12 @@
     <!-- Change password modal -->
     <div v-if="editPasswordTarget" class="modal-overlay" @click.self="closeEditPassword">
       <div class="modal">
-        <h3>{{ $t('admins.pwd_modal_title', { username: editPasswordTarget }) }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('admins.pwd_modal_title', { username: editPasswordTarget }) }}</h3>
+          <button class="modal-close" @click="closeEditPassword" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <form @submit.prevent="confirmEditPassword">
           <div class="field" style="margin-bottom: 0.75rem">
             <label for="edit-password"
@@ -406,7 +426,10 @@
     <!-- Edit admin modal -->
     <div v-if="editTarget" class="modal-overlay" @click.self="closeEdit">
       <div class="modal">
-        <h3>{{ $t('admins.edit_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('admins.edit_modal_title') }}</h3>
+          <button class="modal-close" @click="closeEdit" aria-label="Close">&#x2715;</button>
+        </div>
         <form @submit.prevent="confirmEdit">
           <div class="field" style="margin-bottom: 0.75rem">
             <label for="edit-username">{{ $t('admins.field_username') }}</label>
@@ -913,10 +936,6 @@ input.input-error {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-.modal h3 {
-  font-size: 1.1rem;
-  margin: 0;
 }
 .modal-actions {
   display: flex;

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -160,7 +160,12 @@
     <!-- Revoke modal -->
     <div v-if="revokeTarget" class="modal-overlay" @click.self="revokeTarget = null">
       <div class="modal">
-        <h3>{{ $t('anomalies.revoke_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('anomalies.revoke_modal_title') }}</h3>
+          <button class="modal-close" @click="revokeTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="fp-display">
           <code>{{ revokeTarget.fingerprint }}</code>
         </p>
@@ -465,10 +470,6 @@ code {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-.modal h3 {
-  font-size: 1.1rem;
-  margin: 0;
 }
 label {
   font-size: 0.85rem;

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -51,7 +51,10 @@
       <div class="modal">
         <!-- Step 1: form -->
         <template v-if="!addSuccess">
-          <h3>{{ $t('add_server.title') }}</h3>
+          <div class="modal-header">
+            <h3>{{ $t('add_server.title') }}</h3>
+            <button class="modal-close" @click="closeAddServer" aria-label="Close">&#x2715;</button>
+          </div>
           <div v-if="addError" class="alert-error">{{ addError }}</div>
 
           <label
@@ -102,7 +105,10 @@
 
         <!-- Step 2: success + key display -->
         <template v-else>
-          <h3>{{ $t('add_server.success_title') }}</h3>
+          <div class="modal-header">
+            <h3>{{ $t('add_server.success_title') }}</h3>
+            <button class="modal-close" @click="closeAddServer" aria-label="Close">&#x2715;</button>
+          </div>
           <p class="success-msg">
             {{ $t('add_server.success_msg', { hostname: addForm.hostname }) }}
           </p>
@@ -126,7 +132,10 @@
     <!-- Edit server modal -->
     <div v-if="showEditServer" class="modal-overlay" @click.self="closeEditServer">
       <div class="modal">
-        <h3>{{ $t('edit_server.title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('edit_server.title') }}</h3>
+          <button class="modal-close" @click="closeEditServer" aria-label="Close">&#x2715;</button>
+        </div>
         <div v-if="editError" class="alert-error">{{ editError }}</div>
 
         <label>{{ $t('edit_server.hostname') }}</label>
@@ -493,10 +502,6 @@ h1 {
   gap: 0.75rem;
 }
 
-.modal h3 {
-  font-size: 1.1rem;
-  margin: 0;
-}
 .modal label {
   font-size: 0.85rem;
   font-weight: 600;

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -75,7 +75,12 @@
     <!-- Delete modal -->
     <div v-if="showDeleteModal" class="modal-overlay" @click.self="showDeleteModal = false">
       <div class="modal">
-        <h3>{{ $t('server_detail.delete_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.delete_modal_title') }}</h3>
+          <button class="modal-close" @click="showDeleteModal = false" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="warn-text" v-html="$t('server_detail.delete_modal_warning', { hostname })"></p>
         <div class="modal-actions">
           <button class="btn-danger" @click="deleteServer">
@@ -89,7 +94,12 @@
     <!-- Revoke modal -->
     <div v-if="revokeTarget" class="modal-overlay" @click.self="revokeTarget = null">
       <div class="modal">
-        <h3>{{ $t('server_detail.revoke_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.revoke_modal_title') }}</h3>
+          <button class="modal-close" @click="revokeTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="fp-display">
           <code>{{ revokeTarget.fingerprint }}</code>
         </p>
@@ -118,7 +128,12 @@
     <!-- Assign modal -->
     <div v-if="assignTarget" class="modal-overlay" @click.self="assignTarget = null">
       <div class="modal">
-        <h3>{{ $t('server_detail.assign_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.assign_modal_title') }}</h3>
+          <button class="modal-close" @click="assignTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="fp-display">
           <code>{{ assignTarget }}</code>
         </p>
@@ -143,7 +158,12 @@
     <!-- Expiry modal -->
     <div v-if="expiryTarget" class="modal-overlay" @click.self="expiryTarget = null">
       <div class="modal">
-        <h3>{{ $t('server_detail.expiry_modal_title') }}</h3>
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.expiry_modal_title') }}</h3>
+          <button class="modal-close" @click="expiryTarget = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
         <p class="fp-display">
           <code>{{ expiryTarget.fingerprint }}</code>
         </p>
@@ -511,10 +531,6 @@ dd {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-.modal h3 {
-  font-size: 1.1rem;
-  margin: 0;
 }
 .modal label {
   font-size: 0.85rem;


### PR DESCRIPTION
## Summary

- Global `.modal-header` + `.modal-close` CSS added to `App.vue`
- `×` close button added to all 13 modals: Admins.vue (5), ServerDetail.vue (4), Dashboard.vue (2), Anomalies.vue (1), KeyActions.vue (1)
- Click outside (`.modal-overlay`) still works unchanged

Closes #219

## Test plan

- [ ] Each modal has a visible × in top-right corner
- [ ] Clicking × closes the modal
- [ ] Clicking outside the modal still closes it
- [ ] `npm run format:check` → clean
- [ ] `npx vitest run` → 144 passed