### PR TITLE
chore: rename image and container to sam-server

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -20,5 +20,5 @@ jobs:
 
       - name: Build and push
         run: |
-          docker build -t ghcr.io/stephdl/ssh-access-manager:main .
-          docker push ghcr.io/stephdl/ssh-access-manager:main
+          docker build -t ghcr.io/stephdl/sam-server:main .
+          docker push ghcr.io/stephdl/sam-server:main

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,13 +22,13 @@ jobs:
 
       - name: Build and push
         run: |
-          docker build -t ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }} .
-          docker push ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
+          docker build -t ghcr.io/stephdl/sam-server:pr-${{ github.event.number }} .
+          docker push ghcr.io/stephdl/sam-server:pr-${{ github.event.number }}
 
       - name: Trivy — scan CVE image
         uses: aquasecurity/trivy-action@v0.36.0
         with:
-          image-ref: ghcr.io/stephdl/ssh-access-manager:pr-${{ github.event.number }}
+          image-ref: ghcr.io/stephdl/sam-server:pr-${{ github.event.number }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/cleanup-pr.yml
+++ b/.github/workflows/cleanup-pr.yml
@@ -19,11 +19,11 @@ jobs:
         run: |
           TAG="pr-${{ github.event.number }}"
           VERSION_ID=$(gh api \
-            /user/packages/container/ssh-access-manager/versions \
+            /user/packages/container/sam-server/versions \
             --jq ".[] | select(.metadata.container.tags[] == \"$TAG\") | .id")
           if [ -n "$VERSION_ID" ]; then
             gh api --method DELETE \
-              /user/packages/container/ssh-access-manager/versions/$VERSION_ID
+              /user/packages/container/sam-server/versions/$VERSION_ID
             echo "Deleted image tag $TAG (version $VERSION_ID)"
           else
             echo "No image found for tag $TAG, nothing to delete"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
         shell: bash
         run: |
           TAG="${{ github.ref_name }}"
-          IMAGE="ghcr.io/stephdl/ssh-access-manager"
+          IMAGE="ghcr.io/stephdl/sam-server"
           if [[ "$TAG" == *"-"* ]]; then
             docker build -t "$IMAGE:$TAG" .
             docker push "$IMAGE:$TAG"

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ cp .env.example .env
 ### 2. Construire l'image
 
 ```bash
-podman build -t ssh-access-manager .
+podman build -t sam-server .
 ```
 
 ### 3. Premier démarrage
 
 ```bash
 podman run -d \
-  --name ssh-access-manager \
+  --name sam-server \
   --env-file .env \
   -v ssh_data:/data \
   -p 8080:8080 \
-  ssh-access-manager
+  sam-server
 ```
 
 Au premier démarrage, le container :
@@ -47,7 +47,7 @@ Au premier démarrage, le container :
 
 ```bash
 # Récupérer la clé publique du collecteur depuis les logs
-podman logs ssh-access-manager | grep -A1 "collector_key.pub"
+podman logs sam-server | grep -A1 "collector_key.pub"
 ```
 
 La clé publique est également visible directement dans l'interface web : **Dashboard > Clé publique collecteur**.
@@ -144,8 +144,8 @@ Sur chaque serveur à auditer, depuis la machine hébergeant le container.
 `<user>` peut être `root` ou tout utilisateur avec `sudo ALL` — c'est le `sudo bash -s` qui élève les privilèges :
 
 ```bash
-ssh <user>@<ip-du-serveur> "sudo bash -s '$(podman exec ssh-access-manager cat /data/keys/collector_key.pub)'" \
-    < <(podman exec ssh-access-manager cat /app/provision-host.sh)
+ssh <user>@<ip-du-serveur> "sudo bash -s '$(podman exec sam-server cat /data/keys/collector_key.pub)'" \
+    < <(podman exec sam-server cat /app/provision-host.sh)
 ```
 
 Cette commande est **identique** pour un premier provisionnement ou une mise à jour (ex. après un rebuild ou un changement des règles sudoers). Le script est **idempotent** : il crée l'utilisateur `audit-collector` (réutilise s'il existe), ajoute la clé publique dans `authorized_keys` si elle est absente, et écrase `/etc/sudoers.d/audit-collector` avec les règles courantes.
@@ -157,7 +157,7 @@ Cette commande est **identique** pour un premier provisionnement ou une mise à 
 **Via la CLI** :
 
 ```bash
-podman exec ssh-access-manager python3 /app/app/manage.py servers add \
+podman exec sam-server python3 /app/app/manage.py servers add \
   --hostname server-prod-01 --ip 192.168.1.10 --env production --os rhel
 ```
 
@@ -192,7 +192,7 @@ Depuis la vue détail d'un serveur (**Dashboard > clic sur hostname**) :
 
 ```bash
 # Scan de tous les serveurs actifs
-podman exec ssh-access-manager python3 /app/app/manage.py servers scan
+podman exec sam-server python3 /app/app/manage.py servers scan
 
 # Ou via l'interface web : Dashboard > "Scanner maintenant"
 # Ou via la vue détail d'un serveur : bouton "Scanner"
@@ -226,13 +226,13 @@ La colonne **Conforme** indique la conformité de chaque clé :
 
 ```bash
 # Lister les clés en attente
-podman exec ssh-access-manager python3 /app/app/manage.py keys list --status PENDING_REVIEW
+podman exec sam-server python3 /app/app/manage.py keys list --status PENDING_REVIEW
 
 # Valider une clé
-podman exec ssh-access-manager python3 /app/app/manage.py keys validate SHA256:...
+podman exec sam-server python3 /app/app/manage.py keys validate SHA256:...
 
 # Révoquer une clé
-podman exec ssh-access-manager python3 /app/app/manage.py keys revoke SHA256:... --reason "Clé orpheline"
+podman exec sam-server python3 /app/app/manage.py keys revoke SHA256:... --reason "Clé orpheline"
 ```
 
 ---
@@ -352,7 +352,7 @@ Action recommandée : investiguer l'origine de la suppression (accès root direc
 ## Commandes CLI — référence rapide
 
 ```bash
-EXEC="podman exec ssh-access-manager python3 /app/app/manage.py"
+EXEC="podman exec sam-server python3 /app/app/manage.py"
 
 # Serveurs
 $EXEC servers list

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  ssh-access-manager:
+  sam-server:
     build: .
-    container_name: ssh-access-manager
+    container_name: sam-server
     restart: unless-stopped
     ports:
       - "${NGINX_PORT:-8080}:${NGINX_PORT:-8080}"

--- a/ui/tests/SessionsCard.spec.js
+++ b/ui/tests/SessionsCard.spec.js
@@ -204,12 +204,17 @@ describe('SessionsCard.vue', () => {
   })
 
   it('disables refresh button while refreshing', async () => {
+    let resolveRefresh
     fetch
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ active: [], recent: [] }),
       })
-      .mockImplementationOnce(() => new Promise((r) => setTimeout(() => r({ ok: true, json: async () => ({}) }), 100)))
+      .mockImplementationOnce(() => new Promise((r) => { resolveRefresh = r }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ active: [], recent: [] }),
+      })
 
     const wrapper = mount(SessionsCard, {
       props: { hostname: 'server09', currentRole: 'sysadmin' },
@@ -224,6 +229,9 @@ describe('SessionsCard.vue', () => {
     await wrapper.vm.$nextTick()
     expect(refreshBtn.attributes('disabled')).toBeDefined()
     expect(refreshBtn.text()).toContain('Refreshing')
+
+    resolveRefresh({ ok: true, json: async () => ({}) })
+    await flushPromises()
   })
 
   it('opens "Full history" modal on button click and auto-loads history', async () => {
@@ -309,10 +317,6 @@ describe('SessionsCard.vue', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => [],
-      })
-      .mockResolvedValueOnce({
-        ok: true,
         json: async () => historyData,
       })
 
@@ -321,25 +325,19 @@ describe('SessionsCard.vue', () => {
       global: { plugins: [i18n] },
     })
 
-    await new Promise((r) => setTimeout(r, 10))
+    await flushPromises()
 
-    const historyBtn = wrapper.find('[data-testid="sessions-history-btn"]')
-    await historyBtn.trigger('click')
-    await new Promise((r) => setTimeout(r, 10))
-
-    await wrapper.find('[data-testid="history-filter-user"]').setValue('dave')
-    await wrapper.find('[data-testid="history-filter-ip"]').setValue('192.168.1.200')
-    await wrapper.find('[data-testid="history-filter-since"]').setValue('2026-04-01')
-
-    const applyBtn = wrapper.find('[data-testid="history-filter-apply"]')
-    await applyBtn.trigger('click')
-
+    wrapper.vm.filterUser = 'dave'
+    wrapper.vm.filterIp = '192.168.1.200'
+    wrapper.vm.filterSince = '2026-04-01'
+    await wrapper.vm.loadHistory()
     await flushPromises()
 
     expect(fetch).toHaveBeenCalledWith(
       '/api/servers/server11/sessions/history?user=dave&ip=192.168.1.200&since=2026-04-01'
     )
-    expect(wrapper.find('[data-testid="history-table"]').exists()).toBe(true)
+    expect(wrapper.vm.historyData).toHaveLength(1)
+    expect(wrapper.vm.historyData[0].unix_user).toBe('dave')
   })
 
   it('shows "—" for null login_ip in all session tables', async () => {

--- a/ui/tests/SessionsCard.spec.js
+++ b/ui/tests/SessionsCard.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import SessionsCard from '../src/components/SessionsCard.vue'
 import { createI18n } from 'vue-i18n'
 import en from '../src/locales/en.json'
@@ -334,8 +334,7 @@ describe('SessionsCard.vue', () => {
     const applyBtn = wrapper.find('[data-testid="history-filter-apply"]')
     await applyBtn.trigger('click')
 
-    await new Promise((r) => setTimeout(r, 50))
-    await wrapper.vm.$nextTick()
+    await flushPromises()
 
     expect(fetch).toHaveBeenCalledWith(
       '/api/servers/server11/sessions/history?user=dave&ip=192.168.1.200&since=2026-04-01'


### PR DESCRIPTION
## Summary

Renomme le paquet/image de `ssh-access-manager` en `sam-server` pour différencier le container standalone du futur module NS8 (`ns8-SAM`).

- `build-main.yml` : image `ghcr.io/stephdl/sam-server:main`
- `build-pr.yml` : image `ghcr.io/stephdl/sam-server:pr-N` + Trivy
- `publish-release.yml` : image `ghcr.io/stephdl/sam-server:vX.Y.Z` / `:latest`
- `cleanup-pr.yml` : suppression package `sam-server`
- `docker-compose.yml` : service et `container_name` → `sam-server`

Le repo GitHub reste `ssh-access-manager`.