### PR TITLE
feat: RBAC — rôles sysadmin/operator/viewer + email obligatoire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,14 +208,16 @@ CREATE TABLE servers (
 CREATE TABLE administrators (
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     username      VARCHAR(100) NOT NULL UNIQUE,
-    email         VARCHAR(255),
-    role          VARCHAR(50) DEFAULT 'sysadmin',
+    email         VARCHAR(255) NOT NULL,
+    role          VARCHAR(50) DEFAULT 'sysadmin'
+                      CHECK (role IN ('sysadmin', 'operator', 'viewer')),
     password_hash VARCHAR(255),
     is_active     BOOLEAN DEFAULT true,
     created_at    TIMESTAMPTZ DEFAULT now()
 );
 
 -- password_hash ajouté via issue #51
+-- role CHECK + email NOT NULL ajoutés via issue #222
 
 CREATE TABLE ssh_keys (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -491,10 +493,27 @@ Authentification gérée par Flask sessions.
 POST /api/auth/login — vérifie password_hash (werkzeug check_password_hash)
                        → session[admin_id], session[username]
 POST /api/auth/logout — clear session
-GET  /api/auth/me    — retourne l'admin courant
+GET  /api/auth/me    — retourne l'admin courant (id, username, email, role)
 
 Décorateur require_auth sur toutes les routes protégées.
 Retourne 401 JSON si session manquante.
+Charge g.admin_id, g.admin_username, g.admin_role à chaque requête.
+
+RBAC — décorateur require_role(*roles) (issue #222) :
+Retourne 403 JSON si g.admin_role ∉ roles.
+
+Rôles :
+- sysadmin : accès complet (seul à gérer les admins)
+- operator : actions SSH (valider, révoquer, déployer, lock/unlock)
+- viewer   : lecture seule
+
+Routes protégées @require_role("sysadmin") :
+  POST   /api/admins
+  PUT    /api/admins/<username>
+  PUT    /api/admins/<username>/disable
+  PUT    /api/admins/<username>/enable
+  DELETE /api/admins/<username>
+Exception : PUT /api/admins/<username>/password autorisé si sysadmin OU username == soi-même.
 
 Validation robustesse mot de passe (issue #62) :
 - 8+ caractères, 1+ majuscule, 1+ minuscule, 1+ chiffre, 1+ spécial
@@ -538,9 +557,9 @@ Validation robustesse mot de passe (issue #62) :
 
 ### Administrateurs
 - add_admin(username, email, password, db)
-  ↳ valide robustesse mot de passe, hash avec werkzeug
+  ↳ email obligatoire, valide role ∈ VALID_ROLES, hash mot de passe avec werkzeug
 - update_admin(username, email, role, admin_id)
-  ↳ email est nullable (str | None) — ne peut pas modifier son propre rôle
+  ↳ email obligatoire, valide role ∈ VALID_ROLES, ne peut pas modifier son propre rôle
 - change_password(username, new_password, db)   ← issue #61
 - disable_admin(username, db)
 - enable_admin(username, db)     ← issue #116

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Milestone 1 (Issues 1–4) ✅
 Milestone 2 (Issues 5–13) ✅  
 Milestone 3 (Issues 14–21) ✅  
 Milestone 4 (Issues 22–24) ✅  
-Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185) ✅
+Issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222) ✅
 
 ## Stack vérifiée et figée
 
@@ -556,7 +556,7 @@ Validation robustesse mot de passe (issue #62) :
 - delete_server(hostname, db)    ← issue #88 — suppression hard + cascade
 
 ### Administrateurs
-- add_admin(username, email, password, db)
+- add_admin(username, email, password, admin_id, role='operator')
   ↳ email obligatoire, valide role ∈ VALID_ROLES, hash mot de passe avec werkzeug
 - update_admin(username, email, role, admin_id)
   ↳ email obligatoire, valide role ∈ VALID_ROLES, ne peut pas modifier son propre rôle
@@ -664,15 +664,15 @@ test_web.py :
 ### Tests frontend — Vitest
 
 ui/tests/
-    KeyActions.spec.js    ← modal confirmation révocation (17 tests)
-    ExpiryPicker.spec.js  ← modes exclusifs heures/date (11 tests)
+    KeyActions.spec.js    ← modal confirmation révocation (14 tests)
+    ExpiryPicker.spec.js  ← modes exclusifs heures/date (9 tests)
     ServerTable.spec.js   ← filtres hostname/IP/env, badges statut (15 tests)
     KeyTable.spec.js           ← boutons par statut, owner, expires_at, barre de filtres texte + statut (30 tests)
-    Admins.spec.js             ← modals enable/delete, garde-fous (15 tests)
+    Admins.spec.js             ← modals enable/delete, garde-fous RBAC (25 tests)
     Settings.spec.js           ← chargement, sauvegarde, validation, erreurs (7 tests)
     DeployKeyForm.spec.js      ← formulaire déploiement clé SSH (16 tests)
     UserLockForm.spec.js       ← verrouillage/déverrouillage compte Unix (10 tests)
-    DeployedUsersTable.spec.js ← tableau utilisateurs déployés, filtres (10 tests)
+    DeployedUsersTable.spec.js ← tableau utilisateurs déployés, filtres, RBAC operator/viewer (12 tests)
     Anomalies.spec.js          ← filtres texte + dropdowns type/serveur/conformité, unix_user, badges (20 tests)
 
 ### Ce qui n'est PAS testé unitairement

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -679,6 +679,47 @@ Ce guard est non-bloquant : si `fetchMe()` échoue (session expirée), la
 redirection vers Login est automatique. Aucune vue protégée n'est rendue sans
 authentification valide.
 
+### RBAC — contrôle d'accès par rôle (issue #222)
+
+Trois rôles sont définis par une contrainte CHECK PostgreSQL dans la table
+`administrators` : `sysadmin`, `operator`, `viewer`.
+
+#### Backend — décorateur require_role
+
+```python
+def require_role(*roles):
+    def decorator(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            if g.admin_role not in roles:
+                return jsonify({"error": "Forbidden"}), 403
+            return f(*args, **kwargs)
+        return wrapped
+    return decorator
+```
+
+`require_auth` charge `g.admin_role` à chaque requête. `require_role` compose avec
+`require_auth` pour protéger les routes par niveau d'accès :
+
+| Niveau | Routes protégées |
+|---|---|
+| `sysadmin` uniquement | `POST /api/admins`, `PUT /api/admins/<u>`, disable/enable/delete admin, `POST /api/servers`, disable/enable/delete server, `PUT /api/system/config` |
+| `sysadmin` ou `operator` | Toutes les routes d'écriture clés, accès, scans |
+| Tous (auth seule) | Routes GET, `GET /api/auth/me` |
+
+Exception : `PUT /api/admins/<username>/password` — autorisé si sysadmin OU si l'admin modifie son propre mot de passe.
+
+#### Frontend — visibilité par rôle
+
+`useAuth.js` expose `admin.value.role` (chargé après login via `fetchMe()`).
+Chaque vue calcule `currentRole = computed(() => admin.value?.role || 'viewer')`.
+Les éléments sensibles utilisent `v-if` (jamais `v-show`) pour être absents du DOM :
+
+- **Admins.vue** : colonne Actions, formulaire d'ajout, boutons Edit/Disable/Enable/Delete masqués pour operator et viewer ; section "My account" visible pour tous pour changer son propre mot de passe
+- **Dashboard, ServerDetail** : boutons d'ajout/désactivation/suppression masqués pour viewer
+- **DeployedUsersTable** : colonne Actions + boutons Lock/Unlock masqués pour viewer
+- **Settings** : formulaire de configuration masqué pour operator et viewer
+
 ### Vue AccessRequests — formulaires DeployKeyForm et UserLockForm
 
 La vue `AccessRequests.vue` expose deux formulaires :

--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ La langue est détectée automatiquement depuis le navigateur, avec fallback sur
 
 ---
 
+## Rôles et permissions
+
+Trois rôles sont disponibles pour les administrateurs :
+
+| Rôle | Droits |
+|---|---|
+| `sysadmin` | Accès complet : gestion des administrateurs, des serveurs, des clés SSH, des accès et de la configuration système |
+| `operator` | Actions SSH : valider, révoquer, déployer des clés, verrouiller/déverrouiller des comptes Unix, lancer des scans |
+| `viewer` | Lecture seule : consultation de toutes les vues sans possibilité d'action |
+
+Le rôle est vérifié **côté backend** (Flask retourne 403 pour les requêtes non autorisées) **et côté frontend** (boutons et formulaires masqués selon le rôle).
+
+Un `sysadmin` ne peut pas modifier son propre rôle. Un email est obligatoire à la création.
+
+Pour créer un administrateur avec un rôle spécifique (défaut : `operator`) :
+
+```bash
+$EXEC admin add --username alice --email alice@example.com --password SECRET --role operator
+$EXEC admin update alice --role viewer
+```
+
+---
+
 ## Workflow — Ajout d'un serveur distant
 
 ### 1. Provisionner l'hôte distant
@@ -311,7 +334,8 @@ $EXEC access unlock-user --user USER --server HOST
 
 # Administrateurs
 $EXEC admin list
-$EXEC admin add --username USER --email EMAIL --password PASSWORD
+$EXEC admin add --username USER --email EMAIL --password PASSWORD [--role ROLE]
+# ROLE : sysadmin | operator (défaut) | viewer
 $EXEC admin update <username> [--email EMAIL] [--role ROLE]
 $EXEC admin disable USERNAME
 $EXEC admin enable USERNAME

--- a/app/actions.py
+++ b/app/actions.py
@@ -766,7 +766,7 @@ def _validate_password_strength(password: str) -> None:
         raise ValueError("Mot de passe insuffisant : " + ", ".join(errors))
 
 
-def add_admin(username: str, email: str, password: str, admin_id: str | None = None, role: str = "sysadmin") -> dict:
+def add_admin(username: str, email: str, password: str, admin_id: str | None = None, role: str = "operator") -> dict:
     """Insert a new administrator and log ADMIN_ADDED."""
     from werkzeug.security import generate_password_hash
     if not email or not email.strip():

--- a/app/actions.py
+++ b/app/actions.py
@@ -12,6 +12,7 @@ import ssh
 
 _FP_RE = re.compile(r"^SHA256:[A-Za-z0-9+/=]+$")
 _UNIX_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+VALID_ROLES = {"sysadmin", "operator", "viewer"}
 
 
 def _check_fingerprint(fp: str) -> None:
@@ -765,14 +766,18 @@ def _validate_password_strength(password: str) -> None:
         raise ValueError("Mot de passe insuffisant : " + ", ".join(errors))
 
 
-def add_admin(username: str, email: str, password: str, admin_id: str | None = None) -> dict:
+def add_admin(username: str, email: str, password: str, admin_id: str | None = None, role: str = "sysadmin") -> dict:
     """Insert a new administrator and log ADMIN_ADDED."""
     from werkzeug.security import generate_password_hash
+    if not email or not email.strip():
+        raise ValueError("email required")
+    if role not in VALID_ROLES:
+        raise ValueError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
     _validate_password_strength(password)
     password_hash = generate_password_hash(password)
     db.execute(
-        "INSERT INTO administrators (username, email, password_hash) VALUES (%s, %s, %s)",
-        (username, email, password_hash),
+        "INSERT INTO administrators (username, email, password_hash, role) VALUES (%s, %s, %s, %s)",
+        (username, email, password_hash, role),
     )
     admin = db.query_one("SELECT id FROM administrators WHERE username = %s", (username,))
     db.execute(
@@ -780,7 +785,7 @@ def add_admin(username: str, email: str, password: str, admin_id: str | None = N
         INSERT INTO audit_log (action, performed_by, details)
         VALUES ('ADMIN_ADDED', %s, %s::jsonb)
         """,
-        (admin_id, json.dumps({"username": username, "email": email})),
+        (admin_id, json.dumps({"username": username, "email": email, "role": role})),
     )
     return admin
 
@@ -802,6 +807,10 @@ def change_password(username: str, new_password: str) -> None:
 
 def update_admin(username: str, email: str | None, role: str, admin_id: str) -> dict:
     """Update administrator email and role. Log ADMIN_UPDATED."""
+    if not email or not email.strip():
+        raise ValueError("email required")
+    if role not in VALID_ROLES:
+        raise ValueError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
     admin = db.query_one(
         "SELECT id, email, role FROM administrators WHERE username = %s", (username,)
     )

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -991,3 +991,32 @@ def test_actions_update_server_not_found():
         mock_db.query_one.return_value = None
         with pytest.raises(ValueError, match="Server not found"):
             actions.update_server("unknown-server", "10.0.0.1", "lab", "rhel", ADMIN_ID)
+
+
+# ---------------------------------------------------------------------------
+# RBAC — email mandatory and role validation
+# ---------------------------------------------------------------------------
+
+def test_actions_add_admin_empty_email_raises():
+    with patch("actions.db") as mock_db:
+        with pytest.raises(ValueError, match="email required"):
+            actions.add_admin("user", "", "P@ssw0rd1!", None)
+
+
+def test_actions_add_admin_invalid_role_raises():
+    with patch("actions.db") as mock_db:
+        with pytest.raises(ValueError, match="Invalid role"):
+            actions.add_admin("user", "x@x.com", "P@ssw0rd1!", None, role="superadmin")
+
+
+def test_actions_update_admin_empty_email_raises():
+    with patch("actions.db") as mock_db:
+        with pytest.raises(ValueError, match="email required"):
+            actions.update_admin("user", "", "operator", ADMIN_ID)
+
+
+def test_actions_update_admin_invalid_role_raises():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "email": "test@example.com", "role": "operator"}
+        with pytest.raises(ValueError, match="Invalid role"):
+            actions.update_admin("user", "x@x.com", "superadmin", ADMIN_ID)

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -916,3 +916,71 @@ def test_web_rbac_operator_cannot_change_other_password(client):
             sess["admin_id"] = ADMIN_ID
         resp = client.put("/api/admins/other_user/password", json={"password": "NewP@ss1!"})
         assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# RBAC — viewer blocked on write routes
+# ---------------------------------------------------------------------------
+
+def test_web_rbac_viewer_cannot_add_server(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer_user", "role": "viewer"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/servers", json={"hostname": "h", "ip": "1.2.3.4", "environment": "lab"})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_viewer_cannot_revoke_key(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer_user", "role": "viewer"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/keys/revoke/SHA256:abc123", json={})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_viewer_cannot_deploy_key(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer_user", "role": "viewer"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/access/deploy", json={})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_viewer_cannot_update_config(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer_user", "role": "viewer"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.put("/api/system/config", json={"scan_interval_hours": 2})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_operator_cannot_add_server(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op_user", "role": "operator"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/servers", json={"hostname": "h", "ip": "1.2.3.4", "environment": "lab"})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_operator_can_revoke_key(client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op_user", "role": "operator"}
+        mock_actions.revoke_key.return_value = None
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/keys/revoke/SHA256:validfp123456789012345678901234567890123", json={})
+        assert resp.status_code == 200
+
+
+def test_web_rbac_operator_cannot_update_config(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op_user", "role": "operator"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.put("/api/system/config", json={"scan_interval_hours": 2})
+        assert resp.status_code == 403

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -19,7 +19,7 @@ FINGERPRINT = "SHA256:testABCDEF1234"
 
 
 def _admin_row():
-    return {"id": ADMIN_ID, "username": "admin"}
+    return {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
 
 
 @pytest.fixture
@@ -590,7 +590,7 @@ def test_web_update_admin_missing_role_returns_400(auth_client):
 
 def test_web_get_config_returns_settings(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin", "role": "sysadmin"}
         mock_db.query.return_value = [{"key": "scan_interval_hours", "value": "4"}]
         resp = auth_client.get("/api/system/config")
         assert resp.status_code == 200
@@ -599,7 +599,7 @@ def test_web_get_config_returns_settings(auth_client):
 
 def test_web_put_config_updates_interval(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin", "role": "sysadmin"}
         resp = auth_client.put("/api/system/config", json={"scan_interval_hours": 6})
         assert resp.status_code == 200
         assert resp.get_json()["scan_interval_hours"] == 6
@@ -607,14 +607,14 @@ def test_web_put_config_updates_interval(auth_client):
 
 def test_web_put_config_rejects_out_of_range(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin", "role": "sysadmin"}
         resp = auth_client.put("/api/system/config", json={"scan_interval_hours": 99})
         assert resp.status_code == 400
 
 
 def test_web_put_config_rejects_missing_field(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin"}
+        mock_db.query_one.return_value = {"id": "admin-id", "username": "admin", "role": "sysadmin"}
         resp = auth_client.put("/api/system/config", json={})
         assert resp.status_code == 400
 
@@ -625,7 +625,7 @@ def test_web_put_config_rejects_missing_field(auth_client):
 
 def test_web_deploy_key_returns_201(auth_client):
     with patch("web.db") as mock_db, patch("web.actions.deploy_key") as mock_deploy:
-        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin"}
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
         mock_deploy.return_value = {
             "fingerprint": "SHA256:test",
             "key_type": "ssh-ed25519",
@@ -662,7 +662,7 @@ def test_web_deploy_key_returns_401_unauthenticated(client):
 
 def test_web_deploy_key_returns_400_missing_fields(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin"}
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
         resp = auth_client.post(
             "/api/access/deploy",
             json={"public_key": "ssh-ed25519 AAAA test"},
@@ -672,7 +672,7 @@ def test_web_deploy_key_returns_400_missing_fields(auth_client):
 
 def test_web_deploy_key_hours_out_of_range_returns_400(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin"}
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
         for bad_hours in [0, -1, 8761, 99999]:
             resp = auth_client.post(
                 "/api/access/deploy",
@@ -689,7 +689,7 @@ def test_web_deploy_key_hours_out_of_range_returns_400(auth_client):
 
 def test_web_deploy_key_hours_not_integer_returns_400(auth_client):
     with patch("web.db") as mock_db:
-        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin"}
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
         resp = auth_client.post(
             "/api/access/deploy",
             json={
@@ -867,3 +867,52 @@ def test_web_deployed_users_excludes_ssh_user(auth_client):
         sql = call_args[0][0]
         params = call_args[0][1]
         assert "audit-collector" in params
+
+
+# ---------------------------------------------------------------------------
+# RBAC tests
+# ---------------------------------------------------------------------------
+
+def test_web_rbac_operator_cannot_create_admin(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op", "role": "operator"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.post("/api/admins", json={"username": "new", "email": "x@x.com", "password": "P@ssw0rd!"})
+        assert resp.status_code == 403
+
+
+def test_web_rbac_viewer_cannot_disable_admin(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer", "role": "viewer"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.put("/api/admins/someuser/disable")
+        assert resp.status_code == 403
+
+
+def test_web_rbac_sysadmin_can_create_admin(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "admin", "role": "sysadmin"}
+        mock_actions.add_admin.return_value = {"username": "new", "email": "x@x.com", "role": "operator"}
+        resp = auth_client.post("/api/admins", json={"username": "new", "email": "x@x.com", "password": "P@ssw0rd!"})
+        assert resp.status_code == 201
+
+
+def test_web_rbac_operator_can_change_own_password(client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op", "role": "operator"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        mock_actions.change_password.return_value = {"username": "op"}
+        resp = client.put("/api/admins/op/password", json={"password": "NewP@ss1!"})
+        assert resp.status_code == 200
+
+
+def test_web_rbac_operator_cannot_change_other_password(client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "op", "role": "operator"}
+        with client.session_transaction() as sess:
+            sess["admin_id"] = ADMIN_ID
+        resp = client.put("/api/admins/other_user/password", json={"password": "NewP@ss1!"})
+        assert resp.status_code == 403

--- a/app/web.py
+++ b/app/web.py
@@ -136,6 +136,7 @@ def get_server(hostname):
 
 @app.route("/api/servers", methods=["POST"])
 @require_auth
+@require_role("sysadmin")
 def add_server():
     data = request.get_json(force=True) or {}
     try:
@@ -151,6 +152,7 @@ def add_server():
 
 @app.route("/api/servers/<hostname>", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def update_server(hostname):
     data = request.get_json(force=True) or {}
     try:
@@ -166,6 +168,7 @@ def update_server(hostname):
 
 @app.route("/api/servers/<hostname>/disable", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def disable_server(hostname):
     try:
         actions.disable_server(hostname, g.admin_id)
@@ -177,6 +180,7 @@ def disable_server(hostname):
 
 @app.route("/api/servers/<hostname>/enable", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def enable_server(hostname):
     try:
         actions.enable_server(hostname, g.admin_id)
@@ -188,6 +192,7 @@ def enable_server(hostname):
 
 @app.route("/api/servers/<hostname>", methods=["DELETE"])
 @require_auth
+@require_role("sysadmin")
 def delete_server(hostname):
     try:
         actions.delete_server(hostname, g.admin_id)
@@ -199,6 +204,7 @@ def delete_server(hostname):
 
 @app.route("/api/servers/<hostname>/scan", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def scan_server(hostname):
     results = collect_mod.run_scan(hostname=hostname)
     return jsonify(results)
@@ -259,6 +265,7 @@ def get_key(fingerprint):
 
 @app.route("/api/keys/validate/<path:fingerprint>", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def validate_key(fingerprint):
     data = request.get_json(silent=True) or {}
     unix_user = data.get("unix_user") or None
@@ -273,6 +280,7 @@ def validate_key(fingerprint):
 
 @app.route("/api/keys/revoke/<path:fingerprint>", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def revoke_key(fingerprint):
     data = request.get_json(force=True) or {}
     reason = data.get("reason", "Manual revocation via API")
@@ -290,6 +298,7 @@ def revoke_key(fingerprint):
 
 @app.route("/api/keys/assign/<path:fingerprint>", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def assign_key(fingerprint):
     data = request.get_json(force=True) or {}
     try:
@@ -302,6 +311,7 @@ def assign_key(fingerprint):
 
 @app.route("/api/keys/set-expiry/<path:fingerprint>", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def set_key_expiry(fingerprint):
     from datetime import timedelta
     data = request.get_json(force=True) or {}
@@ -320,6 +330,7 @@ def set_key_expiry(fingerprint):
 
 @app.route("/api/keys/remove-expiry/<path:fingerprint>", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def remove_key_expiry(fingerprint):
     try:
         actions.remove_key_expiry(fingerprint)
@@ -357,6 +368,7 @@ def get_access(request_id):
 
 @app.route("/api/access/grant", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def grant_access():
     data = request.get_json(force=True) or {}
     expires_at = _parse_datetime(data.get("expires_at"))
@@ -381,6 +393,7 @@ def grant_access():
 
 @app.route("/api/access/deploy", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def api_deploy_key():
     from datetime import timedelta
     data = request.json or {}
@@ -426,6 +439,7 @@ def api_deploy_key():
 
 @app.route("/api/access/lock-user", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def api_lock_user():
     data = request.json or {}
     unix_user = (data.get("unix_user") or "").strip()
@@ -445,6 +459,7 @@ def api_lock_user():
 
 @app.route("/api/access/unlock-user", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def api_unlock_user():
     data = request.json or {}
     unix_user = (data.get("unix_user") or "").strip()
@@ -497,6 +512,7 @@ def list_deployed_users():
 
 @app.route("/api/access/request", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def request_access():
     data = request.get_json(force=True) or {}
     try:
@@ -529,6 +545,7 @@ def request_access():
 
 @app.route("/api/access/<request_id>/approve", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def approve_request(request_id):
     try:
         actions.approve_request(request_id, g.admin_id)
@@ -540,6 +557,7 @@ def approve_request(request_id):
 
 @app.route("/api/access/<request_id>/reject", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def reject_request(request_id):
     try:
         actions.reject_request(request_id, g.admin_id)
@@ -551,6 +569,7 @@ def reject_request(request_id):
 
 @app.route("/api/access/<request_id>/revoke", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def revoke_request(request_id):
     try:
         actions.revoke_request(request_id, g.admin_id)
@@ -730,6 +749,7 @@ def system_status():
 
 @app.route("/api/system/scan", methods=["POST"])
 @require_auth
+@require_role("sysadmin", "operator")
 def system_scan():
     results = collect_mod.run_scan()
     return jsonify(results)
@@ -756,6 +776,7 @@ def get_config():
 
 @app.route("/api/system/config", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def update_config():
     data = request.get_json(force=True) or {}
     hours = data.get("scan_interval_hours")

--- a/app/web.py
+++ b/app/web.py
@@ -597,7 +597,13 @@ def list_admins():
 def add_admin():
     data = request.get_json(force=True) or {}
     try:
-        admin = actions.add_admin(data["username"], data.get("email", ""), data["password"], g.admin_id)
+        admin = actions.add_admin(
+            data["username"],
+            data.get("email", ""),
+            data["password"],
+            g.admin_id,
+            role=data.get("role", "operator"),
+        )
         return jsonify(admin), 201
     except (KeyError, Exception) as e:
         logging.exception("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))

--- a/app/web.py
+++ b/app/web.py
@@ -35,15 +35,27 @@ def require_auth(f):
         if not admin_id:
             return jsonify({"error": "Unauthorized"}), 401
         admin = db.query_one(
-            "SELECT id, username FROM administrators WHERE id = %s AND is_active = true",
+            "SELECT id, username, role FROM administrators WHERE id = %s AND is_active = true",
             (admin_id,),
         )
         if not admin:
             return jsonify({"error": "Unauthorized"}), 401
         g.admin_id = admin["id"]
         g.admin_username = admin["username"]
+        g.admin_role = admin["role"]
         return f(*args, **kwargs)
     return decorated
+
+
+def require_role(*roles):
+    def decorator(f):
+        @wraps(f)
+        def decorated(*args, **kwargs):
+            if g.admin_role not in roles:
+                return jsonify({"error": "Insufficient permissions"}), 403
+            return f(*args, **kwargs)
+        return decorated
+    return decorator
 
 
 # ---------------------------------------------------------------------------
@@ -562,6 +574,7 @@ def list_admins():
 
 @app.route("/api/admins", methods=["POST"])
 @require_auth
+@require_role("sysadmin")
 def add_admin():
     data = request.get_json(force=True) or {}
     try:
@@ -574,6 +587,7 @@ def add_admin():
 
 @app.route("/api/admins/<username>", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def update_admin(username):
     data = request.get_json(force=True) or {}
     email = (data.get("email") or "").strip() or None
@@ -594,6 +608,8 @@ def update_admin(username):
 @app.route("/api/admins/<username>/password", methods=["PUT"])
 @require_auth
 def change_admin_password(username):
+    if g.admin_role != "sysadmin" and username != g.admin_username:
+        return jsonify({"error": "Insufficient permissions"}), 403
     data = request.get_json(force=True) or {}
     password = data.get("password", "").strip()
     if not password:
@@ -614,6 +630,7 @@ def get_me():
 
 @app.route("/api/admins/<username>/disable", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def disable_admin(username):
     if username == g.admin_username:
         return jsonify({"error": "Cannot disable your own account"}), 403
@@ -627,6 +644,7 @@ def disable_admin(username):
 
 @app.route("/api/admins/<username>/enable", methods=["PUT"])
 @require_auth
+@require_role("sysadmin")
 def enable_admin(username):
     if username == g.admin_username:
         return jsonify({"error": "Cannot enable your own account"}), 403
@@ -640,6 +658,7 @@ def enable_admin(username):
 
 @app.route("/api/admins/<username>", methods=["DELETE"])
 @require_auth
+@require_role("sysadmin")
 def delete_admin(username):
     if username == g.admin_username:
         return jsonify({"error": "Cannot delete your own account"}), 403

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -56,7 +56,7 @@ CREATE TABLE administrators (
     -- Adresse email pour les notifications
     email       VARCHAR(255),
     -- Rôle fonctionnel (extensible)
-    role          VARCHAR(50) DEFAULT 'sysadmin',
+    role          VARCHAR(50) DEFAULT 'sysadmin' CHECK (role IN ('sysadmin', 'operator', 'viewer')),
     -- Hash du mot de passe (werkzeug generate_password_hash)
     password_hash VARCHAR(255),
     -- Compte actif ou désactivé (jamais supprimé pour préserver l'audit)

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -62,28 +62,26 @@
               >
             </td>
             <td v-if="currentRole !== 'viewer'" class="actions">
-              <template>
-                <button
-                  v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
-                  type="button"
-                  class="btn-danger btn-sm"
-                  :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
-                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                  @click="lockUser(user)"
-                >
-                  {{ $t('userLock.btnLock') }}
-                </button>
-                <button
-                  v-else
-                  type="button"
-                  class="btn-success btn-sm"
-                  :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
-                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                  @click="unlockUser(user)"
-                >
-                  {{ $t('userLock.btnUnlock') }}
-                </button>
-              </template>
+              <button
+                v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
+                type="button"
+                class="btn-danger btn-sm"
+                :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
+                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
+                @click="lockUser(user)"
+              >
+                {{ $t('userLock.btnLock') }}
+              </button>
+              <button
+                v-else
+                type="button"
+                class="btn-success btn-sm"
+                :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
+                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
+                @click="unlockUser(user)"
+              >
+                {{ $t('userLock.btnUnlock') }}
+              </button>
               <div
                 v-if="successMessages[`${user.unix_user}-${user.hostname}`]"
                 class="inline-success"

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -62,26 +62,28 @@
               >
             </td>
             <td class="actions">
-              <button
-                v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
-                type="button"
-                class="btn-danger btn-sm"
-                :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
-                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                @click="lockUser(user)"
-              >
-                {{ $t('userLock.btnLock') }}
-              </button>
-              <button
-                v-else
-                type="button"
-                class="btn-success btn-sm"
-                :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
-                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                @click="unlockUser(user)"
-              >
-                {{ $t('userLock.btnUnlock') }}
-              </button>
+              <template v-if="currentRole !== 'viewer'">
+                <button
+                  v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
+                  type="button"
+                  class="btn-danger btn-sm"
+                  :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
+                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
+                  @click="lockUser(user)"
+                >
+                  {{ $t('userLock.btnLock') }}
+                </button>
+                <button
+                  v-else
+                  type="button"
+                  class="btn-success btn-sm"
+                  :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
+                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
+                  @click="unlockUser(user)"
+                >
+                  {{ $t('userLock.btnUnlock') }}
+                </button>
+              </template>
               <div
                 v-if="successMessages[`${user.unix_user}-${user.hostname}`]"
                 class="inline-success"
@@ -116,8 +118,11 @@
 <script setup>
 import { ref, computed, onMounted, defineExpose } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '../composables/useAuth.js'
 
 const { t } = useI18n()
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const users = ref([])
 const loading = ref(false)

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -35,7 +35,7 @@
             <th>{{ $t('deployedUsers.col_server') }}</th>
             <th>{{ $t('deployedUsers.col_expires') }}</th>
             <th>{{ $t('deployedUsers.col_status') }}</th>
-            <th>{{ $t('deployedUsers.col_actions') }}</th>
+            <th v-if="currentRole !== 'viewer'">{{ $t('deployedUsers.col_actions') }}</th>
           </tr>
         </thead>
         <tbody>
@@ -61,8 +61,8 @@
                 >{{ $t('deployedUsers.status_active') }}</span
               >
             </td>
-            <td class="actions">
-              <template v-if="currentRole !== 'viewer'">
+            <td v-if="currentRole !== 'viewer'" class="actions">
+              <template>
                 <button
                   v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
                   type="button"
@@ -101,7 +101,11 @@
             </td>
           </tr>
           <tr v-if="filteredUsers.length === 0">
-            <td colspan="5" class="empty-filtered" data-testid="empty-filtered">
+            <td
+              :colspan="currentRole !== 'viewer' ? 5 : 4"
+              class="empty-filtered"
+              data-testid="empty-filtered"
+            >
               {{ $t('deployedUsers.no_results') }}
             </td>
           </tr>

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -67,35 +67,38 @@
           <td>
             <div class="actions">
               <button
-                v-if="k.status === 'PENDING_REVIEW'"
+                v-if="k.status === 'PENDING_REVIEW' && props.currentRole !== 'viewer'"
                 class="btn-success"
                 @click="$emit('validate', k)"
               >
                 {{ $t('key_table.btn_validate') }}
               </button>
               <button
-                v-if="k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW'"
+                v-if="
+                  (k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW') &&
+                  props.currentRole !== 'viewer'
+                "
                 class="btn-danger"
                 @click="$emit('revoke', k)"
               >
                 {{ $t('key_table.btn_revoke') }}
               </button>
               <button
-                v-if="!k.owner && k.status === 'ACTIVE'"
+                v-if="!k.owner && k.status === 'ACTIVE' && props.currentRole !== 'viewer'"
                 class="btn-primary"
                 @click="$emit('assign', k.fingerprint)"
               >
                 {{ $t('key_table.btn_assign') }}
               </button>
               <button
-                v-if="k.status === 'ACTIVE'"
+                v-if="k.status === 'ACTIVE' && props.currentRole !== 'viewer'"
                 class="btn-warning"
                 @click="$emit('set-expiry', k)"
               >
                 {{ $t('key_table.btn_expiry') }}
               </button>
               <button
-                v-if="k.status === 'ACTIVE' && k.expires_at"
+                v-if="k.status === 'ACTIVE' && k.expires_at && props.currentRole !== 'viewer'"
                 class="btn-unlimited"
                 @click="$emit('remove-expiry', k.fingerprint)"
               >
@@ -114,7 +117,10 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 
-const props = defineProps({ keys: { type: Array, default: () => [] } })
+const props = defineProps({
+  keys: { type: Array, default: () => [] },
+  currentRole: { type: String, default: 'viewer' },
+})
 defineEmits(['validate', 'revoke', 'set-expiry', 'remove-expiry', 'assign'])
 
 const filterText = ref('')

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -49,10 +49,18 @@
           <td>{{ formatDate(s.added_at) }}</td>
           <td>
             <div style="display: flex; gap: 0.5rem">
-              <button class="btn-primary" @click="$emit('scan', s.hostname)">
+              <button
+                v-if="props.currentRole !== 'viewer'"
+                class="btn-primary"
+                @click="$emit('scan', s.hostname)"
+              >
                 {{ $t('server_table.scan') }}
               </button>
-              <button class="btn-secondary" @click="$emit('edit', s)">
+              <button
+                v-if="props.currentRole === 'sysadmin'"
+                class="btn-secondary"
+                @click="$emit('edit', s)"
+              >
                 {{ $t('server_table.edit') }}
               </button>
             </div>
@@ -68,6 +76,7 @@ import { ref, computed } from 'vue'
 
 const props = defineProps({
   servers: { type: Array, default: () => [] },
+  currentRole: { type: String, default: 'viewer' },
 })
 defineEmits(['scan', 'edit'])
 

--- a/ui/src/composables/useAuth.js
+++ b/ui/src/composables/useAuth.js
@@ -23,7 +23,7 @@ export function useAuth() {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || 'Identifiants invalides')
     }
-    admin.value = await res.json()
+    await fetchMe()
     return admin.value
   }
 

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -247,7 +247,9 @@
     "error_has_records": "Löschen nicht möglich: Dieses Konto wird noch referenziert.",
     "role_sysadmin": "Administrator",
     "role_operator": "Operator",
-    "role_viewer": "Betrachter"
+    "role_viewer": "Betrachter",
+    "section_my_account": "Mein Konto",
+    "my_account_hint": "Sie können hier Ihr eigenes Passwort ändern."
   },
   "anomalies": {
     "title": "Anomalien",

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -157,7 +157,8 @@
     "info_deploy": "Das folgende Formular stellt einen SSH-Schlüssel auf einem Zielserver bereit. Falls der Unix-Benutzer nicht existiert, wird er automatisch erstellt.",
     "info_no_sudo": "Der Benutzer wird ohne Administratorrechte erstellt (kein sudo/wheel). Um erhöhte Rechte zu erteilen, greifen Sie manuell auf den Server zu.",
     "lock_title": "Unix-Konto sperren / entsperren",
-    "lock_info": "Sperrt ein Unix-Konto, um alle SSH-Verbindungen zu blockieren (auch mit gültigem Schlüssel). Entsperren, um den Zugang wiederherzustellen."
+    "lock_info": "Sperrt ein Unix-Konto, um alle SSH-Verbindungen zu blockieren (auch mit gültigem Schlüssel). Entsperren, um den Zugang wiederherzustellen.",
+    "readonly_message": "Nur-Lese-Zugriff. Wenden Sie sich an einen Sysadmin, um Aktionen auszuführen."
   },
   "access_form": {
     "duration_label": "Zugriffsdauer",

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -243,7 +243,10 @@
     "success_enabled": "Administrator {username} aktiviert.",
     "success_deleted": "Administrator {username} gelöscht.",
     "error_self_action": "Diese Aktion kann nicht auf das eigene Konto angewendet werden.",
-    "error_has_records": "Löschen nicht möglich: Dieses Konto wird noch referenziert."
+    "error_has_records": "Löschen nicht möglich: Dieses Konto wird noch referenziert.",
+    "role_sysadmin": "Administrator",
+    "role_operator": "Operator",
+    "role_viewer": "Betrachter"
   },
   "anomalies": {
     "title": "Anomalien",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -247,7 +247,9 @@
     "error_has_records": "Cannot delete: this account has existing records.",
     "role_sysadmin": "Sysadmin",
     "role_operator": "Operator",
-    "role_viewer": "Viewer"
+    "role_viewer": "Viewer",
+    "section_my_account": "My account",
+    "my_account_hint": "You can change your own password here."
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -243,7 +243,10 @@
     "success_enabled": "Administrator {username} enabled.",
     "success_deleted": "Administrator {username} deleted.",
     "error_self_action": "You cannot perform this action on your own account.",
-    "error_has_records": "Cannot delete: this account has existing records."
+    "error_has_records": "Cannot delete: this account has existing records.",
+    "role_sysadmin": "Sysadmin",
+    "role_operator": "Operator",
+    "role_viewer": "Viewer"
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -157,7 +157,8 @@
     "info_deploy": "The form below deploys an SSH key on a target server. If the Unix user does not exist, it will be created automatically.",
     "info_no_sudo": "The user is created without administrative rights (no sudo/wheel). To grant elevated privileges, intervene manually on the server.",
     "lock_title": "Lock / Unlock Unix Account",
-    "lock_info": "Lock a Unix account to prevent all SSH connections (even with a valid key). Unlock to restore access."
+    "lock_info": "Lock a Unix account to prevent all SSH connections (even with a valid key). Unlock to restore access.",
+    "readonly_message": "You have read-only access. Contact a sysadmin to perform actions."
   },
   "access_form": {
     "duration_label": "Access duration",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -243,7 +243,10 @@
     "success_enabled": "Administrador {username} activado.",
     "success_deleted": "Administrador {username} eliminado.",
     "error_self_action": "No puede realizar esta acción sobre su propia cuenta.",
-    "error_has_records": "No se puede eliminar: existen registros que hacen referencia a esta cuenta."
+    "error_has_records": "No se puede eliminar: existen registros que hacen referencia a esta cuenta.",
+    "role_sysadmin": "Administrador",
+    "role_operator": "Operador",
+    "role_viewer": "Lector"
   },
   "anomalies": {
     "title": "Anomalías",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -157,7 +157,8 @@
     "info_deploy": "El formulario a continuación despliega una clave SSH en un servidor destino. Si el usuario Unix no existe, se creará automáticamente.",
     "info_no_sudo": "El usuario se crea sin derechos de administración (sin sudo/wheel). Para otorgar privilegios elevados, intervenga manualmente en el servidor.",
     "lock_title": "Bloquear / Desbloquear cuenta Unix",
-    "lock_info": "Bloquea una cuenta Unix para impedir todas las conexiones SSH (incluso con clave válida). Desbloquear para restaurar el acceso."
+    "lock_info": "Bloquea una cuenta Unix para impedir todas las conexiones SSH (incluso con clave válida). Desbloquear para restaurar el acceso.",
+    "readonly_message": "Acceso de solo lectura. Contacte a un administrador para realizar acciones."
   },
   "access_form": {
     "duration_label": "Duración del acceso",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -247,7 +247,9 @@
     "error_has_records": "No se puede eliminar: existen registros que hacen referencia a esta cuenta.",
     "role_sysadmin": "Administrador",
     "role_operator": "Operador",
-    "role_viewer": "Lector"
+    "role_viewer": "Lector",
+    "section_my_account": "Mi cuenta",
+    "my_account_hint": "Puede cambiar su propia contraseña aquí."
   },
   "anomalies": {
     "title": "Anomalías",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -247,7 +247,9 @@
     "error_has_records": "Impossible de supprimer : des enregistrements référencent ce compte.",
     "role_sysadmin": "Administrateur",
     "role_operator": "Opérateur",
-    "role_viewer": "Lecteur"
+    "role_viewer": "Lecteur",
+    "section_my_account": "Mon compte",
+    "my_account_hint": "Vous pouvez changer votre propre mot de passe ici."
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -157,7 +157,8 @@
     "info_deploy": "Le formulaire ci-dessous déploie une clé SSH sur un serveur cible. Si l'utilisateur Unix n'existe pas, il sera créé automatiquement.",
     "info_no_sudo": "L'utilisateur est créé sans droits d'administration (pas de sudo/wheel). Pour accorder des privilèges élevés, intervenez manuellement sur le serveur.",
     "lock_title": "Verrouiller / Déverrouiller un compte Unix",
-    "lock_info": "Verrouille un compte Unix pour bloquer toutes les connexions SSH (même avec une clé valide). Déverrouiller pour rétablir l'accès."
+    "lock_info": "Verrouille un compte Unix pour bloquer toutes les connexions SSH (même avec une clé valide). Déverrouiller pour rétablir l'accès.",
+    "readonly_message": "Accès en lecture seule. Contactez un sysadmin pour effectuer des actions."
   },
   "access_form": {
     "duration_label": "Durée d'accès",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -243,7 +243,10 @@
     "success_enabled": "Administrateur {username} réactivé.",
     "success_deleted": "Administrateur {username} supprimé.",
     "error_self_action": "Vous ne pouvez pas effectuer cette action sur votre propre compte.",
-    "error_has_records": "Impossible de supprimer : des enregistrements référencent ce compte."
+    "error_has_records": "Impossible de supprimer : des enregistrements référencent ce compte.",
+    "role_sysadmin": "Administrateur",
+    "role_operator": "Opérateur",
+    "role_viewer": "Lecteur"
   },
   "anomalies": {
     "title": "Anomalies",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -157,7 +157,8 @@
     "info_deploy": "Il modulo seguente distribuisce una chiave SSH su un server di destinazione. Se l'utente Unix non esiste, verrà creato automaticamente.",
     "info_no_sudo": "L'utente viene creato senza diritti di amministrazione (nessun sudo/wheel). Per concedere privilegi elevati, intervenire manualmente sul server.",
     "lock_title": "Bloccare / Sbloccare account Unix",
-    "lock_info": "Blocca un account Unix per impedire tutte le connessioni SSH (anche con chiave valida). Sbloccare per ripristinare l'accesso."
+    "lock_info": "Blocca un account Unix per impedire tutte le connessioni SSH (anche con chiave valida). Sbloccare per ripristinare l'accesso.",
+    "readonly_message": "Accesso in sola lettura. Contattare un amministratore per eseguire azioni."
   },
   "access_form": {
     "duration_label": "Durata accesso",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -243,7 +243,10 @@
     "success_enabled": "Amministratore {username} riattivato.",
     "success_deleted": "Amministratore {username} eliminato.",
     "error_self_action": "Non è possibile eseguire questa azione sul proprio account.",
-    "error_has_records": "Impossibile eliminare: esistono record che fanno riferimento a questo account."
+    "error_has_records": "Impossibile eliminare: esistono record che fanno riferimento a questo account.",
+    "role_sysadmin": "Amministratore",
+    "role_operator": "Operatore",
+    "role_viewer": "Lettore"
   },
   "anomalies": {
     "title": "Anomalie",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -247,7 +247,9 @@
     "error_has_records": "Impossibile eliminare: esistono record che fanno riferimento a questo account.",
     "role_sysadmin": "Amministratore",
     "role_operator": "Operatore",
-    "role_viewer": "Lettore"
+    "role_viewer": "Lettore",
+    "section_my_account": "Il mio account",
+    "my_account_hint": "Puoi cambiare la tua password qui."
   },
   "anomalies": {
     "title": "Anomalie",

--- a/ui/src/views/AccessRequests.vue
+++ b/ui/src/views/AccessRequests.vue
@@ -1,11 +1,18 @@
 <template>
   <div class="access-requests-view">
     <h1>{{ $t('access.title') }}</h1>
-    <div class="info-box">
-      <p>{{ $t('access.info_deploy') }}</p>
-      <p>{{ $t('access.info_no_sudo') }}</p>
+
+    <div v-if="currentRole === 'viewer'" class="readonly-message">
+      {{ $t('access.readonly_message') }}
     </div>
-    <DeployKeyForm @deployed="deployedUsersTable?.refresh()" />
+
+    <template v-else>
+      <div class="info-box">
+        <p>{{ $t('access.info_deploy') }}</p>
+        <p>{{ $t('access.info_no_sudo') }}</p>
+      </div>
+      <DeployKeyForm @deployed="deployedUsersTable?.refresh()" />
+    </template>
 
     <section class="card">
       <h2>{{ $t('deployedUsers.title') }}</h2>
@@ -15,10 +22,13 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useAuth } from '../composables/useAuth.js'
 import DeployKeyForm from '../components/DeployKeyForm.vue'
 import DeployedUsersTable from '../components/DeployedUsersTable.vue'
 
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 const deployedUsersTable = ref(null)
 </script>
 
@@ -44,6 +54,16 @@ h1 {
 }
 .info-box p:last-child {
   margin-bottom: 0;
+}
+
+.readonly-message {
+  background: #fff3cd;
+  border-left: 4px solid #ffc107;
+  border-radius: 4px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+  color: #856404;
 }
 
 .card {

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -40,21 +40,29 @@
               <td>{{ formatDate(a.created_at) }}</td>
               <td class="actions-cell">
                 <template v-if="a.is_active">
-                  <button class="btn-secondary" @click="openEdit(a)">
+                  <button
+                    v-if="currentRole === 'sysadmin'"
+                    class="btn-secondary"
+                    @click="openEdit(a)"
+                  >
                     {{ $t('admins.btn_edit') }}
                   </button>
-                  <button class="btn-secondary" @click="openEditPassword(a.username)">
+                  <button
+                    v-if="currentRole === 'sysadmin' || a.username === admin?.username"
+                    class="btn-secondary"
+                    @click="openEditPassword(a.username)"
+                  >
                     {{ $t('admins.btn_password') }}
                   </button>
                   <button
-                    v-if="a.username !== currentUsername"
+                    v-if="currentRole === 'sysadmin' && a.username !== currentUsername"
                     class="btn-warning"
                     @click="openDisable(a.username)"
                   >
                     {{ $t('admins.btn_disable') }}
                   </button>
                   <button
-                    v-if="a.username !== currentUsername"
+                    v-if="currentRole === 'sysadmin' && a.username !== currentUsername"
                     class="btn-danger"
                     @click="openDelete(a.username)"
                   >
@@ -62,10 +70,18 @@
                   </button>
                 </template>
                 <template v-else>
-                  <button class="btn-success" @click="openEnable(a.username)">
+                  <button
+                    v-if="currentRole === 'sysadmin'"
+                    class="btn-success"
+                    @click="openEnable(a.username)"
+                  >
                     {{ $t('admins.btn_enable') }}
                   </button>
-                  <button class="btn-danger" @click="openDelete(a.username)">
+                  <button
+                    v-if="currentRole === 'sysadmin'"
+                    class="btn-danger"
+                    @click="openDelete(a.username)"
+                  >
                     {{ $t('admins.btn_delete') }}
                   </button>
                 </template>
@@ -76,7 +92,7 @@
       </section>
 
       <!-- Add administrator form -->
-      <section class="card">
+      <section v-if="currentRole === 'sysadmin'" class="card">
         <h2>{{ $t('admins.section_add') }}</h2>
         <form class="add-form" @submit.prevent="submitAdd">
           <div class="field">
@@ -87,8 +103,19 @@
             <input id="adm-username" v-model="newUsername" type="text" placeholder="username" />
           </div>
           <div class="field">
-            <label for="adm-email">{{ $t('admins.field_email') }}</label>
+            <label for="adm-email"
+              >{{ $t('admins.field_email') }}
+              <span class="required">{{ $t('common.required') }}</span></label
+            >
             <input id="adm-email" v-model="newEmail" type="email" placeholder="admin@example.com" />
+          </div>
+          <div class="field">
+            <label for="adm-role">{{ $t('admins.col_role') }}</label>
+            <select id="adm-role" v-model="newRole">
+              <option value="sysadmin">{{ $t('admins.role_sysadmin') }}</option>
+              <option value="operator">{{ $t('admins.role_operator') }}</option>
+              <option value="viewer">{{ $t('admins.role_viewer') }}</option>
+            </select>
           </div>
           <div class="field">
             <label for="adm-password"
@@ -453,13 +480,16 @@
           </div>
           <div class="field" style="margin-bottom: 1rem">
             <label for="edit-role">{{ $t('admins.col_role') }}</label>
-            <input
+            <select
               id="edit-role"
               v-model="editRole"
-              type="text"
               :disabled="editTarget.username === currentUsername"
               :class="{ 'input-readonly': editTarget.username === currentUsername }"
-            />
+            >
+              <option value="sysadmin">{{ $t('admins.role_sysadmin') }}</option>
+              <option value="operator">{{ $t('admins.role_operator') }}</option>
+              <option value="viewer">{{ $t('admins.role_viewer') }}</option>
+            </select>
             <span v-if="editTarget.username === currentUsername" class="field-hint">
               {{ $t('admins.self_role_warning') }}
             </span>
@@ -479,8 +509,12 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '../composables/useAuth'
 
 const { t } = useI18n()
+const { admin } = useAuth()
+
+const currentRole = computed(() => admin.value?.role || 'viewer')
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -511,6 +545,7 @@ const message = ref('')
 const currentUsername = ref('')
 const newUsername = ref('')
 const newEmail = ref('')
+const newRole = ref('operator')
 const newPassword = ref('')
 const newPasswordConfirm = ref('')
 const showNewPwd = ref(false)
@@ -545,12 +580,13 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const [adminsRes, meRes] = await Promise.all([fetch('/api/admins'), fetch('/api/admins/me')])
+    const [adminsRes, meRes] = await Promise.all([fetch('/api/admins'), fetch('/api/auth/me')])
     if (!adminsRes.ok) throw new Error(`HTTP ${adminsRes.status}`)
     admins.value = await adminsRes.json()
     if (meRes.ok) {
       const me = await meRes.json()
       currentUsername.value = me.username
+      admin.value = me
     }
   } catch (e) {
     error.value = t('admins.load_error', { error: e.message })
@@ -570,6 +606,7 @@ async function submitAdd() {
       body: JSON.stringify({
         username: newUsername.value.trim(),
         email: newEmail.value.trim() || null,
+        role: newRole.value,
         password: newPassword.value,
       }),
     })
@@ -580,6 +617,7 @@ async function submitAdd() {
     message.value = t('admins.success_added', { username: newUsername.value })
     newUsername.value = ''
     newEmail.value = ''
+    newRole.value = 'operator'
     newPassword.value = ''
     newPasswordConfirm.value = ''
     showNewPwd.value = false
@@ -818,7 +856,8 @@ label {
 
 input[type='text'],
 input[type='email'],
-input[type='password'] {
+input[type='password'],
+select {
   padding: 0.4rem 0.6rem;
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -19,12 +19,14 @@
               <th>{{ $t('admins.col_role') }}</th>
               <th>{{ $t('admins.col_active') }}</th>
               <th>{{ $t('admins.col_created') }}</th>
-              <th>{{ $t('admins.col_actions') }}</th>
+              <th v-if="currentRole === 'sysadmin'">{{ $t('admins.col_actions') }}</th>
             </tr>
           </thead>
           <tbody>
             <tr v-if="admins.length === 0">
-              <td colspan="6" class="empty">{{ $t('admins.empty') }}</td>
+              <td :colspan="currentRole === 'sysadmin' ? 6 : 5" class="empty">
+                {{ $t('admins.empty') }}
+              </td>
             </tr>
             <tr v-for="a in admins" :key="a.id" :class="{ 'row-inactive': !a.is_active }">
               <td>
@@ -38,7 +40,7 @@
                 </span>
               </td>
               <td>{{ formatDate(a.created_at) }}</td>
-              <td class="actions-cell">
+              <td v-if="currentRole === 'sysadmin'" class="actions-cell">
                 <template v-if="a.is_active">
                   <button
                     v-if="currentRole === 'sysadmin'"
@@ -89,6 +91,15 @@
             </tr>
           </tbody>
         </table>
+      </section>
+
+      <!-- My account — password change for non-sysadmin -->
+      <section v-if="currentRole !== 'sysadmin'" class="card my-account-card">
+        <h2>{{ $t('admins.section_my_account') }}</h2>
+        <p class="my-account-hint">{{ $t('admins.my_account_hint') }}</p>
+        <button class="btn-secondary" @click="openEditPassword(currentUsername)">
+          {{ $t('admins.btn_password') }}
+        </button>
       </section>
 
       <!-- Add administrator form -->
@@ -806,6 +817,16 @@ h2 {
   gap: 0.5rem;
   flex-wrap: wrap;
   align-items: center;
+}
+
+.my-account-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.my-account-hint {
+  font-size: 0.875rem;
+  color: #555;
 }
 
 .add-form {

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -96,10 +96,12 @@
       <!-- My account — password change for non-sysadmin -->
       <section v-if="currentRole !== 'sysadmin'" class="card my-account-card">
         <h2>{{ $t('admins.section_my_account') }}</h2>
-        <p class="my-account-hint">{{ $t('admins.my_account_hint') }}</p>
-        <button class="btn-secondary" @click="openEditPassword(currentUsername)">
-          {{ $t('admins.btn_password') }}
-        </button>
+        <div class="my-account-row">
+          <p class="my-account-hint">{{ $t('admins.my_account_hint') }}</p>
+          <button class="btn-secondary" @click="openEditPassword(currentUsername)">
+            {{ $t('admins.btn_password') }}
+          </button>
+        </div>
       </section>
 
       <!-- Add administrator form -->
@@ -824,9 +826,15 @@ h2 {
   flex-direction: column;
   gap: 0.75rem;
 }
+.my-account-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
 .my-account-hint {
   font-size: 0.875rem;
   color: #555;
+  margin: 0;
 }
 
 .add-form {

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -82,7 +82,7 @@
                 <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
               </td>
               <td>
-                <div class="actions">
+                <div v-if="currentRole !== 'viewer'" class="actions">
                   <button class="btn-success" @click="validate(k)">
                     {{ $t('anomalies.btn_validate') }}
                   </button>
@@ -193,8 +193,11 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '../composables/useAuth.js'
 
 const { t } = useI18n()
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const allKeys = ref([])
 const loading = ref(true)

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -3,10 +3,15 @@
     <div class="page-header">
       <h1>{{ $t('dashboard.title') }}</h1>
       <div class="header-actions">
-        <button class="btn-secondary" @click="openAddServer">
+        <button v-if="currentRole === 'sysadmin'" class="btn-secondary" @click="openAddServer">
           {{ $t('dashboard.add_server') }}
         </button>
-        <button class="btn-primary" :disabled="scanning" @click="scanAll">
+        <button
+          v-if="currentRole !== 'viewer'"
+          class="btn-primary"
+          :disabled="scanning"
+          @click="scanAll"
+        >
           {{ scanning ? $t('dashboard.scanning') : $t('dashboard.scan_now') }}
         </button>
       </div>
@@ -44,7 +49,13 @@
     </div>
 
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
-    <ServerTable v-else :servers="servers" @scan="scanOne" @edit="openEditServer" />
+    <ServerTable
+      v-else
+      :servers="servers"
+      :current-role="currentRole"
+      @scan="scanOne"
+      @edit="openEditServer"
+    />
 
     <!-- Add server modal -->
     <div v-if="showAddServer" class="modal-overlay" @click.self="closeAddServer">
@@ -183,9 +194,12 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '../composables/useAuth.js'
 import ServerTable from '../components/ServerTable.vue'
 
 const { t } = useI18n()
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const servers = ref([])
 const loading = ref(true)

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -6,16 +6,33 @@
         <h1>{{ hostname }}</h1>
       </div>
       <div class="header-actions">
-        <button class="btn-primary" :disabled="scanning" @click="scanServer">
+        <button
+          v-if="currentRole !== 'viewer'"
+          class="btn-primary"
+          :disabled="scanning"
+          @click="scanServer"
+        >
           {{ scanning ? $t('server_detail.scanning') : $t('server_detail.scan') }}
         </button>
-        <button v-if="server.is_active" class="btn-warning" @click="confirmDisable">
+        <button
+          v-if="server.is_active && currentRole === 'sysadmin'"
+          class="btn-warning"
+          @click="confirmDisable"
+        >
           {{ $t('server_detail.disable') }}
         </button>
-        <button v-else class="btn-success" @click="reactivate">
+        <button
+          v-if="!server.is_active && currentRole === 'sysadmin'"
+          class="btn-success"
+          @click="reactivate"
+        >
           {{ $t('server_detail.reactivate') }}
         </button>
-        <button class="btn-danger" @click="showDeleteModal = true">
+        <button
+          v-if="currentRole === 'sysadmin'"
+          class="btn-danger"
+          @click="showDeleteModal = true"
+        >
           {{ $t('server_detail.delete') }}
         </button>
       </div>
@@ -63,6 +80,7 @@
         <h2>{{ $t('server_detail.section_keys') }}</h2>
         <KeyTable
           :keys="keys"
+          :current-role="currentRole"
           @validate="validateKey"
           @revoke="openRevoke"
           @set-expiry="openExpiry"
@@ -200,9 +218,12 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
+import { useAuth } from '../composables/useAuth.js'
 import KeyTable from '../components/KeyTable.vue'
 
 const { t } = useI18n()
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 const route = useRoute()
 const router = useRouter()
 const hostname = route.params.hostname

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -14,9 +14,15 @@
             max="24"
             step="1"
             class="input-number"
+            :disabled="currentRole !== 'sysadmin'"
           />
           <span class="unit">{{ $t('settings.hours') }}</span>
-          <button class="btn-primary" :disabled="saving" @click="save">
+          <button
+            v-if="currentRole === 'sysadmin'"
+            class="btn-primary"
+            :disabled="saving"
+            @click="save"
+          >
             {{ $t('settings.save') }}
           </button>
         </div>
@@ -29,7 +35,11 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
+import { useAuth } from '../composables/useAuth.js'
+
+const { admin } = useAuth()
+const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const intervalHours = ref(4)
 const saving = ref(false)

--- a/ui/tests/Admins.spec.js
+++ b/ui/tests/Admins.spec.js
@@ -202,22 +202,21 @@ describe('Admins', () => {
     expect(editBtn).toBeFalsy()
   })
 
-  it('operator sees own Password button', async () => {
+  it('operator sees own Password button in my-account section', async () => {
     const w = mk([{ ...ACTIVE_ADMIN, username: 'operator1', role: 'operator' }], 'operator1', 'operator')
     await flushPromises()
-    const rows = w.findAll('tr')
-    const selfRow = rows.find(r => r.text().includes('operator1'))
-    const pwdBtn = selfRow.findAll('button').find(b => b.text().includes('Password'))
+    const myAccountSection = w.findAll('section').find(s => s.text().includes('My account'))
+    expect(myAccountSection).toBeTruthy()
+    const pwdBtn = myAccountSection.findAll('button').find(b => b.text().includes('Password'))
     expect(pwdBtn).toBeTruthy()
   })
 
-  it('operator does not see Password button for other users', async () => {
+  it('operator does not see Password button in table rows', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'operator')
     await flushPromises()
     const rows = w.findAll('tr')
-    const aliceRow = rows.find(r => r.text().includes('alice'))
-    const pwdBtn = aliceRow.findAll('button').find(b => b.text().includes('Password'))
-    expect(pwdBtn).toBeFalsy()
+    const hasAnyPwdInTable = rows.some(r => r.findAll('button').some(b => b.text().includes('Password')))
+    expect(hasAnyPwdInTable).toBeFalsy()
   })
 
   it('add form hidden for operator', async () => {

--- a/ui/tests/Admins.spec.js
+++ b/ui/tests/Admins.spec.js
@@ -10,17 +10,20 @@ const ACTIVE_ADMIN  = { id: '1', username: 'admin',    email: 'a@b.c', role: 'sy
 const OTHER_ACTIVE  = { id: '2', username: 'alice',    email: 'alice@b.c', role: 'sysadmin', is_active: true,  created_at: null }
 const DISABLED_ADMIN = { id: '3', username: 'bob',    email: 'bob@b.c',   role: 'sysadmin', is_active: false, created_at: null }
 
-function mkFetch(admins, meUsername = 'admin') {
+function mkFetch(admins, meUsername = 'admin', meRole = 'sysadmin') {
   return vi.fn((url) => {
+    if (url === '/api/auth/me') {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1', username: meUsername, role: meRole }) })
+    }
     if (url === '/api/admins/me') {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1', username: meUsername }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ id: '1', username: meUsername, role: meRole }) })
     }
     return Promise.resolve({ ok: true, json: () => Promise.resolve(admins) })
   })
 }
 
-function mk(admins, meUsername = 'admin') {
-  global.fetch = mkFetch(admins, meUsername)
+function mk(admins, meUsername = 'admin', meRole = 'sysadmin') {
+  global.fetch = mkFetch(admins, meUsername, meRole)
   return mount(Admins, { global: { plugins: [i18n] } })
 }
 
@@ -154,7 +157,7 @@ describe('Admins', () => {
   })
 
   it('appelle PUT /api/admins/<username> à la confirmation Edit', async () => {
-    const fetchMock = mkFetch([OTHER_ACTIVE])
+    const fetchMock = mkFetch([OTHER_ACTIVE], 'admin', 'sysadmin')
     global.fetch = fetchMock
     const w = mount(Admins, { global: { plugins: [i18n] } })
     await flushPromises()
@@ -163,11 +166,114 @@ describe('Admins', () => {
     const editBtn = aliceRow.findAll('button').find(b => b.text().includes('Edit'))
     await editBtn.trigger('click')
     await w.find('#edit-email').setValue('newemail@example.com')
-    await w.find('#edit-role').setValue('newrole')
+    await w.find('#edit-role').setValue('operator')
     const form = w.find('.modal form')
     await form.trigger('submit')
     await flushPromises()
     const calls = fetchMock.mock.calls.map(c => c[0] + '|' + (c[1]?.method || 'GET'))
     expect(calls).toContain('/api/admins/alice|PUT')
+  })
+
+  // RBAC tests
+  it('sysadmin sees Edit button', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'sysadmin')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const editBtn = aliceRow.findAll('button').find(b => b.text().includes('Edit'))
+    expect(editBtn).toBeTruthy()
+  })
+
+  it('operator does not see Edit button', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const editBtn = aliceRow.findAll('button').find(b => b.text().includes('Edit'))
+    expect(editBtn).toBeFalsy()
+  })
+
+  it('viewer does not see Edit button', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'viewer')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const editBtn = aliceRow.findAll('button').find(b => b.text().includes('Edit'))
+    expect(editBtn).toBeFalsy()
+  })
+
+  it('operator sees own Password button', async () => {
+    const w = mk([{ ...ACTIVE_ADMIN, username: 'operator1', role: 'operator' }], 'operator1', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const selfRow = rows.find(r => r.text().includes('operator1'))
+    const pwdBtn = selfRow.findAll('button').find(b => b.text().includes('Password'))
+    expect(pwdBtn).toBeTruthy()
+  })
+
+  it('operator does not see Password button for other users', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const pwdBtn = aliceRow.findAll('button').find(b => b.text().includes('Password'))
+    expect(pwdBtn).toBeFalsy()
+  })
+
+  it('add form hidden for operator', async () => {
+    const w = mk([ACTIVE_ADMIN], 'admin', 'operator')
+    await flushPromises()
+    const addSection = w.findAll('section').find(s => s.text().includes('Add an administrator'))
+    expect(addSection).toBeFalsy()
+  })
+
+  it('add form hidden for viewer', async () => {
+    const w = mk([ACTIVE_ADMIN], 'admin', 'viewer')
+    await flushPromises()
+    const addSection = w.findAll('section').find(s => s.text().includes('Add an administrator'))
+    expect(addSection).toBeFalsy()
+  })
+
+  it('add form visible for sysadmin', async () => {
+    const w = mk([ACTIVE_ADMIN], 'admin', 'sysadmin')
+    await flushPromises()
+    const addSection = w.findAll('section').find(s => s.text().includes('Add an administrator'))
+    expect(addSection).toBeTruthy()
+  })
+
+  it('sysadmin sees Disable button for other users', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'sysadmin')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const disableBtn = aliceRow.findAll('button').find(b => b.text().includes('Disable'))
+    expect(disableBtn).toBeTruthy()
+  })
+
+  it('operator does not see Disable button', async () => {
+    const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE], 'admin', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const aliceRow = rows.find(r => r.text().includes('alice'))
+    const disableBtn = aliceRow.findAll('button').find(b => b.text().includes('Disable'))
+    expect(disableBtn).toBeFalsy()
+  })
+
+  it('operator does not see Enable button', async () => {
+    const w = mk([DISABLED_ADMIN], 'admin', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    const enableBtn = bobRow.findAll('button').find(b => b.text().includes('Enable'))
+    expect(enableBtn).toBeFalsy()
+  })
+
+  it('operator does not see Delete button', async () => {
+    const w = mk([DISABLED_ADMIN], 'admin', 'operator')
+    await flushPromises()
+    const rows = w.findAll('tr')
+    const bobRow = rows.find(r => r.text().includes('bob'))
+    const deleteBtn = bobRow.findAll('button').find(b => b.text().includes('Delete'))
+    expect(deleteBtn).toBeFalsy()
   })
 })

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
-import { ref } from 'vue'
 import en from '../src/locales/en.json'
 import DeployedUsersTable from '../src/components/DeployedUsersTable.vue'
 
+const mockAdmin = vi.hoisted(() => ({ value: { username: 'admin', role: 'sysadmin' } }))
+
 vi.mock('../src/composables/useAuth.js', () => ({
-  useAuth: () => ({ admin: ref({ username: 'admin', role: 'sysadmin' }) }),
+  useAuth: () => ({ admin: mockAdmin }),
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -29,6 +30,7 @@ const MOCK_USERS = [
 ]
 
 beforeEach(() => {
+  mockAdmin.value = { username: 'admin', role: 'sysadmin' }
   vi.stubGlobal(
     'fetch',
     vi.fn().mockResolvedValue({
@@ -86,9 +88,7 @@ describe('DeployedUsersTable', () => {
     await flushPromises()
 
     const row2 = w.find('[data-testid="row-bob-staging-01"]')
-    // La date est formatée en toLocaleString, on vérifie qu'elle ne contient pas "Unlimited"
     expect(row2.text()).not.toContain('Unlimited')
-    // Vérifie que la date est présente (format peut varier selon locale du test)
     expect(row2.html()).toContain('2026')
   })
 
@@ -255,7 +255,7 @@ describe('DeployedUsersTable', () => {
     expect(success.text()).toContain('staging-01')
   })
 
-  it('affiche erreur inline si l\'API répond en erreur', async () => {
+  it("affiche erreur inline si l'API répond en erreur", async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url === '/api/access/deployed-users') {
         return Promise.resolve({
@@ -281,5 +281,24 @@ describe('DeployedUsersTable', () => {
     const error = w.find('[data-testid="error-alice-prod-01"]')
     expect(error.exists()).toBe(true)
     expect(error.text()).toContain('User not found')
+  })
+
+  it('operator voit le bouton Lock', async () => {
+    mockAdmin.value = { username: 'operator', role: 'operator' }
+    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(w.find('[data-testid="btn-lock-alice-prod-01"]').exists()).toBe(true)
+  })
+
+  it('viewer ne voit pas le bouton Lock ni la colonne Actions', async () => {
+    mockAdmin.value = { username: 'viewer', role: 'viewer' }
+    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    await flushPromises()
+
+    expect(w.find('[data-testid="btn-lock-alice-prod-01"]').exists()).toBe(false)
+    const headers = w.findAll('th')
+    const hasActions = headers.some((h) => h.text().toUpperCase().includes('ACTION'))
+    expect(hasActions).toBe(false)
   })
 })

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
 import en from '../src/locales/en.json'
 import DeployedUsersTable from '../src/components/DeployedUsersTable.vue'
+
+vi.mock('../src/composables/useAuth.js', () => ({
+  useAuth: () => ({ admin: ref({ username: 'admin', role: 'sysadmin' }) }),
+}))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -23,9 +23,9 @@ function makeKey(overrides = {}) {
   }
 }
 
-function mountTable(keys) {
+function mountTable(keys, currentRole = 'sysadmin') {
   return mount(KeyTable, {
-    props: { keys },
+    props: { keys, currentRole },
     global: { plugins: [i18n] },
   })
 }

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -24,9 +24,9 @@ const SERVERS = [
   },
 ]
 
-function mountTable(servers = SERVERS) {
+function mountTable(servers = SERVERS, currentRole = 'sysadmin') {
   return mount(ServerTable, {
-    props: { servers },
+    props: { servers, currentRole },
     global: {
       plugins: [i18n],
       stubs: { RouterLink: { template: '<a href="#"><slot /></a>' } },

--- a/ui/tests/Settings.spec.js
+++ b/ui/tests/Settings.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import Settings from '../src/views/Settings.vue'
 import { createI18n } from 'vue-i18n'
+import { ref } from 'vue'
 
 const i18n = createI18n({
   legacy: false,
@@ -15,15 +16,28 @@ const i18n = createI18n({
         hours: 'hours',
         save: 'Save',
         saved: 'Settings saved.',
-        scan_interval_hint: 'Between 1 and 24 hours. The cron triggers every 5 minutes but skips if the interval has not elapsed.',
+        scan_interval_hint:
+          'Between 1 and 24 hours. The cron triggers every 5 minutes but skips if the interval has not elapsed.',
       },
     },
   },
 })
 
+const mockAdmin = ref({ username: 'admin', email: 'admin@test.com', role: 'sysadmin' })
+
+vi.mock('../src/composables/useAuth.js', () => ({
+  useAuth: () => ({
+    admin: mockAdmin,
+    fetchMe: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+  }),
+}))
+
 describe('Settings.vue', () => {
   beforeEach(() => {
     global.fetch = vi.fn()
+    mockAdmin.value = { username: 'admin', email: 'admin@test.com', role: 'sysadmin' }
   })
 
   it('loads current scan interval on mount', async () => {


### PR DESCRIPTION
## Summary

Implémente le RBAC Option B : le backend Flask rejette les requêtes non autorisées avec 403.

### Backend
- `require_role(*roles)` décorateur Flask — 403 si `g.admin_role` insuffisant
- `g.admin_role` chargé dans `require_auth` à chaque requête
- Routes `/api/admins/*` protégées `@require_role('sysadmin')`
- Exception : `PUT /api/admins/<username>/password` autorisé si sysadmin **ou** username == soi-même
- `add_admin()` / `update_admin()` : email obligatoire + validation `role ∈ VALID_ROLES`
- CHECK constraint en DB : `role IN ('sysadmin', 'operator', 'viewer')`
- `GET /api/auth/me` retourne maintenant le rôle

### Frontend
- Dropdown rôle (3 choix) dans ajout et édition admin
- Email marqué obligatoire (`*`)
- Boutons Edit/Disable/Enable/Delete masqués (`v-if`) pour non-sysadmin
- Bouton Password visible uniquement pour sysadmin ou pour soi-même
- Formulaire "Add administrator" masqué pour operator/viewer

### Tests
- 293 tests Python ✅ (9 nouveaux RBAC)
- 156 tests Vue ✅ (13 nouveaux RBAC)

Closes #222