### PR TITLE
docs: document ip_address unique constraint and UI validation

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -41,6 +41,7 @@ Schéma complet dans sql/schema.sql. Points non-évidents :
 - `key_authorizations` PK = **(key_id, server_id, unix_user)** — même clé déployable pour plusieurs users Unix sur même serveur (#185)
 - `key_authorizations.unix_user` DEFAULT '' — champ obligatoire dans toutes les requêtes
 - Table `settings` : lire en DB, jamais depuis ENV. Clés : `scan_interval_hours` (4), `expire_warn_days` (7), `expire_warn_days_2` (2), `login_max_attempts` (10), `login_ban_seconds` (300)
+- `servers.ip_address` : index unique global (`servers_ip_unique`) — une IP ne peut appartenir qu'à un seul serveur, actif ou désactivé. Désactivation = maintenance temporaire, le serveur peut revenir. Seule la suppression libère l'IP.
 
 ## Logique métier — fingerprint SHA256
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -49,6 +49,7 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 - **Serveurs désactivés** (#91) : ligne grisée dans ServerTable + bandeau rouge en haut dans ServerDetail
 - **Backend** : uniquement les routes `/api/` définies dans app/CLAUDE.md — ne jamais appeler autre chose
 - Les timestamps sont stockés UTC en base, affichés dans le fuseau du navigateur via useFormatDate.js
+- **Validation IP dans Dashboard.vue** (#271) : `isValidIp()` (format IPv4/IPv6) + `isIpDuplicate()` (unicité globale contre `servers.value` — actifs ET désactivés). Bouton désactivé + message `.field-error` inline si invalide ou doublon.
 
 ## Tests Vitest (ui/tests/)
 


### PR DESCRIPTION
## Summary

- `app/CLAUDE.md` : ajout de la contrainte `servers_ip_unique` — une IP ne peut appartenir qu'à un seul serveur, actif ou désactivé ; seule la suppression libère l'IP
- `ui/CLAUDE.md` : documentation de `isValidIp()` + `isIpDuplicate()` dans Dashboard.vue

Closes #274