### PR TITLE
fix: container exits with clear error if FLASK_SECRET_KEY or POSTGRES_PASSWORD are weak

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,6 +37,32 @@ generate_msmtprc() {
 }
 
 # ---------------------------------------------------------------------------
+# Vérification des variables d'environnement obligatoires
+# ---------------------------------------------------------------------------
+_fail=0
+if [ -z "${FLASK_SECRET_KEY}" ] || [ "${FLASK_SECRET_KEY}" = "changeme" ]; then
+    echo "================================================================" >&2
+    echo " ERREUR : FLASK_SECRET_KEY est absent ou vaut 'changeme'." >&2
+    echo " Les sessions Flask ne peuvent pas être sécurisées." >&2
+    echo " Générez une clé forte : openssl rand -hex 32" >&2
+    echo " Puis ajoutez-la dans votre fichier .env :" >&2
+    echo "   FLASK_SECRET_KEY=<valeur générée>" >&2
+    echo "================================================================" >&2
+    _fail=1
+fi
+if [ -z "${POSTGRES_PASSWORD}" ] || [ "${POSTGRES_PASSWORD}" = "changeme" ]; then
+    echo "================================================================" >&2
+    echo " ERREUR : POSTGRES_PASSWORD est absent ou vaut 'changeme'." >&2
+    echo " Définissez un mot de passe fort dans votre fichier .env :" >&2
+    echo "   POSTGRES_PASSWORD=<mot de passe fort>" >&2
+    echo "================================================================" >&2
+    _fail=1
+fi
+if [ "${_fail}" = "1" ]; then
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
 # Premier démarrage — détecté par l'absence de /data/pg/PG_VERSION
 # ---------------------------------------------------------------------------
 if [ ! -f /data/pg/PG_VERSION ]; then


### PR DESCRIPTION
## Summary

Ajout d'un bloc de vérification dans `bootstrap.sh` qui s'exécute **avant** supervisord. Si `FLASK_SECRET_KEY` ou `POSTGRES_PASSWORD` sont absents ou valent `"changeme"`, le container s'arrête immédiatement avec un message explicite sur stderr :

```
================================================================
 ERREUR : FLASK_SECRET_KEY est absent ou vaut 'changeme'.
 Les sessions Flask ne peuvent pas être sécurisées.
 Générez une clé forte : openssl rand -hex 32
 Puis ajoutez-la dans votre fichier .env :
   FLASK_SECRET_KEY=<valeur générée>
================================================================
```

## Test plan

- [ ] `podman run ... -e FLASK_SECRET_KEY=changeme` → container s'arrête, message visible dans `podman logs`
- [ ] `podman run ...` sans `FLASK_SECRET_KEY` → idem
- [ ] `podman run ...` avec une vraie clé et un vrai mot de passe → démarre normalement

Closes #279