### PR TITLE
docs: update CLAUDE.md for issue #253 (SSH session history)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Projet "ssh-access-manager" — audit et gestion des accès SSH dans un containe
 VAE RNCP41330 "Expert en développement logiciel" Niveau 7 — C.1.6.
 Développeur : Stéphane de Labrusse.
 
-## État du projet — toutes issues fermées (48/48)
+## État du projet — toutes issues fermées (49/49)
 
-Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239) ✅
+Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253) ✅
 
 ## Stack vérifiée et figée
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -205,7 +205,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - Couverture minimale actions.py : 80%
 - pytest doit passer avant tout commit
 
-Fichiers : conftest.py, test_db.py (7), test_servers.py (6), test_ssh.py (15), test_actions.py (74), test_collect.py (34), test_expire.py (9), test_alerts.py (12), test_web.py (42+), test_manage.py (40+).
+Fichiers : conftest.py, test_db.py (7), test_servers.py (9), test_ssh.py (38), test_actions.py (93), test_collect.py (34), test_expire.py (12), test_alerts.py (19), test_web.py (115), test_manage.py (35).
 
 Fixtures obligatoires dans conftest.py : `mock_db`, `mock_ssh_client`, `mock_smtp`, `sample_server`, `sample_key`.
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -28,6 +28,7 @@
 | AuditTable.vue | Tableau audit + filtres serveur/action/date + pagination (#250) |
 | AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) |
 | PaginationBar.vue | Composant pagination réutilisable avec contrôles taille de page |
+| SessionsCard.vue | Sessions SSH actives + modal Full History (filtres user/ip/date, pagination, export CSV) — sysadmin/operator uniquement (#253) |
 
 ## Composables
 
@@ -55,10 +56,10 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 |---------|-------|--------------------|
 | KeyActions.spec.js | 14 | modal confirmation révocation |
 | ExpiryPicker.spec.js | 9 | modes exclusifs heures/date |
-| ServerTable.spec.js | 15 | filtres hostname/IP/env, badges statut |
+| ServerTable.spec.js | 16 | filtres hostname/IP/env, badges statut |
 | KeyTable.spec.js | 30 | boutons par statut, owner, expires_at, filtres |
 | Admins.spec.js | 31 | modals enable/delete, RBAC, toggle alerts |
-| Settings.spec.js | 14 | validation champs, SMTP test |
+| Settings.spec.js | 18 | validation champs, SMTP test |
 | DeployKeyForm.spec.js | 16 | formulaire déploiement clé SSH |
 | UserLockForm.spec.js | 10 | lock/unlock compte Unix |
 | DeployedUsersTable.spec.js | 12 | filtres, RBAC operator/viewer |
@@ -66,6 +67,7 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | Login.spec.js | 8 | checkbox remember-me, payload remember_me |
 | AdminsTable.spec.js | 13 | filtre texte, pagination, RBAC, garde-fou self, events (#250) |
 | AuditTable.spec.js | 8 | filtres serveur/action/date, pagination, row classes (#250) |
-| AnomaliesTable.spec.js | 14 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
+| AnomaliesTable.spec.js | 13 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
+| SessionsCard.spec.js | 17 | sessions actives, modal historique, filtres, pagination, CSV export, RBAC (#253) |
 
 vitest doit passer avant tout commit.


### PR DESCRIPTION
## Summary

- CLAUDE.md : compteur 48/48 → 49/49, ajout #253 dans la liste des issues
- app/CLAUDE.md : mise à jour des compteurs de tests (test_ssh 15→38, test_web 42+→115, etc.)
- ui/CLAUDE.md : ajout SessionsCard.vue dans les composants, SessionsCard.spec.js dans les tests (17 tests), correction des compteurs existants (ServerTable 15→16, Settings 14→18, AnomaliesTable 14→13)

Closes #253