### PR TITLE
feat: show banner if admin password never changed, simplify .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,5 @@ SMTP_USER=alerts@example.com
 SMTP_PASSWORD=changeme
 SMTP_FROM=ssh-manager@example.com
 
-# Collector
-SSH_USER=audit-collector
-ADMIN_USERNAME=admin
-ADMIN_EMAIL=admin@example.com
+# Initial admin password (defaults: username=admin, email=admin@example.com)
 ADMIN_PASSWORD=changeme

--- a/app/actions.py
+++ b/app/actions.py
@@ -822,7 +822,7 @@ def change_password(username: str, new_password: str) -> None:
     if not admin:
         raise ValueError(f"Active admin not found: {username}")
     db.execute(
-        "UPDATE administrators SET password_hash = %s WHERE id = %s",
+        "UPDATE administrators SET password_hash = %s, password_changed_at = now() WHERE id = %s",
         (generate_password_hash(new_password), admin["id"]),
     )
 
@@ -836,7 +836,7 @@ def reset_password(username: str, new_password: str) -> None:
     if not admin:
         raise ValueError(f"Admin not found: {username}")
     db.execute(
-        "UPDATE administrators SET password_hash = %s WHERE id = %s",
+        "UPDATE administrators SET password_hash = %s, password_changed_at = now() WHERE id = %s",
         (generate_password_hash(new_password), admin["id"]),
     )
     db.execute(

--- a/app/web.py
+++ b/app/web.py
@@ -204,12 +204,14 @@ def auth_me():
     if not admin_id:
         return jsonify({"error": "Unauthorized"}), 401
     admin = db.query_one(
-        "SELECT username, email, role FROM administrators WHERE id = %s AND is_active = true",
+        "SELECT username, email, role, password_changed_at FROM administrators WHERE id = %s AND is_active = true",
         (admin_id,),
     )
     if not admin:
         return jsonify({"error": "Unauthorized"}), 401
-    return jsonify(dict(admin)), 200
+    data = dict(admin)
+    data["must_change_password"] = data.pop("password_changed_at") is None
+    return jsonify(data), 200
 
 
 def _parse_datetime(value: str | None) -> datetime | None:

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -64,7 +64,9 @@ CREATE TABLE administrators (
     -- Reçoit les emails d'alerte CRITICAL/WARNING
     receive_alerts BOOLEAN DEFAULT true NOT NULL,
     -- Date de création du compte
-    created_at    TIMESTAMPTZ DEFAULT now()
+    created_at    TIMESTAMPTZ DEFAULT now(),
+    -- NULL = password never changed since account creation
+    password_changed_at TIMESTAMPTZ
 );
 
 COMMENT ON TABLE administrators IS 'Utilisateurs autorisés à gérer les accès SSH';

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,17 +19,10 @@
       <span class="nav-user">{{ admin.username }}</span>
       <button class="btn-logout" @click="handleLogout">{{ $t('nav.logout') }}</button>
     </nav>
-    <div v-if="admin?.must_change_password && !bannerDismissed" class="password-banner">
+    <div v-if="admin?.must_change_password" class="password-banner">
       <span>{{ $t('password_banner.message') }}</span>
       <button class="btn-banner-action" @click="goChangePassword">
         {{ $t('password_banner.btn_change') }}
-      </button>
-      <button
-        class="btn-banner-dismiss"
-        @click="bannerDismissed = true"
-        :aria-label="$t('password_banner.btn_dismiss')"
-      >
-        ✕
       </button>
     </div>
     <main class="content">
@@ -39,7 +32,6 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from './composables/useAuth.js'
@@ -47,10 +39,9 @@ import { useAuth } from './composables/useAuth.js'
 const router = useRouter()
 const { admin, logout } = useAuth()
 const { locale } = useI18n()
-const bannerDismissed = ref(false)
 
 function goChangePassword() {
-  router.push('/admins')
+  router.push('/admins?changePassword=true')
 }
 
 async function handleLogout() {
@@ -165,18 +156,6 @@ body {
 }
 .btn-banner-action:hover {
   background: #e0a800;
-}
-.btn-banner-dismiss {
-  background: none;
-  border: none;
-  color: #856404;
-  font-size: 1rem;
-  cursor: pointer;
-  padding: 0 0.25rem;
-  line-height: 1;
-}
-.btn-banner-dismiss:hover {
-  color: #533f03;
 }
 
 .content {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -19,6 +19,19 @@
       <span class="nav-user">{{ admin.username }}</span>
       <button class="btn-logout" @click="handleLogout">{{ $t('nav.logout') }}</button>
     </nav>
+    <div v-if="admin?.must_change_password && !bannerDismissed" class="password-banner">
+      <span>{{ $t('password_banner.message') }}</span>
+      <button class="btn-banner-action" @click="goChangePassword">
+        {{ $t('password_banner.btn_change') }}
+      </button>
+      <button
+        class="btn-banner-dismiss"
+        @click="bannerDismissed = true"
+        :aria-label="$t('password_banner.btn_dismiss')"
+      >
+        ✕
+      </button>
+    </div>
     <main class="content">
       <router-view />
     </main>
@@ -26,6 +39,7 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAuth } from './composables/useAuth.js'
@@ -33,6 +47,11 @@ import { useAuth } from './composables/useAuth.js'
 const router = useRouter()
 const { admin, logout } = useAuth()
 const { locale } = useI18n()
+const bannerDismissed = ref(false)
+
+function goChangePassword() {
+  router.push('/admins')
+}
 
 async function handleLogout() {
   await logout()
@@ -119,6 +138,45 @@ body {
 .lang-select option {
   color: #000;
   background: #fff;
+}
+
+.password-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.6rem 1.5rem;
+  background: #fff3cd;
+  color: #856404;
+  border-bottom: 1px solid #ffc107;
+  font-size: 0.9rem;
+}
+.password-banner span {
+  flex: 1;
+}
+.btn-banner-action {
+  background: #ffc107;
+  color: #000;
+  border: none;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-banner-action:hover {
+  background: #e0a800;
+}
+.btn-banner-dismiss {
+  background: none;
+  border: none;
+  color: #856404;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 0.25rem;
+  line-height: 1;
+}
+.btn-banner-dismiss:hover {
+  color: #533f03;
 }
 
 .content {

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -414,7 +414,6 @@
   },
   "password_banner": {
     "message": "Ihr Passwort wurde noch nie geändert. Bitte aktualisieren Sie es aus Sicherheitsgründen.",
-    "btn_change": "Passwort ändern",
-    "btn_dismiss": "Schließen"
+    "btn_change": "Passwort ändern"
   }
 }

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -411,5 +411,10 @@
     "export_csv": "CSV exportieren",
     "refresh_error": "Aktualisierung fehlgeschlagen: {error}",
     "load_error": "Sitzungen konnten nicht geladen werden: {error}"
+  },
+  "password_banner": {
+    "message": "Ihr Passwort wurde noch nie geändert. Bitte aktualisieren Sie es aus Sicherheitsgründen.",
+    "btn_change": "Passwort ändern",
+    "btn_dismiss": "Schließen"
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -411,5 +411,10 @@
     "export_csv": "Export CSV",
     "refresh_error": "Refresh failed: {error}",
     "load_error": "Failed to load sessions: {error}"
+  },
+  "password_banner": {
+    "message": "Your password has never been changed. Please update it for security.",
+    "btn_change": "Change password",
+    "btn_dismiss": "Dismiss"
   }
 }

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -414,7 +414,6 @@
   },
   "password_banner": {
     "message": "Your password has never been changed. Please update it for security.",
-    "btn_change": "Change password",
-    "btn_dismiss": "Dismiss"
+    "btn_change": "Change password"
   }
 }

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -414,7 +414,6 @@
   },
   "password_banner": {
     "message": "Su contraseña nunca ha sido cambiada. Por favor, actualícela por seguridad.",
-    "btn_change": "Cambiar contraseña",
-    "btn_dismiss": "Cerrar"
+    "btn_change": "Cambiar contraseña"
   }
 }

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -411,5 +411,10 @@
     "export_csv": "Exportar CSV",
     "refresh_error": "Error al actualizar: {error}",
     "load_error": "Error al cargar sesiones: {error}"
+  },
+  "password_banner": {
+    "message": "Su contraseña nunca ha sido cambiada. Por favor, actualícela por seguridad.",
+    "btn_change": "Cambiar contraseña",
+    "btn_dismiss": "Cerrar"
   }
 }

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -414,7 +414,6 @@
   },
   "password_banner": {
     "message": "Votre mot de passe n'a jamais été changé. Veuillez le mettre à jour pour votre sécurité.",
-    "btn_change": "Changer le mot de passe",
-    "btn_dismiss": "Ignorer"
+    "btn_change": "Changer le mot de passe"
   }
 }

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -411,5 +411,10 @@
     "export_csv": "Exporter CSV",
     "refresh_error": "Actualisation échouée : {error}",
     "load_error": "Impossible de charger les sessions : {error}"
+  },
+  "password_banner": {
+    "message": "Votre mot de passe n'a jamais été changé. Veuillez le mettre à jour pour votre sécurité.",
+    "btn_change": "Changer le mot de passe",
+    "btn_dismiss": "Ignorer"
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -411,5 +411,10 @@
     "export_csv": "Esporta CSV",
     "refresh_error": "Aggiornamento fallito: {error}",
     "load_error": "Impossibile caricare le sessioni: {error}"
+  },
+  "password_banner": {
+    "message": "La password non è mai stata cambiata. Aggiornala per motivi di sicurezza.",
+    "btn_change": "Cambia password",
+    "btn_dismiss": "Chiudi"
   }
 }

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -414,7 +414,6 @@
   },
   "password_banner": {
     "message": "La password non è mai stata cambiata. Aggiornala per motivi di sicurezza.",
-    "btn_change": "Cambia password",
-    "btn_dismiss": "Chiudi"
+    "btn_change": "Cambia password"
   }
 }

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -696,6 +696,9 @@ async function confirmEditPassword() {
       throw new Error(data.error || `HTTP ${res.status}`)
     }
     message.value = t('admins.success_pwd', { username })
+    if (username === currentUsername.value && admin.value) {
+      admin.value.must_change_password = false
+    }
   } catch (e) {
     error.value = e.message
   }

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -453,11 +453,14 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '../composables/useAuth'
 import AdminsTable from '../components/AdminsTable.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
+const route = useRoute()
+const router = useRouter()
 
 const currentRole = computed(() => admin.value?.role || 'viewer')
 
@@ -734,7 +737,13 @@ async function confirmEdit() {
   }
 }
 
-onMounted(load)
+onMounted(async () => {
+  await load()
+  if (route?.query?.changePassword === 'true' && currentUsername.value) {
+    openEditPassword(currentUsername.value)
+    router.replace({ path: '/admins' })
+  }
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary

- `password_changed_at TIMESTAMPTZ` column added to `administrators` (NULL = never changed)
- `change_password()` and `reset_password()` now set `password_changed_at = now()`
- `GET /api/auth/me` returns `must_change_password: true` when column is NULL
- Warning banner in `App.vue` (all pages) when `must_change_password: true` — dismissible for the session, button navigates to `/admins`
- `SSH_USER`, `ADMIN_USERNAME`, `ADMIN_EMAIL` removed from `.env.example` (defaults already hardcoded in bootstrap.sh)
- i18n keys added in all 5 locales (EN/FR/ES/IT/DE)

## Test plan

- [x] pytest 436 passed
- [x] vitest 248 passed
- [x] Prettier clean
- [ ] Manual: login with fresh admin → banner visible
- [ ] Manual: change password → banner disappears on next login
- [ ] Manual: dismiss → banner hidden for session, reappears after logout/login

Closes #291