### PR TITLE
feat: add client-side pagination to all tables

### DIFF
--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -40,7 +40,7 @@
         </thead>
         <tbody>
           <tr
-            v-for="user in filteredUsers"
+            v-for="user in paginatedItems"
             :key="`${user.unix_user}-${user.hostname}`"
             :data-testid="`row-${user.unix_user}-${user.hostname}`"
           >
@@ -109,6 +109,16 @@
           </tr>
         </tbody>
       </table>
+
+      <PaginationBar
+        v-if="filteredUsers.length > 0"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :total-items="totalItems"
+        :page-size="pageSize"
+        @update:current-page="currentPage = $event"
+        @update:page-size="setPageSize"
+      />
     </template>
 
     <div v-else class="empty-state" data-testid="empty-state">
@@ -122,6 +132,8 @@ import { ref, computed, onMounted, defineExpose } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
@@ -154,6 +166,9 @@ const filteredUsers = computed(() => {
     return true
   })
 })
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filteredUsers)
 
 onMounted(async () => {
   await loadUsers()

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -43,7 +43,7 @@
             {{ $t('key_table.no_results') }}
           </td>
         </tr>
-        <tr v-for="k in filteredKeys" :key="k.fingerprint + '|' + (k.unix_user || '')">
+        <tr v-for="k in paginatedItems" :key="k.fingerprint + '|' + (k.unix_user || '')">
           <td>
             <span class="badge" :class="statusBadge(k.status)">{{ k.status }}</span>
           </td>
@@ -109,6 +109,16 @@
         </tr>
       </tbody>
     </table>
+
+    <PaginationBar
+      v-if="filteredKeys.length > 0"
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      :total-items="totalItems"
+      :page-size="pageSize"
+      @update:current-page="currentPage = $event"
+      @update:page-size="setPageSize"
+    />
   </div>
 </template>
 
@@ -116,6 +126,8 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
 
 const { t } = useI18n()
 const { formatDate } = useFormatDate()
@@ -142,6 +154,9 @@ const filteredKeys = computed(() => {
     )
   })
 })
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filteredKeys)
 
 function complianceTooltip(k) {
   if (k.key_type === 'ssh-rsa') {

--- a/ui/src/components/PaginationBar.vue
+++ b/ui/src/components/PaginationBar.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="pagination-bar">
+    <div class="pagination-left">
+      <label for="page-size" class="page-size-label"> {{ $t('pagination.rowsPerPage') }}: </label>
+      <select
+        id="page-size"
+        :value="pageSize"
+        class="page-size-select"
+        @change="$emit('update:pageSize', parseInt($event.target.value))"
+      >
+        <option v-for="size in pageSizes" :key="size" :value="size">{{ size }}</option>
+      </select>
+
+      <span class="showing-info">
+        {{ $t('pagination.showing', { from, to, total: totalItems }) }}
+      </span>
+    </div>
+
+    <div class="pagination-right">
+      <button
+        class="btn-pagination"
+        :disabled="currentPage === 1"
+        @click="$emit('update:currentPage', currentPage - 1)"
+      >
+        {{ $t('pagination.previous') }}
+      </button>
+      <button
+        class="btn-pagination"
+        :disabled="currentPage === totalPages"
+        @click="$emit('update:currentPage', currentPage + 1)"
+      >
+        {{ $t('pagination.next') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  currentPage: { type: Number, required: true },
+  totalPages: { type: Number, required: true },
+  totalItems: { type: Number, required: true },
+  pageSize: { type: Number, required: true },
+  pageSizes: { type: Array, default: () => [10, 20, 40, 50, 100] },
+})
+
+defineEmits(['update:currentPage', 'update:pageSize'])
+
+const from = computed(() => {
+  if (props.totalItems === 0) return 0
+  return (props.currentPage - 1) * props.pageSize + 1
+})
+
+const to = computed(() => {
+  const end = props.currentPage * props.pageSize
+  return Math.min(end, props.totalItems)
+})
+</script>
+
+<style scoped>
+.pagination-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 0;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.pagination-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pagination-right {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.page-size-label {
+  font-size: 0.875rem;
+  color: #444;
+}
+
+.page-size-select {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.showing-info {
+  font-size: 0.875rem;
+  color: #666;
+}
+
+.btn-pagination {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-pagination:hover:not(:disabled) {
+  background: #f0f0f0;
+}
+
+.btn-pagination:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  background: #f9f9f9;
+}
+</style>

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -25,7 +25,7 @@
         <tr v-if="filtered.length === 0">
           <td colspan="7" class="empty">{{ $t('server_table.empty') }}</td>
         </tr>
-        <tr v-for="s in filtered" :key="s.id" :class="rowClass(s)">
+        <tr v-for="s in paginatedItems" :key="s.id" :class="rowClass(s)">
           <td>{{ statusIcon(s) }}</td>
           <td>
             <router-link
@@ -68,12 +68,24 @@
         </tr>
       </tbody>
     </table>
+
+    <PaginationBar
+      v-if="filtered.length > 0"
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      :total-items="totalItems"
+      :page-size="pageSize"
+      @update:current-page="currentPage = $event"
+      @update:page-size="setPageSize"
+    />
   </div>
 </template>
 
 <script setup>
 import { ref, computed } from 'vue'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
 
 const { formatDateOnly } = useFormatDate()
 
@@ -96,6 +108,9 @@ const filtered = computed(() => {
       (s.os_family || '').toLowerCase().includes(q)
   )
 })
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filtered)
 
 function statusIcon(s) {
   if (!s.is_active) return '🔴'

--- a/ui/src/composables/usePagination.js
+++ b/ui/src/composables/usePagination.js
@@ -1,0 +1,61 @@
+import { ref, computed, watch } from 'vue'
+
+export const PAGE_SIZES = [10, 20, 40, 50, 100]
+
+/**
+ * Composable pour la pagination côté client.
+ * @param {Ref} filteredItems - Ref/Computed contenant les items filtrés
+ * @returns {Object} - Objet avec les propriétés et méthodes de pagination
+ */
+export function usePagination(filteredItems) {
+  const pageSize = ref(10)
+  const currentPage = ref(1)
+
+  // Reset currentPage à 1 quand la liste filtrée change
+  watch(
+    () => filteredItems.value?.length,
+    () => {
+      currentPage.value = 1
+    }
+  )
+
+  const totalItems = computed(() => filteredItems.value?.length || 0)
+
+  const totalPages = computed(() => Math.ceil(totalItems.value / pageSize.value) || 1)
+
+  const paginatedItems = computed(() => {
+    const items = filteredItems.value || []
+    const start = (currentPage.value - 1) * pageSize.value
+    const end = start + pageSize.value
+    return items.slice(start, end)
+  })
+
+  function nextPage() {
+    if (currentPage.value < totalPages.value) {
+      currentPage.value++
+    }
+  }
+
+  function prevPage() {
+    if (currentPage.value > 1) {
+      currentPage.value--
+    }
+  }
+
+  function setPageSize(size) {
+    pageSize.value = size
+    currentPage.value = 1
+  }
+
+  return {
+    pageSize,
+    currentPage,
+    totalItems,
+    totalPages,
+    paginatedItems,
+    nextPage,
+    prevPage,
+    setPageSize,
+    PAGE_SIZES,
+  }
+}

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -369,5 +369,11 @@
     "unlock_success": "Konto '{user}' entsperrt auf {server}.",
     "lock_error": "Sperrung fehlgeschlagen: {error}",
     "unlock_error": "Entsperrung fehlgeschlagen: {error}"
+  },
+  "pagination": {
+    "rowsPerPage": "Zeilen pro Seite",
+    "showing": "{from}–{to} von {total}",
+    "previous": "Zurück",
+    "next": "Weiter"
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -369,5 +369,11 @@
     "unlock_success": "Account '{user}' unlocked on {server}.",
     "lock_error": "Lock failed: {error}",
     "unlock_error": "Unlock failed: {error}"
+  },
+  "pagination": {
+    "rowsPerPage": "Rows per page",
+    "showing": "{from}–{to} of {total}",
+    "previous": "Previous",
+    "next": "Next"
   }
 }

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -369,5 +369,11 @@
     "unlock_success": "Cuenta '{user}' desbloqueada en {server}.",
     "lock_error": "Fallo al bloquear: {error}",
     "unlock_error": "Fallo al desbloquear: {error}"
+  },
+  "pagination": {
+    "rowsPerPage": "Filas por página",
+    "showing": "{from}–{to} de {total}",
+    "previous": "Anterior",
+    "next": "Siguiente"
   }
 }

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -369,5 +369,11 @@
     "unlock_success": "Compte '{user}' déverrouillé sur {server}.",
     "lock_error": "Échec du verrouillage : {error}",
     "unlock_error": "Échec du déverrouillage : {error}"
+  },
+  "pagination": {
+    "rowsPerPage": "Lignes par page",
+    "showing": "{from}–{to} sur {total}",
+    "previous": "Précédent",
+    "next": "Suivant"
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -369,5 +369,11 @@
     "unlock_success": "Account '{user}' sbloccato su {server}.",
     "lock_error": "Blocco fallito: {error}",
     "unlock_error": "Sblocco fallito: {error}"
+  },
+  "pagination": {
+    "rowsPerPage": "Righe per pagina",
+    "showing": "{from}–{to} di {total}",
+    "previous": "Precedente",
+    "next": "Successivo"
   }
 }

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -29,7 +29,7 @@
                 {{ $t('admins.empty') }}
               </td>
             </tr>
-            <tr v-for="a in admins" :key="a.id" :class="{ 'row-inactive': !a.is_active }">
+            <tr v-for="a in paginatedAdmins" :key="a.id" :class="{ 'row-inactive': !a.is_active }">
               <td>
                 <strong>{{ a.username }}</strong>
               </td>
@@ -117,6 +117,16 @@
             </tr>
           </tbody>
         </table>
+
+        <PaginationBar
+          v-if="admins.length > 0"
+          :current-page="currentPage"
+          :total-pages="totalPages"
+          :total-items="totalItems"
+          :page-size="pageSize"
+          @update:current-page="currentPage = $event"
+          @update:page-size="setPageSize"
+        />
       </section>
 
       <!-- My account — password change for non-sysadmin -->
@@ -550,6 +560,8 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from '../components/PaginationBar.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
@@ -584,6 +596,16 @@ const loading = ref(true)
 const error = ref('')
 const message = ref('')
 const currentUsername = ref('')
+
+const adminsComputed = computed(() => admins.value)
+const {
+  pageSize,
+  currentPage,
+  totalItems,
+  totalPages,
+  paginatedItems: paginatedAdmins,
+  setPageSize,
+} = usePagination(adminsComputed)
 const newUsername = ref('')
 const newEmail = ref('')
 const newRole = ref('operator')

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -57,7 +57,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="k in pendingFiltered"
+              v-for="k in paginatedPending"
               :key="k.fingerprint + k.server_hostname"
               :data-testid="`pending-row-${k.fingerprint}`"
             >
@@ -100,6 +100,16 @@
         <p v-else class="empty" data-testid="pending-no-results">
           {{ $t('anomalies.no_results') }}
         </p>
+
+        <PaginationBar
+          v-if="pendingFiltered.length > 0"
+          :current-page="pendingCurrentPage"
+          :total-pages="pendingTotalPages"
+          :total-items="pendingTotalItems"
+          :page-size="pendingPageSize"
+          @update:current-page="pendingCurrentPage = $event"
+          @update:page-size="setPendingPageSize"
+        />
       </section>
 
       <!-- Out-of-system revocations (last 30 days) -->
@@ -124,7 +134,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="k in outOfSystemFiltered"
+              v-for="k in paginatedOutOfSystem"
               :key="k.fingerprint + k.server_hostname"
               :data-testid="`revoked-row-${k.fingerprint}`"
             >
@@ -154,6 +164,16 @@
         <p v-else class="empty" data-testid="revoked-no-results">
           {{ $t('anomalies.no_results') }}
         </p>
+
+        <PaginationBar
+          v-if="outOfSystemFiltered.length > 0"
+          :current-page="outOfSystemCurrentPage"
+          :total-pages="outOfSystemTotalPages"
+          :total-items="outOfSystemTotalItems"
+          :page-size="outOfSystemPageSize"
+          @update:current-page="outOfSystemCurrentPage = $event"
+          @update:page-size="setOutOfSystemPageSize"
+        />
       </section>
     </template>
 
@@ -195,6 +215,8 @@ import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from '../components/PaginationBar.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
@@ -255,6 +277,24 @@ function matchesFilter(k) {
 
 const pendingFiltered = computed(() => pendingAll.value.filter(matchesFilter))
 const outOfSystemFiltered = computed(() => outOfSystemAll.value.filter(matchesFilter))
+
+const {
+  pageSize: pendingPageSize,
+  currentPage: pendingCurrentPage,
+  totalItems: pendingTotalItems,
+  totalPages: pendingTotalPages,
+  paginatedItems: paginatedPending,
+  setPageSize: setPendingPageSize,
+} = usePagination(pendingFiltered)
+
+const {
+  pageSize: outOfSystemPageSize,
+  currentPage: outOfSystemCurrentPage,
+  totalItems: outOfSystemTotalItems,
+  totalPages: outOfSystemTotalPages,
+  paginatedItems: paginatedOutOfSystem,
+  setPageSize: setOutOfSystemPageSize,
+} = usePagination(outOfSystemFiltered)
 
 async function load() {
   loading.value = true

--- a/ui/src/views/Audit.vue
+++ b/ui/src/views/Audit.vue
@@ -44,7 +44,7 @@
           <tr v-if="entries.length === 0">
             <td colspan="6" class="empty">{{ $t('audit.empty') }}</td>
           </tr>
-          <tr v-for="e in entries" :key="e.id" :class="rowClass(e.action)">
+          <tr v-for="e in paginatedItems" :key="e.id" :class="rowClass(e.action)">
             <td class="date">{{ formatDate(e.performed_at) }}</td>
             <td>
               <span class="badge" :class="actionBadge(e.action)">{{ e.action }}</span>
@@ -59,14 +59,26 @@
           </tr>
         </tbody>
       </table>
+
+      <PaginationBar
+        v-if="entries.length > 0"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :total-items="totalItems"
+        :page-size="pageSize"
+        @update:current-page="currentPage = $event"
+        @update:page-size="setPageSize"
+      />
     </section>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from '../components/PaginationBar.vue'
 
 const { t } = useI18n()
 const { formatDate } = useFormatDate()
@@ -96,6 +108,10 @@ const loading = ref(true)
 const error = ref('')
 
 const filters = ref({ server: '', action: '', since: '' })
+
+const entriesComputed = computed(() => entries.value)
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(entriesComputed)
 
 async function load() {
   loading.value = true

--- a/ui/tests/PaginationBar.spec.js
+++ b/ui/tests/PaginationBar.spec.js
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PaginationBar from '../src/components/PaginationBar.vue'
+import { createI18n } from 'vue-i18n'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      pagination: {
+        rowsPerPage: 'Rows per page',
+        showing: '{from}–{to} of {total}',
+        previous: 'Previous',
+        next: 'Next',
+      },
+    },
+  },
+})
+
+describe('PaginationBar.vue', () => {
+  it('renders correctly with 42 items, pageSize=10', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 5,
+        totalItems: 42,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    expect(wrapper.text()).toContain('1–10 of 42')
+  })
+
+  it('shows correct range on page 2', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 2,
+        totalPages: 5,
+        totalItems: 42,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    expect(wrapper.text()).toContain('11–20 of 42')
+  })
+
+  it('shows correct range on last page (partial)', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 5,
+        totalPages: 5,
+        totalItems: 42,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    expect(wrapper.text()).toContain('41–42 of 42')
+  })
+
+  it('disables Previous button on page 1', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 3,
+        totalItems: 30,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const prevButton = buttons.find((b) => b.text() === 'Previous')
+    expect(prevButton.element.disabled).toBe(true)
+  })
+
+  it('disables Next button on last page', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 3,
+        totalPages: 3,
+        totalItems: 30,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const nextButton = buttons.find((b) => b.text() === 'Next')
+    expect(nextButton.element.disabled).toBe(true)
+  })
+
+  it('emits update:currentPage when clicking Next', async () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 3,
+        totalItems: 30,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const nextButton = buttons.find((b) => b.text() === 'Next')
+    await nextButton.trigger('click')
+
+    expect(wrapper.emitted('update:currentPage')).toBeTruthy()
+    expect(wrapper.emitted('update:currentPage')[0]).toEqual([2])
+  })
+
+  it('emits update:currentPage when clicking Previous', async () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 2,
+        totalPages: 3,
+        totalItems: 30,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const buttons = wrapper.findAll('button')
+    const prevButton = buttons.find((b) => b.text() === 'Previous')
+    await prevButton.trigger('click')
+
+    expect(wrapper.emitted('update:currentPage')).toBeTruthy()
+    expect(wrapper.emitted('update:currentPage')[0]).toEqual([1])
+  })
+
+  it('emits update:pageSize when changing the selector', async () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 5,
+        totalItems: 42,
+        pageSize: 10,
+        pageSizes: [10, 20, 40],
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const select = wrapper.find('select')
+    await select.setValue('20')
+
+    expect(wrapper.emitted('update:pageSize')).toBeTruthy()
+    expect(wrapper.emitted('update:pageSize')[0]).toEqual([20])
+  })
+
+  it('displays available page sizes', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: 10,
+        pageSize: 10,
+        pageSizes: [10, 20, 40, 50, 100],
+      },
+      global: { plugins: [i18n] },
+    })
+
+    const options = wrapper.findAll('option')
+    expect(options).toHaveLength(5)
+    expect(options[0].text()).toBe('10')
+    expect(options[4].text()).toBe('100')
+  })
+
+  it('shows 0–0 of 0 when totalItems is 0', () => {
+    const wrapper = mount(PaginationBar, {
+      props: {
+        currentPage: 1,
+        totalPages: 1,
+        totalItems: 0,
+        pageSize: 10,
+      },
+      global: { plugins: [i18n] },
+    })
+
+    expect(wrapper.text()).toContain('0–0 of 0')
+  })
+})

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -132,4 +132,20 @@ describe('ServerTable', () => {
     expect(w.emitted('edit')).toBeTruthy()
     expect(w.emitted('edit')[0][0]).toEqual(SERVERS[0])
   })
+
+  it('affiche seulement 10 items par défaut sur la première page', () => {
+    const manyServers = Array.from({ length: 25 }, (_, i) => ({
+      id: String(i + 1),
+      hostname: `server-${i + 1}`,
+      ip_address: `10.0.0.${i + 1}`,
+      environment: 'production',
+      os_family: 'rhel',
+      added_at: null,
+      is_active: true,
+      has_anomalies: false,
+    }))
+    const w = mountTable(manyServers)
+    const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
+    expect(rows.length).toBe(10)
+  })
 })


### PR DESCRIPTION
## Summary

- Nouveau composable `usePagination.js` — page courante, taille de page (10/20/40/50/100), reset auto sur changement de filtre
- Nouveau composant `PaginationBar.vue` — sélecteur taille, indicateur "1–10 sur 42", boutons Précédent/Suivant
- Pagination appliquée aux 6 tables : `ServerTable`, `KeyTable`, `DeployedUsersTable`, `Admins`, `Audit`, `Anomalies`
- Traductions dans les 5 locales (EN/FR/ES/IT/DE)
- Aucune modification backend — 100% côté client

Closes #248

## Test plan

- [ ] 194 tests Vitest passent (`npm run test -- --run`)
- [ ] Vérifier l'affichage de la pagination sous chaque table
- [ ] Vérifier le reset à la page 1 quand un filtre change
- [ ] Vérifier les boutons Précédent/Suivant désactivés en limite
- [ ] Vérifier le changement de taille de page (10/20/40/50/100)
- [ ] Vérifier les 5 langues sur l'indicateur "X–Y sur Z"