### PR TITLE
fix: raise RuntimeError on weak FLASK_SECRET_KEY and fix INTERVAL injection

### DIFF
--- a/app/expire.py
+++ b/app/expire.py
@@ -31,7 +31,7 @@ def warn_expiring_keys() -> int:
         WHERE ka.status = 'ACTIVE'
           AND ka.expires_at IS NOT NULL
           AND ka.expires_at > now()
-          AND ka.expires_at <= now() + INTERVAL '%s days'
+          AND ka.expires_at <= now() + make_interval(days => %s)
         """,
         (max(warn_days, warn_days_2),),
     )

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,10 +1,13 @@
 import base64
 import hashlib
+import os
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+os.environ.setdefault("FLASK_SECRET_KEY", "test-secret-key-for-testing")
 
 
 def _compute_fingerprint(key_b64: str) -> str:

--- a/app/web.py
+++ b/app/web.py
@@ -89,10 +89,10 @@ SESSION_LONG_HOURS = 8       # avec "remember me"
 
 app = Flask(__name__)
 _flask_secret = os.environ.get("FLASK_SECRET_KEY")
-if not _flask_secret:
-    import warnings
-    warnings.warn("FLASK_SECRET_KEY not set — sessions are insecure", RuntimeWarning, stacklevel=1)
-    _flask_secret = "changeme"
+if not _flask_secret or _flask_secret == "changeme":
+    raise RuntimeError(
+        "FLASK_SECRET_KEY must be set to a strong secret (not 'changeme')"
+    )
 app.secret_key = _flask_secret
 
 


### PR DESCRIPTION
## Summary

- **`web.py`** : `RuntimeError` au démarrage si `FLASK_SECRET_KEY` est absent ou vaut `"changeme"` — empêche de lancer le container en production avec un secret faible
- **`expire.py`** : remplace `INTERVAL '%s days'` par `make_interval(days => %s)` — paramètre lié psycopg2 correct, pas d'interpolation dans le littéral SQL
- **`conftest.py`** : `os.environ.setdefault("FLASK_SECRET_KEY", "test-secret-key-for-testing")` avant tout import de `web` dans les tests

## Test plan

- [ ] Lancer le container sans `FLASK_SECRET_KEY` → crash au démarrage
- [ ] Lancer avec `FLASK_SECRET_KEY=changeme` → crash au démarrage
- [ ] Lancer avec une vraie valeur → démarre normalement
- [ ] `pytest app/tests/` → 428 passed

Closes #276
Closes #277