### PR TITLE
feat: add manage.py admin reset-password CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ $EXEC admin update <username> [--email EMAIL] [--role ROLE]
 $EXEC admin disable USERNAME
 $EXEC admin enable USERNAME
 $EXEC admin delete USERNAME
+$EXEC admin reset-password USERNAME --password NEW_PASSWORD
 
 # Audit
 $EXEC audit list --action ANOMALY_DETECTED --since 2025-01-01
@@ -400,6 +401,25 @@ $EXEC audit list --server HOST
 $EXEC system status
 $EXEC system report
 ```
+
+---
+
+## Récupération de mot de passe administrateur
+
+Si un administrateur a perdu son mot de passe, un sysadmin ayant accès au container peut le réinitialiser via la CLI sans connexion préalable :
+
+```bash
+# Docker
+docker exec -it ssh-access-manager python3 /app/app/manage.py admin reset-password <username> --password <new_password>
+
+# Podman
+podman exec -it sam-server python3 /app/app/manage.py admin reset-password <username> --password <new_password>
+```
+
+Contraintes :
+- Le mot de passe doit respecter la politique de sécurité (8+ caractères, majuscule, minuscule, chiffre, caractère spécial)
+- Fonctionne même si le compte est désactivé
+- L'opération est tracée dans l'audit log (`PASSWORD_RESET`, `performed_by=NULL`)
 
 ---
 

--- a/app/actions.py
+++ b/app/actions.py
@@ -827,6 +827,24 @@ def change_password(username: str, new_password: str) -> None:
     )
 
 
+def reset_password(username: str, new_password: str) -> None:
+    """Reset password for any administrator (active or disabled). CLI use only."""
+    from werkzeug.security import generate_password_hash
+
+    _validate_password_strength(new_password)
+    admin = db.query_one("SELECT id FROM administrators WHERE username = %s", (username,))
+    if not admin:
+        raise ValueError(f"Admin not found: {username}")
+    db.execute(
+        "UPDATE administrators SET password_hash = %s WHERE id = %s",
+        (generate_password_hash(new_password), admin["id"]),
+    )
+    db.execute(
+        "INSERT INTO audit_log (action, performed_by, details) VALUES ('PASSWORD_RESET', NULL, %s::jsonb)",
+        (json.dumps({"username": username, "method": "cli"}),),
+    )
+
+
 def update_admin(username: str, email: str | None, role: str, admin_id: str) -> dict:
     """Update administrator email and role. Log ADMIN_UPDATED."""
     if not email or not email.strip():

--- a/app/manage.py
+++ b/app/manage.py
@@ -502,6 +502,18 @@ def admin_update(username, email, role):
         raise click.ClickException(str(e))
 
 
+@admin.command("reset-password")
+@click.argument("username")
+@click.option("--password", required=True, help="New password")
+def admin_reset_password(username, password):
+    """Reset an administrator's password (emergency use, no login required)."""
+    try:
+        actions.reset_password(username, password)
+        click.echo(f"Password for {username} has been reset.")
+    except ValueError as e:
+        raise click.ClickException(str(e))
+
+
 @admin.command("delete")
 @click.argument("username")
 @click.confirmation_option(prompt="Permanently delete this administrator?")

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -1106,3 +1106,46 @@ def test_actions_toggle_alerts_unknown_admin_raises():
         mock_db.query_one.return_value = None
         with pytest.raises(ValueError, match="Active admin not found"):
             actions.toggle_alerts("ghost", True)
+
+
+# ---------------------------------------------------------------------------
+# reset_password
+# ---------------------------------------------------------------------------
+
+def test_actions_reset_password_updates_hash():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        actions.reset_password("alice", "N3wStr0ng#Pass!")
+        sql = mock_db.execute.call_args_list[0][0][0]
+        assert "password_hash" in sql
+
+
+def test_actions_reset_password_writes_audit_log():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        actions.reset_password("alice", "N3wStr0ng#Pass!")
+        audit_sql = mock_db.execute.call_args_list[1][0][0]
+        assert "PASSWORD_RESET" in audit_sql
+
+
+def test_actions_reset_password_works_for_disabled_admin():
+    """reset_password does not filter by is_active — works on disabled admins."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        actions.reset_password("disabled_user", "N3wStr0ng#Pass!")
+        sql = mock_db.query_one.call_args[0][0]
+        assert "is_active" not in sql
+
+
+def test_actions_reset_password_raises_if_not_found():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = None
+        with pytest.raises(ValueError, match="Admin not found"):
+            actions.reset_password("ghost", "N3wStr0ng#Pass!")
+
+
+def test_actions_reset_password_rejects_weak_password():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        with pytest.raises(ValueError):
+            actions.reset_password("alice", "weak")

--- a/app/tests/test_manage.py
+++ b/app/tests/test_manage.py
@@ -392,3 +392,39 @@ def test_manage_access_unlock_user(runner):
         ])
         assert result.exit_code == 0
         assert "unlocked" in result.output
+
+
+# ---------------------------------------------------------------------------
+# admin reset-password
+# ---------------------------------------------------------------------------
+
+def test_manage_admin_reset_password_success(runner):
+    with patch("manage.actions") as mock_actions:
+        result = runner.invoke(manage.cli, [
+            "admin", "reset-password", "alice",
+            "--password", "N3wStr0ng#Pass!"
+        ])
+        assert result.exit_code == 0
+        assert "reset" in result.output
+        mock_actions.reset_password.assert_called_once_with("alice", "N3wStr0ng#Pass!")
+
+
+def test_manage_admin_reset_password_unknown_user(runner):
+    with patch("manage.actions") as mock_actions:
+        mock_actions.reset_password.side_effect = ValueError("Admin not found: ghost")
+        result = runner.invoke(manage.cli, [
+            "admin", "reset-password", "ghost",
+            "--password", "N3wStr0ng#Pass!"
+        ])
+        assert result.exit_code != 0
+        assert "Admin not found" in result.output
+
+
+def test_manage_admin_reset_password_weak_password(runner):
+    with patch("manage.actions") as mock_actions:
+        mock_actions.reset_password.side_effect = ValueError("Password must be at least 8 characters")
+        result = runner.invoke(manage.cli, [
+            "admin", "reset-password", "alice",
+            "--password", "weak"
+        ])
+        assert result.exit_code != 0

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -261,7 +261,8 @@ CREATE TABLE audit_log (
                       'USER_LOCKED',        -- compte Unix verrouillé (SSH bloqué)
                       'USER_UNLOCKED',      -- compte Unix déverrouillé
                       'LOGIN_FAILED',       -- tentative de connexion échouée (mauvais mot de passe)
-                      'LOGIN_BANNED'        -- IP bannie après trop de tentatives échouées
+                      'LOGIN_BANNED',       -- IP bannie après trop de tentatives échouées
+                      'PASSWORD_RESET'      -- réinitialisation de mot de passe via CLI
                   )),
     -- Administrateur ayant déclenché l'action (NULL si automatique)
     performed_by  UUID REFERENCES administrators(id) ON DELETE SET NULL,


### PR DESCRIPTION
## Summary

- New `admin reset-password <username> --password <new>` command in `manage.py`
- New `reset_password()` function in `actions.py` (works on active **and** disabled accounts)
- Password strength validated by existing `_validate_password_strength()`
- Audit log entry `PASSWORD_RESET` with `performed_by=NULL` (CLI, no session)
- README: new dedicated section + CLI reference updated

## Test plan

- [x] `test_actions_reset_password_updates_hash` — password hash is updated
- [x] `test_actions_reset_password_writes_audit_log` — `PASSWORD_RESET` entry written
- [x] `test_actions_reset_password_works_for_disabled_admin` — no `is_active` filter in query
- [x] `test_actions_reset_password_raises_if_not_found` — `ValueError` on unknown username
- [x] `test_actions_reset_password_rejects_weak_password` — strength validation enforced
- [x] `test_manage_admin_reset_password_success` — CLI exits 0, calls `actions.reset_password`
- [x] `test_manage_admin_reset_password_unknown_user` — CLI exits non-0, error message shown
- [x] `test_manage_admin_reset_password_weak_password` — CLI exits non-0

Closes #286