### PR TITLE
fix: allow admin deletion regardless of audit records

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -913,31 +913,12 @@ def toggle_alerts(username: str, receive_alerts: bool) -> dict:
 
 
 def delete_admin(username: str, admin_id: str | None = None) -> None:
-    """Permanently delete an admin if no FK references exist. Log ADMIN_DELETED."""
+    """Permanently delete an admin. FK references in audit tables are set to NULL. Log ADMIN_DELETED."""
     admin = db.query_one(
         "SELECT id FROM administrators WHERE username = %s", (username,)
     )
     if not admin:
         raise ValueError(f"Admin not found: {username}")
-    ref = db.query_one(
-        """
-        SELECT 1 FROM (
-            SELECT performed_by AS ref_id FROM audit_log WHERE performed_by = %s
-            UNION ALL
-            SELECT authorized_by FROM key_authorizations WHERE authorized_by = %s
-            UNION ALL
-            SELECT revoked_by    FROM key_authorizations WHERE revoked_by    = %s
-            UNION ALL
-            SELECT requested_by  FROM access_requests    WHERE requested_by  = %s
-            UNION ALL
-            SELECT approved_by   FROM access_requests    WHERE approved_by   = %s
-        ) refs
-        LIMIT 1
-        """,
-        (admin["id"],) * 5,
-    )
-    if ref:
-        raise ValueError(f"Cannot delete admin '{username}': existing audit records reference this account")
     db.execute(
         """
         INSERT INTO audit_log (action, performed_by, details)

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -560,7 +560,7 @@ def test_actions_enable_admin_raises_if_not_found():
 
 def test_actions_delete_admin_removes_row():
     with patch("actions.db") as mock_db:
-        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, None]
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
         actions.delete_admin("someuser", ADMIN_ID)
         sqls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("DELETE FROM administrators" in s for s in sqls)
@@ -568,7 +568,7 @@ def test_actions_delete_admin_removes_row():
 
 def test_actions_delete_admin_logs_admin_deleted():
     with patch("actions.db") as mock_db:
-        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, None]
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
         actions.delete_admin("someuser", ADMIN_ID)
         sqls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("ADMIN_DELETED" in s for s in sqls)
@@ -579,13 +579,6 @@ def test_actions_delete_admin_raises_if_not_found():
         mock_db.query_one.return_value = None
         with pytest.raises(ValueError, match="Admin not found"):
             actions.delete_admin("ghost")
-
-
-def test_actions_delete_admin_raises_if_has_references():
-    with patch("actions.db") as mock_db:
-        mock_db.query_one.side_effect = [{"id": ADMIN_ID}, {"1": 1}]
-        with pytest.raises(ValueError, match="existing audit records"):
-            actions.delete_admin("someuser")
 
 
 # ---------------------------------------------------------------------------

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -139,7 +139,7 @@ CREATE TABLE key_authorizations (
     -- Utilisateur Unix propriétaire de la clé sur ce serveur
     unix_user                VARCHAR(100) NOT NULL DEFAULT '',
     -- Administrateur ayant validé l'autorisation (NULL si détection automatique)
-    authorized_by            UUID REFERENCES administrators(id),
+    authorized_by            UUID REFERENCES administrators(id) ON DELETE SET NULL,
     -- Date de première autorisation ou détection
     authorized_at            TIMESTAMPTZ DEFAULT now(),
     -- Date d'expiration programmée (NULL = pas d'expiration)
@@ -156,7 +156,7 @@ CREATE TABLE key_authorizations (
     -- Date effective de révocation
     revoked_at               TIMESTAMPTZ,
     -- Administrateur ayant révoqué (NULL si révocation automatique hors système)
-    revoked_by               UUID REFERENCES administrators(id),
+    revoked_by               UUID REFERENCES administrators(id) ON DELETE SET NULL,
     -- True si révocation déclenchée automatiquement (expiration ou hors système)
     revoked_automatically    BOOLEAN DEFAULT false,
     -- Justification de révocation ou d'anomalie
@@ -187,9 +187,9 @@ CREATE TABLE access_requests (
     -- Identifiant unique généré automatiquement
     id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -- Administrateur demandeur
-    requested_by         UUID REFERENCES administrators(id),
+    requested_by         UUID REFERENCES administrators(id) ON DELETE SET NULL,
     -- Administrateur approbateur (NULL tant que non traité)
-    approved_by          UUID REFERENCES administrators(id),
+    approved_by          UUID REFERENCES administrators(id) ON DELETE SET NULL,
     -- Clé SSH pour laquelle l'accès est demandé
     key_id               UUID REFERENCES ssh_keys(id),
     -- Serveur cible de la demande
@@ -264,7 +264,7 @@ CREATE TABLE audit_log (
                       'LOGIN_BANNED'        -- IP bannie après trop de tentatives échouées
                   )),
     -- Administrateur ayant déclenché l'action (NULL si automatique)
-    performed_by  UUID REFERENCES administrators(id),
+    performed_by  UUID REFERENCES administrators(id) ON DELETE SET NULL,
     -- Clé SSH concernée par l'action (NULL si non applicable)
     target_key    UUID REFERENCES ssh_keys(id),
     -- Serveur concerné par l'action (NULL si non applicable)

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -253,7 +253,7 @@
     "enable_modal_text": "Aktivierung von {username} bestätigen?",
     "btn_enable_confirm": "Aktivieren",
     "delete_modal_title": "Administrator löschen",
-    "delete_modal_text": "{username} dauerhaft löschen? Diese Aktion ist unumkehrbar und schlägt fehl, wenn das Konto referenziert wird.",
+    "delete_modal_text": "{username} dauerhaft löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
     "btn_delete_confirm": "Löschen",
     "success_enabled": "Administrator {username} aktiviert.",
     "success_deleted": "Administrator {username} gelöscht.",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -253,7 +253,7 @@
     "enable_modal_text": "Confirm enabling {username}?",
     "btn_enable_confirm": "Enable",
     "delete_modal_title": "Delete administrator",
-    "delete_modal_text": "Permanently delete {username}? This action is irreversible and will fail if the account has existing records.",
+    "delete_modal_text": "Permanently delete {username}? This action cannot be undone.",
     "btn_delete_confirm": "Delete",
     "success_enabled": "Administrator {username} enabled.",
     "success_deleted": "Administrator {username} deleted.",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -253,7 +253,7 @@
     "enable_modal_text": "¿Confirmar la activación de {username}?",
     "btn_enable_confirm": "Activar",
     "delete_modal_title": "Eliminar administrador",
-    "delete_modal_text": "¿Eliminar definitivamente a {username}? Esta acción es irreversible y fallará si existen registros asociados.",
+    "delete_modal_text": "¿Eliminar definitivamente a {username}? Esta acción no se puede deshacer.",
     "btn_delete_confirm": "Eliminar",
     "success_enabled": "Administrador {username} activado.",
     "success_deleted": "Administrador {username} eliminado.",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -253,7 +253,7 @@
     "enable_modal_text": "Confirmer la réactivation de {username} ?",
     "btn_enable_confirm": "Réactiver",
     "delete_modal_title": "Supprimer un administrateur",
-    "delete_modal_text": "Supprimer définitivement {username} ? Action irréversible. Échoue si des enregistrements référencent ce compte.",
+    "delete_modal_text": "Supprimer définitivement {username} ? Cette action est irréversible.",
     "btn_delete_confirm": "Supprimer",
     "success_enabled": "Administrateur {username} réactivé.",
     "success_deleted": "Administrateur {username} supprimé.",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -253,7 +253,7 @@
     "enable_modal_text": "Confermare la riattivazione di {username}?",
     "btn_enable_confirm": "Riattiva",
     "delete_modal_title": "Elimina amministratore",
-    "delete_modal_text": "Eliminare definitivamente {username}? Azione irreversibile. Fallisce se l'account ha record associati.",
+    "delete_modal_text": "Eliminare definitivamente {username}? Questa azione non può essere annullata.",
     "btn_delete_confirm": "Elimina",
     "success_enabled": "Amministratore {username} riattivato.",
     "success_deleted": "Amministratore {username} eliminato.",


### PR DESCRIPTION
## Summary

- FK columns referencing `administrators` (`performed_by`, `authorized_by`, `revoked_by`, `requested_by`, `approved_by`) now use `ON DELETE SET NULL` — audit history is preserved but no longer blocks admin deletion
- Remove Python FK pre-check from `delete_admin()` — deletion is always possible
- Update UI wording in all 5 locales to drop the "will fail if existing records" caveat

## Test plan

- [ ] `pytest` — 96 tests pass (test_actions.py: 3 delete_admin tests updated, FK-blocking test removed)
- [ ] `vitest` — 248 tests pass (no changes needed, locale strings are not unit-tested)
- [ ] Delete an admin that has audit log entries — succeeds, audit rows show `performed_by = NULL`
- [ ] Delete modal wording shows no mention of blocking conditions

Closes #265