### PR TITLE
feat: add server link and IP column in Deployed Users table

### DIFF
--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -62,7 +62,7 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | Settings.spec.js | 18 | validation champs, SMTP test |
 | DeployKeyForm.spec.js | 16 | formulaire déploiement clé SSH |
 | UserLockForm.spec.js | 10 | lock/unlock compte Unix |
-| DeployedUsersTable.spec.js | 12 | filtres, RBAC operator/viewer |
+| DeployedUsersTable.spec.js | 15 | filtres, RBAC operator/viewer, lien serveur, colonne IP |
 | Anomalies.spec.js | 20 | filtres texte + dropdowns, unix_user, badges |
 | Login.spec.js | 8 | checkbox remember-me, payload remember_me |
 | AdminsTable.spec.js | 13 | filtre texte, pagination, RBAC, garde-fou self, events (#250) |

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -33,6 +33,7 @@
           <tr>
             <th>{{ $t('deployedUsers.col_user') }}</th>
             <th>{{ $t('deployedUsers.col_server') }}</th>
+            <th>{{ $t('deployedUsers.col_ip') }}</th>
             <th>{{ $t('deployedUsers.col_expires') }}</th>
             <th>{{ $t('deployedUsers.col_status') }}</th>
             <th v-if="currentRole !== 'viewer'">{{ $t('deployedUsers.col_actions') }}</th>
@@ -45,7 +46,10 @@
             :data-testid="`row-${user.unix_user}-${user.hostname}`"
           >
             <td>{{ user.unix_user }}</td>
-            <td>{{ user.hostname }}</td>
+            <td>
+              <RouterLink :to="`/servers/${user.hostname}`">{{ user.hostname }}</RouterLink>
+            </td>
+            <td>{{ user.ip_address || '—' }}</td>
             <td>{{ formatExpiry(user.expires_at) }}</td>
             <td>
               <span
@@ -100,7 +104,7 @@
           </tr>
           <tr v-if="filteredUsers.length === 0">
             <td
-              :colspan="currentRole !== 'viewer' ? 5 : 4"
+              :colspan="currentRole !== 'viewer' ? 6 : 5"
               class="empty-filtered"
               data-testid="empty-filtered"
             >
@@ -129,6 +133,7 @@
 
 <script setup>
 import { ref, computed, onMounted, defineExpose } from 'vue'
+import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -360,6 +360,7 @@
     "title": "Bereitgestellte Benutzer",
     "col_user": "Unix-Benutzer",
     "col_server": "Server",
+    "col_ip": "IP",
     "col_expires": "Läuft ab",
     "col_status": "Status",
     "col_actions": "Aktionen",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -360,6 +360,7 @@
     "title": "Deployed Users",
     "col_user": "Unix User",
     "col_server": "Server",
+    "col_ip": "IP",
     "col_expires": "Expires",
     "col_status": "Status",
     "col_actions": "Actions",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -360,6 +360,7 @@
     "title": "Usuarios desplegados",
     "col_user": "Usuario Unix",
     "col_server": "Servidor",
+    "col_ip": "IP",
     "col_expires": "Expira",
     "col_status": "Estado",
     "col_actions": "Acciones",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -360,6 +360,7 @@
     "title": "Utilisateurs déployés",
     "col_user": "Utilisateur Unix",
     "col_server": "Serveur",
+    "col_ip": "IP",
     "col_expires": "Expire le",
     "col_status": "Statut",
     "col_actions": "Actions",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -360,6 +360,7 @@
     "title": "Utenti distribuiti",
     "col_user": "Utente Unix",
     "col_server": "Server",
+    "col_ip": "IP",
     "col_expires": "Scade il",
     "col_status": "Stato",
     "col_actions": "Azioni",

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -12,6 +12,8 @@ vi.mock('../src/composables/useAuth.js', () => ({
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 
+const RouterLinkStub = { template: '<a :href="to" data-testid="router-link"><slot /></a>', props: ['to'] }
+
 const MOCK_USERS = [
   {
     unix_user: 'alice',
@@ -28,6 +30,10 @@ const MOCK_USERS = [
     fingerprint: 'SHA256:def456',
   },
 ]
+
+const mountOpts = {
+  global: { plugins: [i18n], stubs: { RouterLink: RouterLinkStub } },
+}
 
 beforeEach(() => {
   mockAdmin.value = { username: 'admin', role: 'sysadmin' }
@@ -52,7 +58,7 @@ describe('DeployedUsersTable', () => {
     })
     vi.stubGlobal('fetch', fetchSpy)
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     expect(fetchSpy).toHaveBeenCalledWith('/api/access/deployed-users')
@@ -60,7 +66,7 @@ describe('DeployedUsersTable', () => {
   })
 
   it('affiche les lignes avec unix_user et hostname', async () => {
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     const row1 = w.find('[data-testid="row-alice-prod-01"]')
@@ -75,8 +81,37 @@ describe('DeployedUsersTable', () => {
     expect(row2.text()).toContain('staging-01')
   })
 
+  it('le hostname est un lien vers /servers/{hostname}', async () => {
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    const links = w.findAll('a')
+    const hrefs = links.map((l) => l.attributes('href'))
+    expect(hrefs).toContain('/servers/prod-01')
+    expect(hrefs).toContain('/servers/staging-01')
+  })
+
+  it('affiche la colonne IP avec ip_address', async () => {
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    expect(w.find('[data-testid="row-alice-prod-01"]').text()).toContain('10.0.0.1')
+    expect(w.find('[data-testid="row-bob-staging-01"]').text()).toContain('10.0.0.2')
+  })
+
+  it('affiche "—" si ip_address est null', async () => {
+    const usersNoIp = [{ ...MOCK_USERS[0], ip_address: null }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(usersNoIp) }))
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    const row = w.find('[data-testid="row-alice-prod-01"]')
+    expect(row.text()).toContain('—')
+  })
+
   it('affiche "Unlimited" si expires_at null', async () => {
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     const row1 = w.find('[data-testid="row-alice-prod-01"]')
@@ -84,7 +119,7 @@ describe('DeployedUsersTable', () => {
   })
 
   it('affiche la date formatée si expires_at non null', async () => {
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     const row2 = w.find('[data-testid="row-bob-staging-01"]')
@@ -100,7 +135,7 @@ describe('DeployedUsersTable', () => {
       })
     )
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     expect(w.find('[data-testid="empty-state"]').exists()).toBe(true)
@@ -133,7 +168,7 @@ describe('DeployedUsersTable', () => {
       }
     })
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     await w.find('[data-testid="btn-lock-alice-prod-01"]').trigger('click')
@@ -174,7 +209,7 @@ describe('DeployedUsersTable', () => {
       }
     })
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     await w.find('[data-testid="btn-unlock-bob-staging-01"]').trigger('click')
@@ -208,7 +243,7 @@ describe('DeployedUsersTable', () => {
       }
     })
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     await w.find('[data-testid="btn-lock-alice-prod-01"]').trigger('click')
@@ -243,7 +278,7 @@ describe('DeployedUsersTable', () => {
       }
     })
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     await w.find('[data-testid="btn-unlock-bob-staging-01"]').trigger('click')
@@ -272,7 +307,7 @@ describe('DeployedUsersTable', () => {
       }
     })
 
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     await w.find('[data-testid="btn-lock-alice-prod-01"]').trigger('click')
@@ -285,7 +320,7 @@ describe('DeployedUsersTable', () => {
 
   it('operator voit le bouton Lock', async () => {
     mockAdmin.value = { username: 'operator', role: 'operator' }
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     expect(w.find('[data-testid="btn-lock-alice-prod-01"]').exists()).toBe(true)
@@ -293,7 +328,7 @@ describe('DeployedUsersTable', () => {
 
   it('viewer ne voit pas le bouton Lock ni la colonne Actions', async () => {
     mockAdmin.value = { username: 'viewer', role: 'viewer' }
-    const w = mount(DeployedUsersTable, { global: { plugins: [i18n] } })
+    const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
     expect(w.find('[data-testid="btn-lock-alice-prod-01"]').exists()).toBe(false)


### PR DESCRIPTION
## Summary

- Hostname in Deployed Users table is now a clickable `RouterLink` navigating to `/servers/{hostname}`
- New IP column added (data already returned by `GET /api/access/deployed-users` — zero backend change)
- 3 new tests: link href, IP display, null IP → `—`

## Test plan

- [ ] 248 vitest pass (`npx vitest run`)
- [ ] Prettier clean
- [ ] Deployed Users page shows IP column and clickable server names

Closes #257