### PR TITLE
fix: improve wording of disable/delete admin confirmation modals

### DIFF
--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -233,7 +233,7 @@
     "rule_special": "Ein Sonderzeichen",
     "load_error": "Administratoren können nicht geladen werden: {error}",
     "disable_modal_title": "Administrator deaktivieren",
-    "disable_modal_text": "Deaktivierung von {username} bestätigen? Diese Aktion ist über die Oberfläche nicht rückgängig zu machen.",
+    "disable_modal_text": "Konto '{username}' deaktivieren? Das Konto kann sich nicht mehr anmelden. Sie können es später wieder aktivieren.",
     "btn_disable_confirm": "Deaktivieren",
     "pwd_modal_title": "Passwort ändern — {username}",
     "pwd_new_label": "Neues Passwort",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -233,7 +233,7 @@
     "rule_special": "One special character",
     "load_error": "Unable to load administrators: {error}",
     "disable_modal_title": "Disable administrator",
-    "disable_modal_text": "Confirm disabling {username}? This action is irreversible from the interface.",
+    "disable_modal_text": "Disable account '{username}'? The account will no longer be able to log in. You can re-enable it later.",
     "btn_disable_confirm": "Disable",
     "pwd_modal_title": "Change password — {username}",
     "pwd_new_label": "New password",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -233,7 +233,7 @@
     "rule_special": "Un carácter especial",
     "load_error": "No se pueden cargar los administradores: {error}",
     "disable_modal_title": "Desactivar administrador",
-    "disable_modal_text": "¿Confirmar la desactivación de {username}? Esta acción es irreversible desde la interfaz.",
+    "disable_modal_text": "¿Desactivar la cuenta '{username}'? La cuenta no podrá iniciar sesión. Puede reactivarla más tarde.",
     "btn_disable_confirm": "Desactivar",
     "pwd_modal_title": "Cambiar contraseña — {username}",
     "pwd_new_label": "Nueva contraseña",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -233,7 +233,7 @@
     "rule_special": "Un caractère spécial",
     "load_error": "Impossible de charger les administrateurs : {error}",
     "disable_modal_title": "Désactiver l'administrateur",
-    "disable_modal_text": "Confirmer la désactivation de {username} ? Cette action est irréversible depuis l'interface.",
+    "disable_modal_text": "Désactiver le compte '{username}' ? Le compte ne pourra plus se connecter. Vous pourrez le réactiver ultérieurement.",
     "btn_disable_confirm": "Désactiver",
     "pwd_modal_title": "Changer le mot de passe — {username}",
     "pwd_new_label": "Nouveau mot de passe",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -233,7 +233,7 @@
     "rule_special": "Un carattere speciale",
     "load_error": "Impossibile caricare gli amministratori: {error}",
     "disable_modal_title": "Disabilita amministratore",
-    "disable_modal_text": "Confermare la disabilitazione di {username}? Questa azione è irreversibile dall'interfaccia.",
+    "disable_modal_text": "Disabilitare l'account '{username}'? L'account non potrà più accedere. È possibile riabilitarlo in seguito.",
     "btn_disable_confirm": "Disabilita",
     "pwd_modal_title": "Cambia password — {username}",
     "pwd_new_label": "Nuova password",


### PR DESCRIPTION
## Summary

- **Disable** : suppression du mot "irreversible" (incorrect — le compte peut être réactivé). Nouvelle formulation : explique l'effet et mentionne la possibilité de réactiver
- **Delete** : "will fail" → "will be rejected" (intentionnel, pas un bug) + "records" → "audit records" (plus précis)
- 5 locales mises à jour (EN/FR/ES/IT/DE)

Closes #263