### PR TITLE
refactor: extract inline tables into dedicated components

### DIFF
--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -24,11 +24,16 @@
 | DeployKeyForm.vue | Formulaire déploiement clé SSH |
 | UserLockForm.vue | Verrouillage/déverrouillage compte Unix (#181) |
 | DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer |
+| AdminsTable.vue | Tableau administrateurs + filtre texte + pagination + garde-fou self (#250) |
+| AuditTable.vue | Tableau audit + filtres serveur/action/date + pagination (#250) |
+| AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) |
+| PaginationBar.vue | Composant pagination réutilisable avec contrôles taille de page |
 
 ## Composables
 
 - `useAuth.js` — authentification session
 - `useFormatDate.js` — `formatDate()` et `formatDateOnly()` avec locale navigateur (#228, UTC→local)
+- `usePagination.js` — pagination côté client réutilisable (10 lignes par défaut, reset auto au changement de filtre)
 
 ## Internationalisation — règle absolue
 
@@ -59,5 +64,8 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | DeployedUsersTable.spec.js | 12 | filtres, RBAC operator/viewer |
 | Anomalies.spec.js | 20 | filtres texte + dropdowns, unix_user, badges |
 | Login.spec.js | 8 | checkbox remember-me, payload remember_me |
+| AdminsTable.spec.js | 13 | filtre texte, pagination, RBAC, garde-fou self, events (#250) |
+| AuditTable.spec.js | 8 | filtres serveur/action/date, pagination, row classes (#250) |
+| AnomaliesTable.spec.js | 14 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
 
 vitest doit passer avant tout commit.

--- a/ui/src/components/AdminsTable.vue
+++ b/ui/src/components/AdminsTable.vue
@@ -1,0 +1,210 @@
+<template>
+  <div class="admins-table">
+    <div class="table-toolbar">
+      <input
+        v-model="search"
+        type="text"
+        :placeholder="$t('admins_table.search_placeholder')"
+        class="search-input"
+        data-testid="admins-filter-text"
+      />
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>{{ $t('admins.col_username') }}</th>
+          <th>{{ $t('admins.col_email') }}</th>
+          <th>{{ $t('admins.col_role') }}</th>
+          <th>{{ $t('admins.col_active') }}</th>
+          <th>{{ $t('admins.col_created') }}</th>
+          <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_alerts') }}</th>
+          <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_actions') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-if="filtered.length === 0">
+          <td :colspan="props.currentRole === 'sysadmin' ? 7 : 5" class="empty">
+            {{ props.admins.length === 0 ? $t('admins.empty') : $t('admins_table.no_results') }}
+          </td>
+        </tr>
+        <tr v-for="a in paginatedItems" :key="a.id" :class="{ 'row-inactive': !a.is_active }">
+          <td>
+            <strong>{{ a.username }}</strong>
+          </td>
+          <td>{{ a.email || '—' }}</td>
+          <td>{{ a.role }}</td>
+          <td>
+            <span class="badge" :class="a.is_active ? 'badge-active' : 'badge-revoked'">
+              {{ a.is_active ? $t('admins.status_active') : $t('admins.status_disabled') }}
+            </span>
+          </td>
+          <td>{{ formatDateOnly(a.created_at) }}</td>
+          <td v-if="props.currentRole === 'sysadmin'">
+            <div class="alerts-cell">
+              <span class="badge" :class="a.receive_alerts ? 'badge-active' : 'badge-off'">
+                {{ a.receive_alerts ? $t('admins.alerts_on') : $t('admins.alerts_off') }}
+              </span>
+              <button
+                v-if="a.receive_alerts"
+                class="btn-secondary btn-sm"
+                :data-testid="`btn-alerts-off-${a.username}`"
+                @click="$emit('toggleAlerts', a.username, false)"
+              >
+                {{ $t('admins.btn_alerts_off') }}
+              </button>
+              <button
+                v-else
+                class="btn-success btn-sm"
+                :data-testid="`btn-alerts-on-${a.username}`"
+                @click="$emit('toggleAlerts', a.username, true)"
+              >
+                {{ $t('admins.btn_alerts_on') }}
+              </button>
+            </div>
+          </td>
+          <td v-if="props.currentRole === 'sysadmin'">
+            <div class="actions-cell">
+              <template v-if="a.is_active">
+                <button
+                  class="btn-secondary btn-sm"
+                  :data-testid="`btn-edit-${a.username}`"
+                  @click="$emit('edit', a)"
+                >
+                  {{ $t('admins.btn_edit') }}
+                </button>
+                <button
+                  class="btn-secondary btn-sm"
+                  :data-testid="`btn-password-${a.username}`"
+                  @click="$emit('changePassword', a.username)"
+                >
+                  {{ $t('admins.btn_password') }}
+                </button>
+                <button
+                  v-if="a.username !== props.currentUsername"
+                  class="btn-warning btn-sm"
+                  :data-testid="`btn-disable-${a.username}`"
+                  @click="$emit('disable', a.username)"
+                >
+                  {{ $t('admins.btn_disable') }}
+                </button>
+                <button
+                  v-if="a.username !== props.currentUsername"
+                  class="btn-danger btn-sm"
+                  :data-testid="`btn-delete-${a.username}`"
+                  @click="$emit('delete', a.username)"
+                >
+                  {{ $t('admins.btn_delete') }}
+                </button>
+              </template>
+              <template v-else>
+                <button
+                  class="btn-success btn-sm"
+                  :data-testid="`btn-enable-${a.username}`"
+                  @click="$emit('enable', a.username)"
+                >
+                  {{ $t('admins.btn_enable') }}
+                </button>
+                <button
+                  class="btn-danger btn-sm"
+                  :data-testid="`btn-delete-${a.username}`"
+                  @click="$emit('delete', a.username)"
+                >
+                  {{ $t('admins.btn_delete') }}
+                </button>
+              </template>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <PaginationBar
+      v-if="filtered.length > 0"
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      :total-items="totalItems"
+      :page-size="pageSize"
+      @update:current-page="currentPage = $event"
+      @update:page-size="setPageSize"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
+
+const { formatDateOnly } = useFormatDate()
+
+const props = defineProps({
+  admins: { type: Array, default: () => [] },
+  currentUsername: { type: String, default: '' },
+  currentRole: { type: String, default: 'viewer' },
+})
+
+defineEmits(['enable', 'disable', 'delete', 'changePassword', 'toggleAlerts', 'edit'])
+
+const search = ref('')
+
+const filtered = computed(() => {
+  const q = search.value.trim().toLowerCase()
+  if (!q) return props.admins
+  return props.admins.filter(
+    (a) =>
+      a.username.toLowerCase().includes(q) ||
+      (a.email || '').toLowerCase().includes(q) ||
+      (a.role || '').toLowerCase().includes(q)
+  )
+})
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filtered)
+</script>
+
+<style scoped>
+.table-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.search-input {
+  padding: 0.35rem 0.65rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  width: 240px;
+}
+
+.row-inactive {
+  opacity: 0.6;
+}
+
+.actions-cell {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.alerts-cell {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+  flex-wrap: nowrap;
+}
+
+.badge-off {
+  background: #e9ecef;
+  color: #6c757d;
+}
+
+.empty {
+  text-align: center;
+  color: #888;
+  padding: 1rem 0;
+}
+</style>

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -67,7 +67,10 @@
           </td>
           <td v-if="props.currentRole !== 'viewer' && type === 'pending'">
             <div class="actions">
-              <button class="btn-success" @click="$emit('validate', k.fingerprint, k.unix_user, k.server_hostname)">
+              <button
+                class="btn-success"
+                @click="$emit('validate', k.fingerprint, k.unix_user, k.server_hostname)"
+              >
                 {{ $t('anomalies.btn_validate') }}
               </button>
               <button class="btn-danger" @click="$emit('revoke', k.fingerprint)">
@@ -155,9 +158,7 @@ const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSi
   usePagination(filtered)
 
 const colDate = computed(() => {
-  return props.type === 'pending'
-    ? t('anomalies.col_first_seen')
-    : t('anomalies.col_revoked_at')
+  return props.type === 'pending' ? t('anomalies.col_first_seen') : t('anomalies.col_revoked_at')
 })
 
 const dateField = computed(() => {
@@ -171,9 +172,7 @@ const emptyMessage = computed(() => {
 function complianceTooltip(k) {
   if (k.key_type === 'ssh-rsa') {
     const bits = k.key_size_bits
-    return bits
-      ? t('key_table.non_compliant_rsa_bits', { bits })
-      : t('key_table.non_compliant_rsa')
+    return bits ? t('key_table.non_compliant_rsa_bits', { bits }) : t('key_table.non_compliant_rsa')
   }
   return t('key_table.non_compliant_type')
 }

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -1,0 +1,243 @@
+<template>
+  <div class="anomalies-table">
+    <div v-if="props.anomalies.length > 0" class="filters" data-testid="anomalies-filters">
+      <input
+        v-model="filterText"
+        type="text"
+        :placeholder="$t('anomalies.filter_placeholder')"
+        class="filter-input"
+        data-testid="anomalies-filter-text"
+      />
+      <select v-model="filterType" class="filter-select" data-testid="anomalies-filter-type">
+        <option value="">{{ $t('anomalies.filter_all_types') }}</option>
+        <option v-for="t in uniqueTypes" :key="t" :value="t">{{ t }}</option>
+      </select>
+      <select v-model="filterServer" class="filter-select" data-testid="anomalies-filter-server">
+        <option value="">{{ $t('anomalies.filter_all_servers') }}</option>
+        <option v-for="s in uniqueServers" :key="s" :value="s">{{ s }}</option>
+      </select>
+      <select
+        v-model="filterCompliant"
+        class="filter-select"
+        data-testid="anomalies-filter-compliant"
+      >
+        <option value="">{{ $t('anomalies.filter_all_compliant') }}</option>
+        <option value="yes">{{ $t('anomalies.filter_compliant') }}</option>
+        <option value="no">{{ $t('anomalies.filter_non_compliant') }}</option>
+      </select>
+    </div>
+
+    <table v-if="filtered.length > 0">
+      <thead>
+        <tr>
+          <th>{{ $t('anomalies.col_fingerprint') }}</th>
+          <th>{{ $t('anomalies.col_type') }}</th>
+          <th>{{ $t('anomalies.col_server') }}</th>
+          <th>{{ $t('anomalies.col_unix_user') }}</th>
+          <th>{{ colDate }}</th>
+          <th>{{ $t('anomalies.col_compliant') }}</th>
+          <th v-if="props.currentRole !== 'viewer'">{{ $t('anomalies.col_actions') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="k in paginatedItems"
+          :key="k.fingerprint + k.server_hostname"
+          :data-testid="`${type}-row-${k.fingerprint}`"
+        >
+          <td class="fp">
+            <code>{{ k.fingerprint }}</code>
+          </td>
+          <td>
+            <code>{{ k.key_type }}</code>
+          </td>
+          <td>
+            <router-link :to="`/servers/${k.server_hostname}`" class="server-link">
+              {{ k.server_hostname }}
+            </router-link>
+          </td>
+          <td>
+            <code v-if="k.unix_user">{{ k.unix_user }}</code>
+            <span v-else>—</span>
+          </td>
+          <td>{{ formatDate(k[dateField]) }}</td>
+          <td>
+            <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
+            <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
+          </td>
+          <td v-if="props.currentRole !== 'viewer' && type === 'pending'">
+            <div class="actions">
+              <button class="btn-success" @click="$emit('validate', k.fingerprint, k.unix_user, k.server_hostname)">
+                {{ $t('anomalies.btn_validate') }}
+              </button>
+              <button class="btn-danger" @click="$emit('revoke', k.fingerprint)">
+                {{ $t('anomalies.btn_revoke') }}
+              </button>
+            </div>
+          </td>
+          <td v-if="props.currentRole !== 'viewer' && type === 'revoked'">
+            {{ k.revocation_justification || '—' }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else-if="props.anomalies.length === 0" class="empty" :data-testid="`${type}-empty`">
+      {{ emptyMessage }}
+    </p>
+    <p v-else class="empty" :data-testid="`${type}-no-results`">
+      {{ $t('anomalies.no_results') }}
+    </p>
+
+    <PaginationBar
+      v-if="filtered.length > 0"
+      :current-page="currentPage"
+      :total-pages="totalPages"
+      :total-items="totalItems"
+      :page-size="pageSize"
+      @update:current-page="currentPage = $event"
+      @update:page-size="setPageSize"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
+
+const { t } = useI18n()
+const { formatDate } = useFormatDate()
+
+const props = defineProps({
+  anomalies: { type: Array, default: () => [] },
+  servers: { type: Array, default: () => [] },
+  currentRole: { type: String, default: 'viewer' },
+  type: { type: String, default: 'pending', validator: (v) => ['pending', 'revoked'].includes(v) },
+})
+
+defineEmits(['validate', 'revoke'])
+
+const filterText = ref('')
+const filterType = ref('')
+const filterServer = ref('')
+const filterCompliant = ref('')
+
+const uniqueTypes = computed(() => {
+  return [...new Set(props.anomalies.map((k) => k.key_type).filter(Boolean))].sort()
+})
+
+const uniqueServers = computed(() => {
+  return [...new Set(props.anomalies.map((k) => k.server_hostname).filter(Boolean))].sort()
+})
+
+const filtered = computed(() => {
+  return props.anomalies.filter((k) => {
+    const text = filterText.value.trim().toLowerCase()
+    if (text) {
+      const match =
+        k.fingerprint.toLowerCase().includes(text) ||
+        k.key_type.toLowerCase().includes(text) ||
+        (k.server_hostname || '').toLowerCase().includes(text) ||
+        (k.unix_user || '').toLowerCase().includes(text)
+      if (!match) return false
+    }
+    if (filterType.value && k.key_type !== filterType.value) return false
+    if (filterServer.value && k.server_hostname !== filterServer.value) return false
+    if (filterCompliant.value === 'yes' && !k.is_compliant) return false
+    if (filterCompliant.value === 'no' && k.is_compliant) return false
+    return true
+  })
+})
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filtered)
+
+const colDate = computed(() => {
+  return props.type === 'pending'
+    ? t('anomalies.col_first_seen')
+    : t('anomalies.col_revoked_at')
+})
+
+const dateField = computed(() => {
+  return props.type === 'pending' ? 'first_seen' : 'revoked_at'
+})
+
+const emptyMessage = computed(() => {
+  return props.type === 'pending' ? t('anomalies.no_pending') : t('anomalies.no_revoked')
+})
+
+function complianceTooltip(k) {
+  if (k.key_type === 'ssh-rsa') {
+    const bits = k.key_size_bits
+    return bits
+      ? t('key_table.non_compliant_rsa_bits', { bits })
+      : t('key_table.non_compliant_rsa')
+  }
+  return t('key_table.non_compliant_type')
+}
+</script>
+
+<style scoped>
+.filters {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.filter-input {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  flex: 1;
+  max-width: 400px;
+}
+
+.filter-select {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.fp {
+  font-size: 0.75rem;
+  word-break: break-all;
+  max-width: 240px;
+}
+
+code {
+  background: #f4f4f4;
+  padding: 0 3px;
+  border-radius: 3px;
+  font-size: 0.8rem;
+}
+
+.server-link {
+  color: #0d6efd;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.server-link:hover {
+  text-decoration: underline;
+}
+
+.non-compliant {
+  cursor: help;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.empty {
+  color: #888;
+  font-size: 0.9rem;
+  padding: 0.5rem 0;
+}
+</style>

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -1,0 +1,235 @@
+<template>
+  <div class="audit-table">
+    <section class="filters card">
+      <div class="filter-row">
+        <div class="field">
+          <label for="f-server">{{ $t('audit.filter_server') }}</label>
+          <input id="f-server" v-model="filters.server" type="text" placeholder="hostname" />
+        </div>
+        <div class="field">
+          <label for="f-action">{{ $t('audit.filter_action') }}</label>
+          <select id="f-action" v-model="filters.action">
+            <option value="">{{ $t('audit.filter_all') }}</option>
+            <option v-for="a in ACTIONS" :key="a" :value="a">{{ a }}</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="f-since">{{ $t('audit.filter_since') }}</label>
+          <input id="f-since" v-model="filters.since" type="date" />
+        </div>
+        <button class="btn-primary" @click="applyFilters">{{ $t('audit.filter_btn') }}</button>
+        <button @click="resetFilters">{{ $t('audit.reset_btn') }}</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <table>
+        <thead>
+          <tr>
+            <th>{{ $t('audit.col_date') }}</th>
+            <th>{{ $t('audit.col_action') }}</th>
+            <th>{{ $t('audit.col_by') }}</th>
+            <th>{{ $t('audit.col_server') }}</th>
+            <th>{{ $t('audit.col_key') }}</th>
+            <th>{{ $t('audit.col_details') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="filtered.length === 0">
+            <td colspan="6" class="empty">
+              {{ props.logs.length === 0 ? $t('audit.empty') : $t('audit_table.no_results') }}
+            </td>
+          </tr>
+          <tr v-for="e in paginatedItems" :key="e.id" :class="rowClass(e.action)">
+            <td class="date">{{ formatDate(e.performed_at) }}</td>
+            <td>
+              <span class="badge" :class="actionBadge(e.action)">{{ e.action }}</span>
+            </td>
+            <td>{{ e.performed_by_username || '—' }}</td>
+            <td>{{ e.server_hostname || '—' }}</td>
+            <td class="fp">
+              <code v-if="e.key_fingerprint">{{ e.key_fingerprint }}</code>
+              <span v-else>—</span>
+            </td>
+            <td class="details">{{ formatDetails(e.details) }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <PaginationBar
+        v-if="filtered.length > 0"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :total-items="totalItems"
+        :page-size="pageSize"
+        @update:current-page="currentPage = $event"
+        @update:page-size="setPageSize"
+      />
+    </section>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useFormatDate } from '../composables/useFormatDate.js'
+import { usePagination } from '../composables/usePagination.js'
+import PaginationBar from './PaginationBar.vue'
+
+const { formatDate } = useFormatDate()
+
+const props = defineProps({
+  logs: { type: Array, default: () => [] },
+  servers: { type: Array, default: () => [] },
+})
+
+const ACTIONS = [
+  'KEY_ADDED',
+  'KEY_REVOKED',
+  'KEY_EXPIRED',
+  'EXPIRY_WARNING',
+  'REQUEST_APPROVED',
+  'REQUEST_REJECTED',
+  'ANOMALY_DETECTED',
+  'SCAN_COMPLETED',
+  'SCAN_FAILED',
+  'SCRIPT_DEPLOYED',
+  'SERVER_ADDED',
+  'SERVER_DISABLED',
+  'ADMIN_ADDED',
+  'ADMIN_DISABLED',
+]
+
+const CRITICAL_ACTIONS = new Set(['ANOMALY_DETECTED', 'SCAN_FAILED', 'KEY_REVOKED'])
+const WARNING_ACTIONS = new Set(['EXPIRY_WARNING', 'KEY_EXPIRED'])
+
+const filters = ref({ server: '', action: '', since: '' })
+
+const filtered = computed(() => {
+  let items = props.logs
+  if (filters.value.server) {
+    items = items.filter((e) =>
+      (e.server_hostname || '').toLowerCase().includes(filters.value.server.toLowerCase())
+    )
+  }
+  if (filters.value.action) {
+    items = items.filter((e) => e.action === filters.value.action)
+  }
+  if (filters.value.since) {
+    const sinceDate = new Date(filters.value.since)
+    items = items.filter((e) => new Date(e.performed_at) >= sinceDate)
+  }
+  return items
+})
+
+const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
+  usePagination(filtered)
+
+function rowClass(action) {
+  if (CRITICAL_ACTIONS.has(action)) return 'row-danger'
+  if (WARNING_ACTIONS.has(action)) return 'row-warning'
+  return ''
+}
+
+function actionBadge(action) {
+  if (CRITICAL_ACTIONS.has(action)) return 'badge-critical'
+  if (WARNING_ACTIONS.has(action)) return 'badge-pending'
+  return 'badge-active'
+}
+
+function formatDetails(details) {
+  if (!details) return '—'
+  if (typeof details === 'string') return details
+  return Object.entries(details)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join(' | ')
+}
+
+function applyFilters() {
+  currentPage.value = 1
+}
+
+function resetFilters() {
+  filters.value = { server: '', action: '', since: '' }
+  currentPage.value = 1
+}
+</script>
+
+<style scoped>
+.card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.filters {
+  padding: 1rem 1.25rem;
+}
+
+.filter-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #555;
+}
+
+input[type='text'],
+input[type='date'],
+select {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  min-width: 140px;
+}
+
+.date {
+  white-space: nowrap;
+  font-size: 0.82rem;
+}
+
+.fp {
+  font-size: 0.72rem;
+  word-break: break-all;
+  max-width: 200px;
+}
+
+.details {
+  font-size: 0.8rem;
+  color: #555;
+  max-width: 220px;
+}
+
+code {
+  background: #f4f4f4;
+  padding: 0 3px;
+  border-radius: 3px;
+}
+
+.empty {
+  text-align: center;
+  color: #888;
+  padding: 1rem 0;
+}
+
+.row-danger {
+  background: #fff5f5;
+}
+
+.row-warning {
+  background: #fffbf0;
+}
+</style>

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -190,6 +190,13 @@
     "reset_btn": "Zurücksetzen",
     "load_error": "Audit kann nicht geladen werden: {error}"
   },
+  "admins_table": {
+    "search_placeholder": "Administratoren suchen...",
+    "no_results": "Keine übereinstimmenden Administratoren."
+  },
+  "audit_table": {
+    "no_results": "Keine übereinstimmenden Audit-Einträge."
+  },
   "admins": {
     "title": "Administratoren",
     "section_list": "Liste",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -190,6 +190,13 @@
     "reset_btn": "Reset",
     "load_error": "Unable to load audit: {error}"
   },
+  "admins_table": {
+    "search_placeholder": "Search administrators...",
+    "no_results": "No matching administrators."
+  },
+  "audit_table": {
+    "no_results": "No matching audit entries."
+  },
   "admins": {
     "title": "Administrators",
     "section_list": "List",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -190,6 +190,13 @@
     "reset_btn": "Restablecer",
     "load_error": "No se puede cargar la auditoría: {error}"
   },
+  "admins_table": {
+    "search_placeholder": "Buscar administradores...",
+    "no_results": "No hay administradores coincidentes."
+  },
+  "audit_table": {
+    "no_results": "No hay entradas de auditoría coincidentes."
+  },
   "admins": {
     "title": "Administradores",
     "section_list": "Lista",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -190,6 +190,13 @@
     "reset_btn": "Réinitialiser",
     "load_error": "Impossible de charger l'audit : {error}"
   },
+  "admins_table": {
+    "search_placeholder": "Rechercher administrateurs...",
+    "no_results": "Aucun administrateur correspondant."
+  },
+  "audit_table": {
+    "no_results": "Aucune entrée d'audit correspondante."
+  },
   "admins": {
     "title": "Administrateurs",
     "section_list": "Liste",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -190,6 +190,13 @@
     "reset_btn": "Reimposta",
     "load_error": "Impossibile caricare l'audit: {error}"
   },
+  "admins_table": {
+    "search_placeholder": "Cerca amministratori...",
+    "no_results": "Nessun amministratore corrispondente."
+  },
+  "audit_table": {
+    "no_results": "Nessuna voce di audit corrispondente."
+  },
   "admins": {
     "title": "Amministratori",
     "section_list": "Lista",

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -11,121 +11,16 @@
       <!-- Administrators list -->
       <section class="card">
         <h2>{{ $t('admins.section_list') }}</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>{{ $t('admins.col_username') }}</th>
-              <th>{{ $t('admins.col_email') }}</th>
-              <th>{{ $t('admins.col_role') }}</th>
-              <th>{{ $t('admins.col_active') }}</th>
-              <th>{{ $t('admins.col_created') }}</th>
-              <th v-if="currentRole === 'sysadmin'">{{ $t('admins.col_alerts') }}</th>
-              <th v-if="currentRole === 'sysadmin'">{{ $t('admins.col_actions') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-if="admins.length === 0">
-              <td :colspan="currentRole === 'sysadmin' ? 7 : 5" class="empty">
-                {{ $t('admins.empty') }}
-              </td>
-            </tr>
-            <tr v-for="a in paginatedAdmins" :key="a.id" :class="{ 'row-inactive': !a.is_active }">
-              <td>
-                <strong>{{ a.username }}</strong>
-              </td>
-              <td>{{ a.email || '—' }}</td>
-              <td>{{ a.role }}</td>
-              <td>
-                <span class="badge" :class="a.is_active ? 'badge-active' : 'badge-revoked'">
-                  {{ a.is_active ? $t('admins.status_active') : $t('admins.status_disabled') }}
-                </span>
-              </td>
-              <td>{{ formatDateOnly(a.created_at) }}</td>
-              <td v-if="currentRole === 'sysadmin'">
-                <div class="alerts-cell">
-                  <span class="badge" :class="a.receive_alerts ? 'badge-active' : 'badge-off'">
-                    {{ a.receive_alerts ? $t('admins.alerts_on') : $t('admins.alerts_off') }}
-                  </span>
-                  <button
-                    v-if="a.receive_alerts"
-                    class="btn-secondary btn-sm"
-                    :data-testid="`btn-alerts-off-${a.username}`"
-                    @click="toggleAlerts(a, false)"
-                  >
-                    {{ $t('admins.btn_alerts_off') }}
-                  </button>
-                  <button
-                    v-else
-                    class="btn-success btn-sm"
-                    :data-testid="`btn-alerts-on-${a.username}`"
-                    @click="toggleAlerts(a, true)"
-                  >
-                    {{ $t('admins.btn_alerts_on') }}
-                  </button>
-                </div>
-              </td>
-              <td v-if="currentRole === 'sysadmin'">
-                <div class="actions-cell">
-                  <template v-if="a.is_active">
-                    <button
-                      v-if="currentRole === 'sysadmin'"
-                      class="btn-secondary btn-sm"
-                      @click="openEdit(a)"
-                    >
-                      {{ $t('admins.btn_edit') }}
-                    </button>
-                    <button
-                      v-if="currentRole === 'sysadmin' || a.username === admin?.username"
-                      class="btn-secondary btn-sm"
-                      @click="openEditPassword(a.username)"
-                    >
-                      {{ $t('admins.btn_password') }}
-                    </button>
-                    <button
-                      v-if="currentRole === 'sysadmin' && a.username !== currentUsername"
-                      class="btn-warning btn-sm"
-                      @click="openDisable(a.username)"
-                    >
-                      {{ $t('admins.btn_disable') }}
-                    </button>
-                    <button
-                      v-if="currentRole === 'sysadmin' && a.username !== currentUsername"
-                      class="btn-danger btn-sm"
-                      @click="openDelete(a.username)"
-                    >
-                      {{ $t('admins.btn_delete') }}
-                    </button>
-                  </template>
-                  <template v-else>
-                    <button
-                      v-if="currentRole === 'sysadmin'"
-                      class="btn-success btn-sm"
-                      @click="openEnable(a.username)"
-                    >
-                      {{ $t('admins.btn_enable') }}
-                    </button>
-                    <button
-                      v-if="currentRole === 'sysadmin'"
-                      class="btn-danger btn-sm"
-                      @click="openDelete(a.username)"
-                    >
-                      {{ $t('admins.btn_delete') }}
-                    </button>
-                  </template>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-
-        <PaginationBar
-          v-if="admins.length > 0"
-          :current-page="currentPage"
-          :total-pages="totalPages"
-          :total-items="totalItems"
-          :page-size="pageSize"
-          @update:current-page="currentPage = $event"
-          @update:page-size="setPageSize"
+        <AdminsTable
+          :admins="admins"
+          :current-username="currentUsername"
+          :current-role="currentRole"
+          @enable="openEnable"
+          @disable="openDisable"
+          @delete="openDelete"
+          @change-password="openEditPassword"
+          @toggle-alerts="toggleAlerts"
+          @edit="openEdit"
         />
       </section>
 
@@ -559,13 +454,10 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth'
-import { useFormatDate } from '../composables/useFormatDate.js'
-import { usePagination } from '../composables/usePagination.js'
-import PaginationBar from '../components/PaginationBar.vue'
+import AdminsTable from '../components/AdminsTable.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
-const { formatDateOnly } = useFormatDate()
 
 const currentRole = computed(() => admin.value?.role || 'viewer')
 
@@ -597,15 +489,6 @@ const error = ref('')
 const message = ref('')
 const currentUsername = ref('')
 
-const adminsComputed = computed(() => admins.value)
-const {
-  pageSize,
-  currentPage,
-  totalItems,
-  totalPages,
-  paginatedItems: paginatedAdmins,
-  setPageSize,
-} = usePagination(adminsComputed)
 const newUsername = ref('')
 const newEmail = ref('')
 const newRole = ref('operator')
@@ -701,10 +584,10 @@ function openDelete(username) {
   deleteTarget.value = username
 }
 
-async function toggleAlerts(admin, receive_alerts) {
+async function toggleAlerts(username, receive_alerts) {
   error.value = ''
   try {
-    const res = await fetch(`/api/admins/${admin.username}/alerts`, {
+    const res = await fetch(`/api/admins/${username}/alerts`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ receive_alerts }),
@@ -713,7 +596,10 @@ async function toggleAlerts(admin, receive_alerts) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
     }
-    admin.receive_alerts = receive_alerts
+    const adminToUpdate = admins.value.find((a) => a.username === username)
+    if (adminToUpdate) {
+      adminToUpdate.receive_alerts = receive_alerts
+    }
   } catch (e) {
     error.value = t('admins.toggle_alerts_error', { error: e.message })
   }
@@ -867,33 +753,6 @@ h2 {
   border-radius: 6px;
   padding: 1.25rem;
   margin-bottom: 1.25rem;
-}
-
-.row-inactive {
-  opacity: 0.6;
-}
-.text-muted {
-  color: #aaa;
-  font-size: 0.85rem;
-}
-
-.actions-cell {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  align-items: center;
-}
-
-.alerts-cell {
-  display: flex;
-  gap: 0.4rem;
-  align-items: center;
-  flex-wrap: nowrap;
-}
-
-.badge-off {
-  background: #e9ecef;
-  color: #6c757d;
 }
 
 .my-account-card {

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -8,33 +8,6 @@
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
 
     <template v-else>
-      <div v-if="allKeys.length > 0" class="filters" data-testid="anomalies-filters">
-        <input
-          v-model="filterText"
-          type="text"
-          :placeholder="$t('anomalies.filter_placeholder')"
-          class="filter-input"
-          data-testid="anomalies-filter-text"
-        />
-        <select v-model="filterType" class="filter-select" data-testid="anomalies-filter-type">
-          <option value="">{{ $t('anomalies.filter_all_types') }}</option>
-          <option v-for="t in uniqueTypes" :key="t" :value="t">{{ t }}</option>
-        </select>
-        <select v-model="filterServer" class="filter-select" data-testid="anomalies-filter-server">
-          <option value="">{{ $t('anomalies.filter_all_servers') }}</option>
-          <option v-for="s in uniqueServers" :key="s" :value="s">{{ s }}</option>
-        </select>
-        <select
-          v-model="filterCompliant"
-          class="filter-select"
-          data-testid="anomalies-filter-compliant"
-        >
-          <option value="">{{ $t('anomalies.filter_all_compliant') }}</option>
-          <option value="yes">{{ $t('anomalies.filter_compliant') }}</option>
-          <option value="no">{{ $t('anomalies.filter_non_compliant') }}</option>
-        </select>
-      </div>
-
       <!-- PENDING_REVIEW keys -->
       <section class="card">
         <h2>
@@ -43,72 +16,13 @@
             {{ pendingAll.length }}
           </span>
         </h2>
-        <table v-if="pendingFiltered.length">
-          <thead>
-            <tr>
-              <th>{{ $t('anomalies.col_fingerprint') }}</th>
-              <th>{{ $t('anomalies.col_type') }}</th>
-              <th>{{ $t('anomalies.col_server') }}</th>
-              <th>{{ $t('anomalies.col_unix_user') }}</th>
-              <th>{{ $t('anomalies.col_first_seen') }}</th>
-              <th>{{ $t('anomalies.col_compliant') }}</th>
-              <th>{{ $t('anomalies.col_actions') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="k in paginatedPending"
-              :key="k.fingerprint + k.server_hostname"
-              :data-testid="`pending-row-${k.fingerprint}`"
-            >
-              <td class="fp">
-                <code>{{ k.fingerprint }}</code>
-              </td>
-              <td>
-                <code>{{ k.key_type }}</code>
-              </td>
-              <td>
-                <router-link :to="`/servers/${k.server_hostname}`" class="server-link">
-                  {{ k.server_hostname }}
-                </router-link>
-              </td>
-              <td>
-                <code v-if="k.unix_user">{{ k.unix_user }}</code>
-                <span v-else>—</span>
-              </td>
-              <td>{{ formatDate(k.first_seen) }}</td>
-              <td>
-                <span v-if="k.is_compliant" :title="$t('key_table.compliant_ok')">✅</span>
-                <span v-else class="non-compliant" :title="complianceTooltip(k)">⚠️</span>
-              </td>
-              <td>
-                <div v-if="currentRole !== 'viewer'" class="actions">
-                  <button class="btn-success" @click="validate(k)">
-                    {{ $t('anomalies.btn_validate') }}
-                  </button>
-                  <button class="btn-danger" @click="openRevoke(k)">
-                    {{ $t('anomalies.btn_revoke') }}
-                  </button>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <p v-else-if="pendingAll.length === 0" class="empty" data-testid="pending-empty">
-          {{ $t('anomalies.no_pending') }}
-        </p>
-        <p v-else class="empty" data-testid="pending-no-results">
-          {{ $t('anomalies.no_results') }}
-        </p>
-
-        <PaginationBar
-          v-if="pendingFiltered.length > 0"
-          :current-page="pendingCurrentPage"
-          :total-pages="pendingTotalPages"
-          :total-items="pendingTotalItems"
-          :page-size="pendingPageSize"
-          @update:current-page="pendingCurrentPage = $event"
-          @update:page-size="setPendingPageSize"
+        <AnomaliesTable
+          :anomalies="pendingAll"
+          :servers="servers"
+          :current-role="currentRole"
+          type="pending"
+          @validate="validate"
+          @revoke="openRevokeByFingerprint"
         />
       </section>
 
@@ -121,58 +35,11 @@
           </span>
           <span class="subtitle">{{ $t('anomalies.subtitle_revoked') }}</span>
         </h2>
-        <table v-if="outOfSystemFiltered.length">
-          <thead>
-            <tr>
-              <th>{{ $t('anomalies.col_fingerprint') }}</th>
-              <th>{{ $t('anomalies.col_type') }}</th>
-              <th>{{ $t('anomalies.col_server') }}</th>
-              <th>{{ $t('anomalies.col_unix_user') }}</th>
-              <th>{{ $t('anomalies.col_revoked_at') }}</th>
-              <th>{{ $t('anomalies.col_details') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="k in paginatedOutOfSystem"
-              :key="k.fingerprint + k.server_hostname"
-              :data-testid="`revoked-row-${k.fingerprint}`"
-            >
-              <td class="fp">
-                <code>{{ k.fingerprint }}</code>
-              </td>
-              <td>
-                <code>{{ k.key_type }}</code>
-              </td>
-              <td>
-                <router-link :to="`/servers/${k.server_hostname}`" class="server-link">
-                  {{ k.server_hostname }}
-                </router-link>
-              </td>
-              <td>
-                <code v-if="k.unix_user">{{ k.unix_user }}</code>
-                <span v-else>—</span>
-              </td>
-              <td>{{ formatDate(k.revoked_at) }}</td>
-              <td>{{ k.revocation_justification || '—' }}</td>
-            </tr>
-          </tbody>
-        </table>
-        <p v-else-if="outOfSystemAll.length === 0" class="empty" data-testid="revoked-empty">
-          {{ $t('anomalies.no_revoked') }}
-        </p>
-        <p v-else class="empty" data-testid="revoked-no-results">
-          {{ $t('anomalies.no_results') }}
-        </p>
-
-        <PaginationBar
-          v-if="outOfSystemFiltered.length > 0"
-          :current-page="outOfSystemCurrentPage"
-          :total-pages="outOfSystemTotalPages"
-          :total-items="outOfSystemTotalItems"
-          :page-size="outOfSystemPageSize"
-          @update:current-page="outOfSystemCurrentPage = $event"
-          @update:page-size="setOutOfSystemPageSize"
+        <AnomaliesTable
+          :anomalies="outOfSystemAll"
+          :servers="servers"
+          :current-role="currentRole"
+          type="revoked"
         />
       </section>
     </template>
@@ -214,25 +81,19 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth.js'
-import { useFormatDate } from '../composables/useFormatDate.js'
-import { usePagination } from '../composables/usePagination.js'
-import PaginationBar from '../components/PaginationBar.vue'
+import AnomaliesTable from '../components/AnomaliesTable.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
-const { formatDate } = useFormatDate()
 const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const allKeys = ref([])
+const servers = ref([])
 const loading = ref(true)
 const error = ref('')
 const message = ref('')
 const revokeTarget = ref(null)
 const revokeReason = ref('')
-const filterText = ref('')
-const filterType = ref('')
-const filterServer = ref('')
-const filterCompliant = ref('')
 
 const pendingAll = computed(() => allKeys.value.filter((k) => k.status === 'PENDING_REVIEW'))
 
@@ -247,54 +108,6 @@ const outOfSystemAll = computed(() => {
       new Date(k.revoked_at) >= cutoff
   )
 })
-
-const uniqueTypes = computed(() => {
-  const all = [...pendingAll.value, ...outOfSystemAll.value]
-  return [...new Set(all.map((k) => k.key_type).filter(Boolean))].sort()
-})
-
-const uniqueServers = computed(() => {
-  const all = [...pendingAll.value, ...outOfSystemAll.value]
-  return [...new Set(all.map((k) => k.server_hostname).filter(Boolean))].sort()
-})
-
-function matchesFilter(k) {
-  const text = filterText.value.trim().toLowerCase()
-  if (text) {
-    const match =
-      k.fingerprint.toLowerCase().includes(text) ||
-      k.key_type.toLowerCase().includes(text) ||
-      (k.server_hostname || '').toLowerCase().includes(text) ||
-      (k.unix_user || '').toLowerCase().includes(text)
-    if (!match) return false
-  }
-  if (filterType.value && k.key_type !== filterType.value) return false
-  if (filterServer.value && k.server_hostname !== filterServer.value) return false
-  if (filterCompliant.value === 'yes' && !k.is_compliant) return false
-  if (filterCompliant.value === 'no' && k.is_compliant) return false
-  return true
-}
-
-const pendingFiltered = computed(() => pendingAll.value.filter(matchesFilter))
-const outOfSystemFiltered = computed(() => outOfSystemAll.value.filter(matchesFilter))
-
-const {
-  pageSize: pendingPageSize,
-  currentPage: pendingCurrentPage,
-  totalItems: pendingTotalItems,
-  totalPages: pendingTotalPages,
-  paginatedItems: paginatedPending,
-  setPageSize: setPendingPageSize,
-} = usePagination(pendingFiltered)
-
-const {
-  pageSize: outOfSystemPageSize,
-  currentPage: outOfSystemCurrentPage,
-  totalItems: outOfSystemTotalItems,
-  totalPages: outOfSystemTotalPages,
-  paginatedItems: paginatedOutOfSystem,
-  setPageSize: setOutOfSystemPageSize,
-} = usePagination(outOfSystemFiltered)
 
 async function load() {
   loading.value = true
@@ -312,17 +125,20 @@ async function load() {
 
 const efp = (fp) => encodeURIComponent(fp)
 
-async function validate(key) {
+async function validate(fingerprint, unix_user, hostname) {
   await apiAction(
-    `/api/keys/validate/${efp(key.fingerprint)}`,
-    { unix_user: key.unix_user || null, hostname: key.server_hostname || null },
+    `/api/keys/validate/${efp(fingerprint)}`,
+    { unix_user: unix_user || null, hostname: hostname || null },
     t('anomalies.key_validated')
   )
 }
 
-function openRevoke(key) {
-  revokeTarget.value = key
-  revokeReason.value = ''
+function openRevokeByFingerprint(fingerprint) {
+  const key = allKeys.value.find((k) => k.fingerprint === fingerprint)
+  if (key) {
+    revokeTarget.value = key
+    revokeReason.value = ''
+  }
 }
 
 async function confirmRevoke() {
@@ -355,14 +171,6 @@ async function apiAction(url, body, successMsg) {
   }
 }
 
-function complianceTooltip(k) {
-  if (k.key_type === 'ssh-rsa') {
-    const bits = k.key_size_bits
-    return bits ? t('key_table.non_compliant_rsa_bits', { bits }) : t('key_table.non_compliant_rsa')
-  }
-  return t('key_table.non_compliant_type')
-}
-
 onMounted(load)
 </script>
 
@@ -377,24 +185,6 @@ h2 {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-.non-compliant {
-  cursor: help;
-}
-
-.filters {
-  display: flex;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.filter-input {
-  padding: 0.35rem 0.6rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 0.875rem;
-  flex: 1;
-  max-width: 400px;
 }
 
 .card {
@@ -435,16 +225,12 @@ h2 {
   font-weight: normal;
 }
 
-.fp {
-  font-size: 0.75rem;
-  word-break: break-all;
-  max-width: 240px;
-}
 .fp-display {
   margin: 0.5rem 0 1rem;
   font-size: 0.85rem;
   word-break: break-all;
 }
+
 code {
   background: #f4f4f4;
   padding: 0 3px;
@@ -452,25 +238,6 @@ code {
   font-size: 0.8rem;
 }
 
-.server-link {
-  color: #0d6efd;
-  text-decoration: none;
-  font-weight: 500;
-}
-.server-link:hover {
-  text-decoration: underline;
-}
-
-.actions {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-.empty {
-  color: #888;
-  font-size: 0.9rem;
-  padding: 0.5rem 0;
-}
 .loading {
   text-align: center;
   padding: 2rem;

--- a/ui/src/views/Audit.vue
+++ b/ui/src/views/Audit.vue
@@ -2,126 +2,30 @@
   <div class="audit-view">
     <h1>{{ $t('audit.title') }}</h1>
 
-    <!-- Filters -->
-    <section class="filters card">
-      <div class="filter-row">
-        <div class="field">
-          <label for="f-server">{{ $t('audit.filter_server') }}</label>
-          <input id="f-server" v-model="filters.server" type="text" placeholder="hostname" />
-        </div>
-        <div class="field">
-          <label for="f-action">{{ $t('audit.filter_action') }}</label>
-          <select id="f-action" v-model="filters.action">
-            <option value="">{{ $t('audit.filter_all') }}</option>
-            <option v-for="a in ACTIONS" :key="a" :value="a">{{ a }}</option>
-          </select>
-        </div>
-        <div class="field">
-          <label for="f-since">{{ $t('audit.filter_since') }}</label>
-          <input id="f-since" v-model="filters.since" type="date" />
-        </div>
-        <button class="btn-primary" @click="load">{{ $t('audit.filter_btn') }}</button>
-        <button @click="resetFilters">{{ $t('audit.reset_btn') }}</button>
-      </div>
-    </section>
-
     <div v-if="error" class="alert-error">{{ error }}</div>
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
 
-    <section v-else class="card">
-      <table>
-        <thead>
-          <tr>
-            <th>{{ $t('audit.col_date') }}</th>
-            <th>{{ $t('audit.col_action') }}</th>
-            <th>{{ $t('audit.col_by') }}</th>
-            <th>{{ $t('audit.col_server') }}</th>
-            <th>{{ $t('audit.col_key') }}</th>
-            <th>{{ $t('audit.col_details') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-if="entries.length === 0">
-            <td colspan="6" class="empty">{{ $t('audit.empty') }}</td>
-          </tr>
-          <tr v-for="e in paginatedItems" :key="e.id" :class="rowClass(e.action)">
-            <td class="date">{{ formatDate(e.performed_at) }}</td>
-            <td>
-              <span class="badge" :class="actionBadge(e.action)">{{ e.action }}</span>
-            </td>
-            <td>{{ e.performed_by_username || '—' }}</td>
-            <td>{{ e.server_hostname || '—' }}</td>
-            <td class="fp">
-              <code v-if="e.key_fingerprint">{{ e.key_fingerprint }}</code>
-              <span v-else>—</span>
-            </td>
-            <td class="details">{{ formatDetails(e.details) }}</td>
-          </tr>
-        </tbody>
-      </table>
-
-      <PaginationBar
-        v-if="entries.length > 0"
-        :current-page="currentPage"
-        :total-pages="totalPages"
-        :total-items="totalItems"
-        :page-size="pageSize"
-        @update:current-page="currentPage = $event"
-        @update:page-size="setPageSize"
-      />
-    </section>
+    <AuditTable v-else :logs="entries" :servers="servers" />
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useFormatDate } from '../composables/useFormatDate.js'
-import { usePagination } from '../composables/usePagination.js'
-import PaginationBar from '../components/PaginationBar.vue'
+import AuditTable from '../components/AuditTable.vue'
 
 const { t } = useI18n()
-const { formatDate } = useFormatDate()
-
-const ACTIONS = [
-  'KEY_ADDED',
-  'KEY_REVOKED',
-  'KEY_EXPIRED',
-  'EXPIRY_WARNING',
-  'REQUEST_APPROVED',
-  'REQUEST_REJECTED',
-  'ANOMALY_DETECTED',
-  'SCAN_COMPLETED',
-  'SCAN_FAILED',
-  'SCRIPT_DEPLOYED',
-  'SERVER_ADDED',
-  'SERVER_DISABLED',
-  'ADMIN_ADDED',
-  'ADMIN_DISABLED',
-]
-
-const CRITICAL_ACTIONS = new Set(['ANOMALY_DETECTED', 'SCAN_FAILED', 'KEY_REVOKED'])
-const WARNING_ACTIONS = new Set(['EXPIRY_WARNING', 'KEY_EXPIRED'])
 
 const entries = ref([])
+const servers = ref([])
 const loading = ref(true)
 const error = ref('')
-
-const filters = ref({ server: '', action: '', since: '' })
-
-const entriesComputed = computed(() => entries.value)
-const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(entriesComputed)
 
 async function load() {
   loading.value = true
   error.value = ''
   try {
-    const params = new URLSearchParams()
-    if (filters.value.server) params.set('server', filters.value.server)
-    if (filters.value.action) params.set('action', filters.value.action)
-    if (filters.value.since) params.set('since', filters.value.since)
-    const res = await fetch(`/api/audit?${params}`)
+    const res = await fetch('/api/audit')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     entries.value = await res.json()
   } catch (e) {
@@ -129,31 +33,6 @@ async function load() {
   } finally {
     loading.value = false
   }
-}
-
-function resetFilters() {
-  filters.value = { server: '', action: '', since: '' }
-  load()
-}
-
-function rowClass(action) {
-  if (CRITICAL_ACTIONS.has(action)) return 'row-danger'
-  if (WARNING_ACTIONS.has(action)) return 'row-warning'
-  return ''
-}
-
-function actionBadge(action) {
-  if (CRITICAL_ACTIONS.has(action)) return 'badge-critical'
-  if (WARNING_ACTIONS.has(action)) return 'badge-pending'
-  return 'badge-active'
-}
-
-function formatDetails(details) {
-  if (!details) return '—'
-  if (typeof details === 'string') return details
-  return Object.entries(details)
-    .map(([k, v]) => `${k}: ${v}`)
-    .join(' | ')
 }
 
 onMounted(load)
@@ -165,83 +44,10 @@ h1 {
   margin-bottom: 1.25rem;
 }
 
-.card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
-  border-radius: 6px;
-  padding: 1.25rem;
-  margin-bottom: 1.25rem;
-}
-
-.filters {
-  padding: 1rem 1.25rem;
-}
-
-.filter-row {
-  display: flex;
-  align-items: flex-end;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: #555;
-}
-
-input[type='text'],
-input[type='date'],
-select {
-  padding: 0.35rem 0.6rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  min-width: 140px;
-}
-
-.date {
-  white-space: nowrap;
-  font-size: 0.82rem;
-}
-.fp {
-  font-size: 0.72rem;
-  word-break: break-all;
-  max-width: 200px;
-}
-.details {
-  font-size: 0.8rem;
-  color: #555;
-  max-width: 220px;
-}
-
-code {
-  background: #f4f4f4;
-  padding: 0 3px;
-  border-radius: 3px;
-}
-
-.empty {
-  text-align: center;
-  color: #888;
-  padding: 1rem 0;
-}
 .loading {
   text-align: center;
   padding: 2rem;
   color: #888;
-}
-
-.row-danger {
-  background: #fff5f5;
-}
-.row-warning {
-  background: #fffbf0;
 }
 
 .alert-error {

--- a/ui/tests/AdminsTable.spec.js
+++ b/ui/tests/AdminsTable.spec.js
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AdminsTable from '../src/components/AdminsTable.vue'
+import PaginationBar from '../src/components/PaginationBar.vue'
+import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en },
+})
+
+describe('AdminsTable.vue', () => {
+  const admins = [
+    {
+      id: '1',
+      username: 'alice',
+      email: 'alice@example.com',
+      role: 'sysadmin',
+      is_active: true,
+      receive_alerts: true,
+      created_at: '2024-01-15T10:00:00Z',
+    },
+    {
+      id: '2',
+      username: 'bob',
+      email: 'bob@example.com',
+      role: 'operator',
+      is_active: false,
+      receive_alerts: false,
+      created_at: '2024-01-16T10:00:00Z',
+    },
+    {
+      id: '3',
+      username: 'charlie',
+      email: 'charlie@example.com',
+      role: 'viewer',
+      is_active: true,
+      receive_alerts: true,
+      created_at: '2024-01-17T10:00:00Z',
+    },
+  ]
+
+  it('renders admin list', () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.text()).toContain('alice')
+    expect(wrapper.text()).toContain('bob')
+    expect(wrapper.text()).toContain('charlie')
+  })
+
+  it('filters by username', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const input = wrapper.find('[data-testid="admins-filter-text"]')
+    await input.setValue('bob')
+    expect(wrapper.text()).toContain('bob')
+    expect(wrapper.text()).not.toContain('alice')
+    expect(wrapper.text()).not.toContain('charlie')
+  })
+
+  it('paginates at 10 rows by default', () => {
+    const manyAdmins = Array.from({ length: 25 }, (_, i) => ({
+      id: `${i}`,
+      username: `user${i}`,
+      email: `user${i}@example.com`,
+      role: 'viewer',
+      is_active: true,
+      receive_alerts: false,
+      created_at: '2024-01-01T10:00:00Z',
+    }))
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins: manyAdmins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(10)
+  })
+
+  it('hides action buttons for non-sysadmin', () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'bob',
+        currentRole: 'operator',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.find('[data-testid="btn-disable-alice"]').exists()).toBe(false)
+  })
+
+  it('shows action buttons for sysadmin', () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    // bob is inactive, so enable and delete buttons are shown
+    expect(wrapper.find('[data-testid="btn-enable-bob"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="btn-delete-bob"]').exists()).toBe(true)
+    // charlie is active, so disable and delete buttons are shown
+    expect(wrapper.find('[data-testid="btn-disable-charlie"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="btn-delete-charlie"]').exists()).toBe(true)
+  })
+
+  it('does not show disable button for current user', () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.find('[data-testid="btn-disable-alice"]').exists()).toBe(false)
+  })
+
+  it('emits enable event', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    await wrapper.find('[data-testid="btn-enable-bob"]').trigger('click')
+    expect(wrapper.emitted().enable).toBeTruthy()
+    expect(wrapper.emitted().enable[0]).toEqual(['bob'])
+  })
+
+  it('emits disable event', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    await wrapper.find('[data-testid="btn-disable-charlie"]').trigger('click')
+    expect(wrapper.emitted().disable).toBeTruthy()
+    expect(wrapper.emitted().disable[0]).toEqual(['charlie'])
+  })
+
+  it('emits delete event', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    await wrapper.find('[data-testid="btn-delete-bob"]').trigger('click')
+    expect(wrapper.emitted().delete).toBeTruthy()
+    expect(wrapper.emitted().delete[0]).toEqual(['bob'])
+  })
+
+  it('emits changePassword event', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    await wrapper.find('[data-testid="btn-password-alice"]').trigger('click')
+    expect(wrapper.emitted().changePassword).toBeTruthy()
+    expect(wrapper.emitted().changePassword[0]).toEqual(['alice'])
+  })
+
+  it('emits toggleAlerts event', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    await wrapper.find('[data-testid="btn-alerts-off-alice"]').trigger('click')
+    expect(wrapper.emitted().toggleAlerts).toBeTruthy()
+    expect(wrapper.emitted().toggleAlerts[0]).toEqual(['alice', false])
+  })
+
+  it('shows empty state when no admins', () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins: [],
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.text()).toContain('No administrator')
+  })
+
+  it('shows no results when filter does not match', async () => {
+    const wrapper = mount(AdminsTable, {
+      props: {
+        admins,
+        currentUsername: 'alice',
+        currentRole: 'sysadmin',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const input = wrapper.find('[data-testid="admins-filter-text"]')
+    await input.setValue('nonexistent')
+    expect(wrapper.text()).toContain('No matching administrators')
+  })
+})

--- a/ui/tests/AnomaliesTable.spec.js
+++ b/ui/tests/AnomaliesTable.spec.js
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AnomaliesTable from '../src/components/AnomaliesTable.vue'
+import PaginationBar from '../src/components/PaginationBar.vue'
+import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en },
+})
+
+describe('AnomaliesTable.vue', () => {
+  const pendingAnomalies = [
+    {
+      fingerprint: 'SHA256:abc123',
+      key_type: 'ssh-ed25519',
+      server_hostname: 'server1',
+      unix_user: 'root',
+      first_seen: '2024-01-15T10:00:00Z',
+      is_compliant: true,
+    },
+    {
+      fingerprint: 'SHA256:def456',
+      key_type: 'ssh-rsa',
+      server_hostname: 'server2',
+      unix_user: 'alice',
+      first_seen: '2024-01-16T10:00:00Z',
+      is_compliant: false,
+      key_size_bits: 2048,
+    },
+  ]
+
+  const revokedAnomalies = [
+    {
+      fingerprint: 'SHA256:xyz789',
+      key_type: 'ssh-ed25519',
+      server_hostname: 'server1',
+      unix_user: 'bob',
+      revoked_at: '2024-01-17T10:00:00Z',
+      revocation_justification: 'Manual removal',
+      is_compliant: true,
+    },
+  ]
+
+  it('renders pending anomalies', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).toContain('SHA256:abc123')
+    expect(wrapper.text()).toContain('SHA256:def456')
+  })
+
+  it('filters by text', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const input = wrapper.find('[data-testid="anomalies-filter-text"]')
+    await input.setValue('alice')
+    expect(wrapper.text()).toContain('SHA256:def456')
+    expect(wrapper.text()).not.toContain('SHA256:abc123')
+  })
+
+  it('paginates at 10 rows by default', () => {
+    const manyAnomalies = Array.from({ length: 25 }, (_, i) => ({
+      fingerprint: `SHA256:key${i}`,
+      key_type: 'ssh-ed25519',
+      server_hostname: 'server1',
+      unix_user: 'root',
+      first_seen: '2024-01-01T10:00:00Z',
+      is_compliant: true,
+    }))
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: manyAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(10)
+  })
+
+  it('shows validate and revoke buttons for operator on pending', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).toContain('Validate')
+    expect(wrapper.text()).toContain('Revoke')
+  })
+
+  it('hides action buttons for viewer on pending', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'viewer',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).not.toContain('Validate')
+    expect(wrapper.text()).not.toContain('Revoke')
+  })
+
+  it('emits validate event with fingerprint, unix_user, and hostname', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const validateBtns = wrapper.findAll('button.btn-success')
+    await validateBtns[0].trigger('click')
+    expect(wrapper.emitted().validate).toBeTruthy()
+    expect(wrapper.emitted().validate[0]).toEqual(['SHA256:abc123', 'root', 'server1'])
+  })
+
+  it('emits revoke event with fingerprint', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const revokeBtns = wrapper.findAll('button.btn-danger')
+    await revokeBtns[0].trigger('click')
+    expect(wrapper.emitted().revoke).toBeTruthy()
+    expect(wrapper.emitted().revoke[0]).toEqual(['SHA256:abc123'])
+  })
+
+  it('shows empty state for pending when no anomalies', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: [],
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).toContain('No keys awaiting validation')
+  })
+
+  it('shows empty state for revoked when no anomalies', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: [],
+        servers: [],
+        currentRole: 'operator',
+        type: 'revoked',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).toContain('No out-of-system revocations in 30 days')
+  })
+
+  it('shows no results when filter does not match', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const input = wrapper.find('[data-testid="anomalies-filter-text"]')
+    await input.setValue('nonexistent')
+    expect(wrapper.text()).toContain('No matching anomalies')
+  })
+
+  it('shows revoked anomalies with justification', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: revokedAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'revoked',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.text()).toContain('SHA256:xyz789')
+    expect(wrapper.text()).toContain('Manual removal')
+  })
+
+  it('filters by type dropdown', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const select = wrapper.find('[data-testid="anomalies-filter-type"]')
+    await select.setValue('ssh-rsa')
+    expect(wrapper.text()).toContain('SHA256:def456')
+    expect(wrapper.text()).not.toContain('SHA256:abc123')
+  })
+
+  it('filters by compliance dropdown', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const select = wrapper.find('[data-testid="anomalies-filter-compliant"]')
+    await select.setValue('no')
+    expect(wrapper.text()).toContain('SHA256:def456')
+    expect(wrapper.text()).not.toContain('SHA256:abc123')
+  })
+})

--- a/ui/tests/AuditTable.spec.js
+++ b/ui/tests/AuditTable.spec.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AuditTable from '../src/components/AuditTable.vue'
+import PaginationBar from '../src/components/PaginationBar.vue'
+import { createI18n } from 'vue-i18n'
+import en from '../src/locales/en.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en },
+})
+
+describe('AuditTable.vue', () => {
+  const logs = [
+    {
+      id: '1',
+      action: 'KEY_ADDED',
+      performed_at: '2024-01-15T10:00:00Z',
+      performed_by_username: 'alice',
+      server_hostname: 'server1',
+      key_fingerprint: 'SHA256:abc123',
+      details: { user: 'root' },
+    },
+    {
+      id: '2',
+      action: 'SCAN_FAILED',
+      performed_at: '2024-01-16T10:00:00Z',
+      performed_by_username: null,
+      server_hostname: 'server2',
+      key_fingerprint: null,
+      details: null,
+    },
+    {
+      id: '3',
+      action: 'EXPIRY_WARNING',
+      performed_at: '2024-01-17T10:00:00Z',
+      performed_by_username: 'bob',
+      server_hostname: 'server1',
+      key_fingerprint: 'SHA256:def456',
+      details: { days: 7 },
+    },
+  ]
+
+  it('renders audit logs', () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.text()).toContain('KEY_ADDED')
+    expect(wrapper.text()).toContain('SCAN_FAILED')
+    expect(wrapper.text()).toContain('EXPIRY_WARNING')
+  })
+
+  it('filters by action', async () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const select = wrapper.find('#f-action')
+    await select.setValue('SCAN_FAILED')
+    await wrapper.find('button.btn-primary').trigger('click')
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+    expect(rows[0].text()).toContain('SCAN_FAILED')
+  })
+
+  it('paginates at 10 rows by default', () => {
+    const manyLogs = Array.from({ length: 25 }, (_, i) => ({
+      id: `${i}`,
+      action: 'KEY_ADDED',
+      performed_at: '2024-01-01T10:00:00Z',
+      performed_by_username: 'alice',
+      server_hostname: `server${i}`,
+      key_fingerprint: null,
+      details: null,
+    }))
+    const wrapper = mount(AuditTable, {
+      props: { logs: manyLogs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(10)
+  })
+
+  it('shows empty state when no logs', () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs: [], servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    expect(wrapper.text()).toContain('No audit entries')
+  })
+
+  it('shows no results when filter does not match', async () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const select = wrapper.find('#f-action')
+    await select.setValue('ADMIN_ADDED')
+    await wrapper.find('button.btn-primary').trigger('click')
+    expect(wrapper.text()).toContain('No matching audit entries')
+  })
+
+  it('applies row class for critical actions', () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const rows = wrapper.findAll('tbody tr')
+    const scanFailedRow = rows.find((r) => r.text().includes('SCAN_FAILED'))
+    expect(scanFailedRow.classes()).toContain('row-danger')
+  })
+
+  it('applies row class for warning actions', () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const rows = wrapper.findAll('tbody tr')
+    const warningRow = rows.find((r) => r.text().includes('EXPIRY_WARNING'))
+    expect(warningRow.classes()).toContain('row-warning')
+  })
+
+  it('resets filters on reset button click', async () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const select = wrapper.find('#f-action')
+    await select.setValue('SCAN_FAILED')
+    await wrapper.find('button.btn-primary').trigger('click')
+    let rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(1)
+
+    const resetBtn = wrapper.findAll('button').find((b) => b.text().includes('Reset'))
+    await resetBtn.trigger('click')
+    rows = wrapper.findAll('tbody tr')
+    expect(rows.length).toBe(3)
+  })
+})


### PR DESCRIPTION
## Summary

- `AdminsTable.vue` — extrait de `Admins.vue` (filtrage, pagination, RBAC, garde-fou self)
- `AuditTable.vue` — extrait de `Audit.vue` (filtres serveur/action/date, pagination)
- `AnomaliesTable.vue` — extrait de `Anomalies.vue` (filtres texte/type/conformité, pagination, RBAC)
- Les 3 vues conservent uniquement : fetch API, modals, messages erreur/succès
- Cohérence avec `ServerTable.vue`, `KeyTable.vue`, `DeployedUsersTable.vue`

Closes #250

## Test plan

- [ ] 228 tests Vitest passent (`npm run test -- --run`)
- [ ] AdminsTable : filtre texte, pagination, boutons RBAC sysadmin, garde-fou self
- [ ] AuditTable : filtres serveur/action/date, reset, row-danger/row-warning
- [ ] AnomaliesTable : filtres texte/type/conformité, boutons operator vs viewer
- [ ] Modals Admins.vue toujours fonctionnels (add, enable, disable, delete, password)