### PR TITLE
fix: validate IPv4/IPv6 address in add/edit server forms

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -2,6 +2,7 @@
 actions.py — logique metier partagee entre web.py (API) et manage.py (CLI).
 Jamais de duplication entre les deux consommateurs.
 """
+import ipaddress
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -13,6 +14,13 @@ import ssh
 _FP_RE = re.compile(r"^SHA256:[A-Za-z0-9+/=]+$")
 _UNIX_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 VALID_ROLES = {"sysadmin", "operator", "viewer"}
+
+
+def _validate_ip(ip: str) -> str:
+    try:
+        return str(ipaddress.ip_address(ip.strip()))
+    except ValueError:
+        raise ValueError(f"Invalid IP address: {ip!r} (expected IPv4 or IPv6)")
 
 
 def _check_fingerprint(fp: str) -> None:
@@ -632,6 +640,7 @@ def add_server(
     admin_id: str | None = None,
 ) -> dict:
     """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
+    ip = _validate_ip(ip)
     import servers as servers_mod
     try:
         servers_mod.add_to_known_hosts(ip)
@@ -674,6 +683,7 @@ def update_server(
     admin_id: str | None = None,
 ) -> dict:
     """Update server IP, environment, OS. If IP changes, run ssh-keyscan."""
+    new_ip = _validate_ip(new_ip)
     import servers as servers_mod
     server = db.query_one(
         "SELECT id, ip_address, environment, os_family FROM servers WHERE hostname = %s",

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -1029,6 +1029,17 @@ def test_actions_update_server_not_found():
             actions.update_server("unknown-server", "10.0.0.1", "lab", "rhel", ADMIN_ID)
 
 
+def test_actions_add_server_rejects_invalid_ip():
+    for bad in ["notanip", "999.1.1.1", "192.168.1", "hello world"]:
+        with pytest.raises(ValueError, match="Invalid IP"):
+            actions.add_server("h", bad, "lab", None, ADMIN_ID)
+
+
+def test_actions_update_server_rejects_invalid_ip():
+    with pytest.raises(ValueError, match="Invalid IP"):
+        actions.update_server("h", "not-an-ip", "lab", None, ADMIN_ID)
+
+
 # ---------------------------------------------------------------------------
 # RBAC — email mandatory and role validation
 # ---------------------------------------------------------------------------

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -50,6 +50,7 @@
     "env_placeholder": "— Wählen —",
     "os_family": "OS-Familie",
     "os_placeholder": "z.B.: rhel, debian (optional)",
+    "error_invalid_ip": "Ungültige IP-Adresse (IPv4 oder IPv6 erwartet).",
     "submitting": "Hinzufügen…",
     "submit": "Hinzufügen",
     "success_title": "Server hinzugefügt",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -50,6 +50,7 @@
     "env_placeholder": "— Choose —",
     "os_family": "OS Family",
     "os_placeholder": "e.g.: rhel, debian (optional)",
+    "error_invalid_ip": "Invalid IP address (expected IPv4 or IPv6).",
     "submitting": "Adding…",
     "submit": "Add",
     "success_title": "Server added",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -50,6 +50,7 @@
     "env_placeholder": "— Elegir —",
     "os_family": "Familia OS",
     "os_placeholder": "ej: rhel, debian (opcional)",
+    "error_invalid_ip": "Dirección IP no válida (se esperaba IPv4 o IPv6).",
     "submitting": "Añadiendo…",
     "submit": "Añadir",
     "success_title": "Servidor añadido",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -50,6 +50,7 @@
     "env_placeholder": "— Choisir —",
     "os_family": "OS Family",
     "os_placeholder": "ex: rhel, debian (optionnel)",
+    "error_invalid_ip": "Adresse IP invalide (IPv4 ou IPv6 attendu).",
     "submitting": "Ajout en cours…",
     "submit": "Ajouter",
     "success_title": "Serveur ajouté",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -50,6 +50,7 @@
     "env_placeholder": "— Scegliere —",
     "os_family": "Famiglia OS",
     "os_placeholder": "es: rhel, debian (opzionale)",
+    "error_invalid_ip": "Indirizzo IP non valido (atteso IPv4 o IPv6).",
     "submitting": "Aggiunta…",
     "submit": "Aggiungi",
     "success_title": "Server aggiunto",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -83,6 +83,7 @@
             <span class="required">{{ $t('common.required') }}</span></label
           >
           <input v-model="addForm.ip" type="text" :placeholder="$t('add_server.ip_placeholder')" />
+          <span v-if="addIpError" class="field-error">{{ addIpError }}</span>
 
           <label
             >{{ $t('add_server.environment') }}
@@ -157,6 +158,7 @@
           <span class="required">{{ $t('common.required') }}</span></label
         >
         <input v-model="editForm.ip" type="text" :placeholder="$t('edit_server.ip_placeholder')" />
+        <span v-if="editIpError" class="field-error">{{ editIpError }}</span>
 
         <label
           >{{ $t('edit_server.environment') }}
@@ -227,11 +229,32 @@ const counts = computed(() => ({
   danger: servers.value.filter((s) => !s.is_active).length,
 }))
 
-const addFormValid = computed(
-  () => addForm.value.hostname.trim() && addForm.value.ip.trim() && addForm.value.environment
+function isValidIp(ip) {
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+  const m = v4.exec(ip.trim())
+  if (m) return m.slice(1).every((n) => +n <= 255)
+  const v6 = /^[0-9a-fA-F:]+$/
+  return v6.test(ip.trim()) && ip.includes(':')
+}
+
+const addIpError = computed(() =>
+  addForm.value.ip.trim() && !isValidIp(addForm.value.ip) ? t('add_server.error_invalid_ip') : ''
+)
+const editIpError = computed(() =>
+  editForm.value.ip.trim() && !isValidIp(editForm.value.ip) ? t('add_server.error_invalid_ip') : ''
 )
 
-const editFormValid = computed(() => editForm.value.ip.trim() && editForm.value.environment)
+const addFormValid = computed(
+  () =>
+    addForm.value.hostname.trim() &&
+    addForm.value.ip.trim() &&
+    isValidIp(addForm.value.ip) &&
+    addForm.value.environment
+)
+
+const editFormValid = computed(
+  () => editForm.value.ip.trim() && isValidIp(editForm.value.ip) && editForm.value.environment
+)
 
 async function loadCollectorKey() {
   try {
@@ -488,6 +511,12 @@ h1 {
   padding: 0.6rem 1rem;
   border-radius: 4px;
   margin-bottom: 1rem;
+}
+.field-error {
+  font-size: 0.8rem;
+  color: #c00;
+  margin-top: 0.2rem;
+  display: block;
 }
 .alert-info {
   background: #d4edda;


### PR DESCRIPTION
## Summary

- **Backend** (`actions.py`): `_validate_ip()` via `ipaddress.ip_address()` appelé dans `add_server()` et `update_server()` — ValueError explicite avant tout accès DB ou SSH
- **Frontend** (`Dashboard.vue`): `isValidIp()` — le bouton Submit est désactivé et un message d'erreur s'affiche sous le champ IP tant que la valeur n'est pas une IPv4 ou IPv6 valide
- **i18n**: clé `add_server.error_invalid_ip` ajoutée dans les 5 locales (EN/FR/ES/IT/DE)

## Test plan

- [ ] `pytest tests/test_actions.py` — 98 tests passent (2 nouveaux : `test_actions_add_server_rejects_invalid_ip`, `test_actions_update_server_rejects_invalid_ip`)
- [ ] Saisir `notanip` → message d'erreur inline, bouton désactivé
- [ ] Saisir `192.168.1.10` → pas d'erreur, bouton actif
- [ ] Saisir `::1` (IPv6 loopback) → pas d'erreur
- [ ] Saisir `999.1.1.1` → message d'erreur

Closes #269