### PR TITLE
feat: session timeout with keep-me-logged-in checkbox (issue #239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,6 +514,13 @@ Décorateur require_auth sur toutes les routes protégées.
 Retourne 401 JSON si session manquante.
 Charge g.admin_id, g.admin_username, g.admin_role à chaque requête.
 
+Timeout de session (issue #239) :
+- Sans coche "Keep me logged on this device" → expire après SESSION_SHORT_MINUTES (30 min)
+- Avec coche → expire après SESSION_LONG_HOURS (8h)
+- `session["expires_at"]` (timestamp UTC) posé au login, vérifié dans require_auth
+- Session expirée → clear session + 401 {"error": "Session expired"}
+- Durées hardcodées comme constantes dans web.py (pas de settings table)
+
 RBAC — décorateur require_role(*roles) (issue #222) :
 Retourne 403 JSON si g.admin_role ∉ roles.
 
@@ -762,6 +769,9 @@ test_web.py :
 - PUT /api/admins/<username> retourne 200/401/403/404
 - POST /api/system/test-smtp retourne 200/400/401/500/502
 - GET /api/system/collector-key retourne {public_key, ssh_user}
+- GET /api/* retourne 401 si session expirée (expires_at dans le passé)
+- POST /api/auth/login sans remember_me → expires_at dans ~30 min
+- POST /api/auth/login avec remember_me=true → expires_at dans ~8h
 
 ### Tests frontend — Vitest
 
@@ -776,6 +786,7 @@ ui/tests/
     UserLockForm.spec.js       ← verrouillage/déverrouillage compte Unix (10 tests)
     DeployedUsersTable.spec.js ← tableau utilisateurs déployés, filtres, RBAC operator/viewer (12 tests)
     Anomalies.spec.js          ← filtres texte + dropdowns type/serveur/conformité, unix_user, badges (20 tests)
+    Login.spec.js              ← checkbox remember-me, payload remember_me (8 tests)
 
 ### Ce qui n'est PAS testé unitairement
 
@@ -968,7 +979,7 @@ POST /api/system/test-smtp          ← envoie un email de test à l'adresse de 
 ## Interface Vue.js 3 — vues
 
 ui/src/views/
-    Login.vue           ← page de connexion (issue #53)
+    Login.vue           ← page de connexion + checkbox "Keep me logged on this device" (issues #53, #239)
     Dashboard.vue       ← tableau serveurs + recherche + compteurs
                           + modal ajout serveur (issue #71)
                           + affichage clé collecteur (issue #74)

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -873,6 +873,14 @@ L'état en mémoire est perdu au redémarrage du conteneur, mais la combinaison
 (limitation applicative éphémère + audit_log permanent + fail2ban optionnel)
 couvre les trois couches : applicative, traçabilité, réseau.
 
+### Timeout de session (issue #239)
+
+Deux durées de session selon le choix de l'utilisateur au login :
+- **30 minutes** (défaut) — session courte, sans "Keep me logged on this device"
+- **8 heures** — session longue, avec la checkbox cochée
+
+Implémentation : `session["expires_at"]` (timestamp UTC float) posé dans `auth_login()`, vérifié dans `require_auth` avant chaque requête protégée. Session expirée → `session.clear()` + HTTP 401. Durées hardcodées comme constantes `SESSION_SHORT_MINUTES = 30` et `SESSION_LONG_HOURS = 8` dans `web.py` — pas de dépendance à la table `settings`, pas de redémarrage nécessaire.
+
 ### Vue AccessRequests — formulaires DeployKeyForm et UserLockForm
 
 La vue `AccessRequests.vue` expose deux formulaires :

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Ces logs structurés facilitent l'intégration avec des systèmes de détection 
 
 ---
 
+## Gestion de session
+
+La durée de session est contrôlée par une checkbox sur la page de connexion :
+
+| Mode | Durée |
+|------|-------|
+| Sans coche | 30 minutes |
+| "Keep me logged on this device" | 8 heures |
+
+À l'expiration, les routes protégées retournent HTTP 401 et l'UI redirige vers `/login`.
+Les durées sont des constantes dans `web.py` — pas de redémarrage nécessaire pour les modifier en dev.
+
+---
+
 ## Workflow — Ajout d'un serveur distant
 
 ### 1. Provisionner l'hôte distant

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -1373,3 +1373,92 @@ def test_web_config_login_ban_seconds_too_low(auth_client):
         mock_db.query_one.return_value = _admin_row()
         resp = auth_client.put("/api/system/config", json={"login_ban_seconds": 10})
     assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Session timeout
+# ---------------------------------------------------------------------------
+
+def test_web_session_expired_returns_401(client):
+    """Expired session returns 401."""
+    past = datetime.now(timezone.utc).timestamp() - 1
+    with client.session_transaction() as sess:
+        sess["admin_id"] = ADMIN_ID
+        sess["admin_username"] = "admin"
+        sess["expires_at"] = past
+    with patch("web.db") as mock_db:
+        resp = client.get("/api/keys")
+    assert resp.status_code == 401
+    data = resp.get_json()
+    assert data["error"] == "Session expired"
+
+
+def test_web_session_not_expired_passes(client):
+    """Session with future expiry passes through require_auth."""
+    future = datetime.now(timezone.utc).timestamp() + 3600
+    with client.session_transaction() as sess:
+        sess["admin_id"] = ADMIN_ID
+        sess["admin_username"] = "admin"
+        sess["expires_at"] = future
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = []
+        resp = client.get("/api/keys")
+    assert resp.status_code == 200
+
+
+def test_web_session_no_expiry_field_passes(client):
+    """Session without expires_at (legacy) passes — no regression."""
+    with client.session_transaction() as sess:
+        sess["admin_id"] = ADMIN_ID
+        sess["admin_username"] = "admin"
+        # no expires_at
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = []
+        resp = client.get("/api/keys")
+    assert resp.status_code == 200
+
+
+def test_web_login_without_remember_me_sets_short_expiry(client):
+    """Login without remember_me sets expires_at ~30 minutes from now."""
+    web._login_attempts.clear()
+    with patch("web.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"value": "10"},
+            {"value": "300"},
+            {"id": ADMIN_ID, "username": "admin", "password_hash": "pbkdf2:sha256:hash"},
+        ]
+        with patch("web.check_password_hash", return_value=True):
+            resp = client.post(
+                "/api/auth/login",
+                json={"username": "admin", "password": "correct"},
+            )
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        expires_at = sess.get("expires_at")
+    now = datetime.now(timezone.utc).timestamp()
+    expected = now + web.SESSION_SHORT_MINUTES * 60
+    assert abs(expires_at - expected) < 5  # within 5 seconds
+
+
+def test_web_login_with_remember_me_sets_long_expiry(client):
+    """Login with remember_me=True sets expires_at ~8 hours from now."""
+    web._login_attempts.clear()
+    with patch("web.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"value": "10"},
+            {"value": "300"},
+            {"id": ADMIN_ID, "username": "admin", "password_hash": "pbkdf2:sha256:hash"},
+        ]
+        with patch("web.check_password_hash", return_value=True):
+            resp = client.post(
+                "/api/auth/login",
+                json={"username": "admin", "password": "correct", "remember_me": True},
+            )
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        expires_at = sess.get("expires_at")
+    now = datetime.now(timezone.utc).timestamp()
+    expected = now + web.SESSION_LONG_HOURS * 3600
+    assert abs(expires_at - expected) < 5

--- a/app/web.py
+++ b/app/web.py
@@ -80,6 +80,13 @@ def _reset_attempts(ip: str) -> None:
         _login_attempts.pop(ip, None)
 
 
+# ---------------------------------------------------------------------------
+# Session timeout — constantes (pas de config DB, pas de UI)
+# ---------------------------------------------------------------------------
+SESSION_SHORT_MINUTES = 30   # sans "remember me"
+SESSION_LONG_HOURS = 8       # avec "remember me"
+
+
 app = Flask(__name__)
 _flask_secret = os.environ.get("FLASK_SECRET_KEY")
 if not _flask_secret:
@@ -99,6 +106,11 @@ def require_auth(f):
         admin_id = session.get("admin_id")
         if not admin_id:
             return jsonify({"error": "Unauthorized"}), 401
+        # Check session expiry
+        expires_at = session.get("expires_at")
+        if expires_at and datetime.now(timezone.utc).timestamp() > expires_at:
+            session.clear()
+            return jsonify({"error": "Session expired"}), 401
         admin = db.query_one(
             "SELECT id, username, role FROM administrators WHERE id = %s AND is_active = true",
             (admin_id,),
@@ -170,9 +182,13 @@ def auth_login():
         return jsonify({"error": "Invalid credentials"}), 401
 
     _reset_attempts(ip)
+    remember_me = bool(data.get("remember_me", False))
+    expires_delta = SESSION_LONG_HOURS * 3600 if remember_me else SESSION_SHORT_MINUTES * 60
+    expires_at = datetime.now(timezone.utc).timestamp() + expires_delta
     session.clear()
     session["admin_id"] = str(admin["id"])
     session["admin_username"] = admin["username"]
+    session["expires_at"] = expires_at
     return jsonify({"username": admin["username"]}), 200
 
 

--- a/ui/src/composables/useAuth.js
+++ b/ui/src/composables/useAuth.js
@@ -13,11 +13,11 @@ export function useAuth() {
     return admin.value
   }
 
-  async function login(username, password) {
+  async function login(username, password, rememberMe = false) {
     const res = await fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, remember_me: rememberMe }),
     })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -19,6 +19,7 @@
     "username": "Benutzername",
     "username_placeholder": "admin",
     "password": "Passwort",
+    "remember_me": "Angemeldet bleiben",
     "submit": "Anmelden",
     "submitting": "Anmeldung…"
   },

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -19,6 +19,7 @@
     "username": "Username",
     "username_placeholder": "admin",
     "password": "Password",
+    "remember_me": "Keep me logged on this device",
     "submit": "Sign in",
     "submitting": "Signing in…"
   },

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -19,6 +19,7 @@
     "username": "Usuario",
     "username_placeholder": "admin",
     "password": "Contraseña",
+    "remember_me": "Mantenerme conectado",
     "submit": "Entrar",
     "submitting": "Entrando…"
   },

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -19,6 +19,7 @@
     "username": "Username",
     "username_placeholder": "admin",
     "password": "Mot de passe",
+    "remember_me": "Rester connecté",
     "submit": "Se connecter",
     "submitting": "Connexion…"
   },

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -19,6 +19,7 @@
     "username": "Nome utente",
     "username_placeholder": "admin",
     "password": "Password",
+    "remember_me": "Ricordami",
     "submit": "Accedi",
     "submitting": "Accesso…"
   },

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -29,6 +29,13 @@
           />
         </div>
 
+        <div class="field field-checkbox">
+          <label class="checkbox-label">
+            <input type="checkbox" v-model="rememberMe" :disabled="loading" />
+            {{ $t('auth.remember_me') }}
+          </label>
+        </div>
+
         <div v-if="error" class="alert-error">{{ error }}</div>
 
         <button type="submit" class="btn-primary btn-full" :disabled="loading || !canSubmit">
@@ -49,6 +56,7 @@ const { login } = useAuth()
 
 const username = ref('')
 const password = ref('')
+const rememberMe = ref(false)
 const error = ref('')
 const loading = ref(false)
 
@@ -58,7 +66,7 @@ async function submit() {
   error.value = ''
   loading.value = true
   try {
-    await login(username.value.trim(), password.value)
+    await login(username.value.trim(), password.value, rememberMe.value)
     router.push('/')
   } catch (e) {
     error.value = e.message
@@ -114,9 +122,25 @@ form {
   flex-direction: column;
   gap: 0.3rem;
 }
+.field-checkbox {
+  flex-direction: row;
+  align-items: center;
+}
 label {
   font-size: 0.85rem;
   font-weight: 600;
+}
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: normal;
+  cursor: pointer;
+}
+.checkbox-label input[type='checkbox'] {
+  width: auto;
+  cursor: pointer;
 }
 
 input {

--- a/ui/tests/Login.spec.js
+++ b/ui/tests/Login.spec.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import en from '../src/locales/en.json'
+import Login from '../src/views/Login.vue'
+
+const loginMock = vi.fn().mockResolvedValue({})
+
+vi.mock('../src/composables/useAuth.js', () => ({
+  useAuth: () => ({
+    login: loginMock,
+  }),
+}))
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', component: { template: '<div>Home</div>' } },
+    { path: '/login', component: Login },
+  ],
+})
+
+function mk() {
+  return mount(Login, {
+    global: {
+      plugins: [i18n, router],
+    },
+  })
+}
+
+describe('Login', () => {
+  beforeEach(() => {
+    loginMock.mockClear()
+    loginMock.mockResolvedValue({})
+  })
+
+  it('renders the checkbox on the login form', () => {
+    const w = mk()
+    const checkbox = w.find('input[type="checkbox"]')
+    expect(checkbox.exists()).toBe(true)
+  })
+
+  it('checkbox is unchecked by default', () => {
+    const w = mk()
+    const checkbox = w.find('input[type="checkbox"]')
+    expect(checkbox.element.checked).toBe(false)
+  })
+
+  it('login call without checkbox sends remember_me: false', async () => {
+    const w = mk()
+    await w.find('#username').setValue('admin')
+    await w.find('#password').setValue('password')
+    await w.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(loginMock).toHaveBeenCalledWith('admin', 'password', false)
+  })
+
+  it('login call with checkbox checked sends remember_me: true', async () => {
+    const w = mk()
+    await w.find('#username').setValue('admin')
+    await w.find('#password').setValue('password')
+    await w.find('input[type="checkbox"]').setValue(true)
+    await w.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(loginMock).toHaveBeenCalledWith('admin', 'password', true)
+  })
+
+  it('shows error message on failed login', async () => {
+    loginMock.mockRejectedValueOnce(new Error('Invalid credentials'))
+
+    const w = mk()
+    await w.find('#username').setValue('admin')
+    await w.find('#password').setValue('wrong')
+    await w.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(w.find('.alert-error').exists()).toBe(true)
+    expect(w.find('.alert-error').text()).toContain('Invalid credentials')
+  })
+
+  it('submit button disabled when fields are empty', () => {
+    const w = mk()
+    const submitButton = w.find('button[type="submit"]')
+    expect(submitButton.element.disabled).toBe(true)
+  })
+
+  it('submit button enabled when fields are filled', async () => {
+    const w = mk()
+    await w.find('#username').setValue('admin')
+    await w.find('#password').setValue('password')
+    await flushPromises()
+
+    const submitButton = w.find('button[type="submit"]')
+    expect(submitButton.element.disabled).toBe(false)
+  })
+
+  it('checkbox displays the correct label from i18n', () => {
+    const w = mk()
+    const label = w.find('.checkbox-label')
+    expect(label.text()).toContain('Keep me logged on this device')
+  })
+})


### PR DESCRIPTION
## Summary

- Checkbox "Keep me logged on this device" on the login page
- **Without checkbox**: session expires after **30 minutes** → HTTP 401 → redirect to `/login`
- **With checkbox**: session expires after **8 hours**
- `session["expires_at"]` (UTC timestamp) stored at login, checked in `require_auth` before every protected request
- Expired session clears itself and returns `{"error": "Session expired"}` with HTTP 401
- Durations hardcoded as constants (`SESSION_SHORT_MINUTES = 30`, `SESSION_LONG_HOURS = 8`) — no settings table entry, no container restart needed

## Test plan

- [x] 5 new pytest tests: expired session → 401, future expiry → 200, no expiry field → 200 (no regression), short/long duration set correctly
- [x] 8 new Vitest tests (`Login.spec.js`): checkbox renders, unchecked by default, `remember_me: false/true` in payload, error display, submit disabled state
- [x] All 397 Python tests pass, all 183 Vitest tests pass
- [x] Prettier clean
- [x] CLAUDE.md, README.md, DESIGN.md updated

Closes #239