### PR TITLE
style: swap modal button order — Cancel left, primary action right

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -300,4 +300,7 @@ button:disabled {
   color: #333;
   background: #f0f0f0;
 }
+.modal-actions button {
+  min-width: 6rem;
+}
 </style>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -300,7 +300,11 @@ button:disabled {
   color: #333;
   background: #f0f0f0;
 }
-.modal-actions button {
+.btn-primary,
+.btn-secondary,
+.btn-danger,
+.btn-success,
+.btn-warning {
   min-width: 6rem;
 }
 </style>

--- a/ui/src/components/KeyActions.vue
+++ b/ui/src/components/KeyActions.vue
@@ -35,7 +35,7 @@
           :placeholder="$t('server_detail.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
-          <button data-testid="cancel-revoke" @click="confirming = false">
+          <button data-testid="cancel-revoke" class="btn-secondary" @click="confirming = false">
             {{ $t('common.cancel') }}
           </button>
           <button

--- a/ui/src/components/KeyActions.vue
+++ b/ui/src/components/KeyActions.vue
@@ -35,6 +35,9 @@
           :placeholder="$t('server_detail.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
+          <button data-testid="cancel-revoke" @click="confirming = false">
+            {{ $t('common.cancel') }}
+          </button>
           <button
             class="btn-danger"
             :disabled="!reason.trim()"
@@ -42,9 +45,6 @@
             @click="confirmRevoke"
           >
             {{ $t('server_detail.revoke_confirm') }}
-          </button>
-          <button data-testid="cancel-revoke" @click="confirming = false">
-            {{ $t('common.cancel') }}
           </button>
         </div>
       </div>

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -323,7 +323,7 @@
     "seconds": "Sekunden",
     "smtp_section": "SMTP-Konfiguration",
     "smtp_hint": "Sendet eine Test-E-Mail an Ihre Adresse, um die SMTP-Konfiguration zu überprüfen.",
-    "smtp_test_btn": "Test-E-Mail senden",
+    "smtp_test_btn": "Senden",
     "smtp_testing": "Wird gesendet…",
     "smtp_sent": "Test-E-Mail wurde an {to} gesendet.",
     "smtp_error": "Senden fehlgeschlagen: {error}"

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -323,7 +323,7 @@
     "seconds": "seconds",
     "smtp_section": "SMTP configuration",
     "smtp_hint": "Send a test email to your account address to verify the SMTP configuration.",
-    "smtp_test_btn": "Send test email",
+    "smtp_test_btn": "Send",
     "smtp_testing": "Sending…",
     "smtp_sent": "Test email sent to {to}.",
     "smtp_error": "Failed to send: {error}"

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -323,7 +323,7 @@
     "seconds": "segundos",
     "smtp_section": "Configuración SMTP",
     "smtp_hint": "Envía un correo de prueba a tu dirección para verificar la configuración SMTP.",
-    "smtp_test_btn": "Enviar correo de prueba",
+    "smtp_test_btn": "Enviar",
     "smtp_testing": "Enviando…",
     "smtp_sent": "Correo de prueba enviado a {to}.",
     "smtp_error": "Error al enviar: {error}"

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -323,7 +323,7 @@
     "seconds": "secondes",
     "smtp_section": "Configuration SMTP",
     "smtp_hint": "Envoie un email de test à votre adresse pour vérifier la configuration SMTP.",
-    "smtp_test_btn": "Envoyer un email de test",
+    "smtp_test_btn": "Envoyer",
     "smtp_testing": "Envoi en cours…",
     "smtp_sent": "Email de test envoyé à {to}.",
     "smtp_error": "Échec de l'envoi : {error}"

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -323,7 +323,7 @@
     "seconds": "secondi",
     "smtp_section": "Configurazione SMTP",
     "smtp_hint": "Invia un'email di prova al tuo indirizzo per verificare la configurazione SMTP.",
-    "smtp_test_btn": "Invia email di prova",
+    "smtp_test_btn": "Invia",
     "smtp_testing": "Invio in corso…",
     "smtp_sent": "Email di prova inviata a {to}.",
     "smtp_error": "Invio fallito: {error}"

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -200,10 +200,10 @@
         </div>
         <p>{{ $t('admins.disable_modal_text', { username: disableTarget }) }}</p>
         <div class="modal-actions">
+          <button @click="disableTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-danger" @click="confirmDisable">
             {{ $t('admins.btn_disable_confirm') }}
           </button>
-          <button @click="disableTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -219,10 +219,10 @@
         </div>
         <p>{{ $t('admins.enable_modal_text', { username: enableTarget }) }}</p>
         <div class="modal-actions">
+          <button @click="enableTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-success" @click="confirmEnable">
             {{ $t('admins.btn_enable_confirm') }}
           </button>
-          <button @click="enableTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -238,10 +238,10 @@
         </div>
         <p>{{ $t('admins.delete_modal_text', { username: deleteTarget }) }}</p>
         <div class="modal-actions">
+          <button @click="deleteTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-danger" @click="confirmDelete">
             {{ $t('admins.btn_delete_confirm') }}
           </button>
-          <button @click="deleteTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -385,10 +385,10 @@
             </span>
           </div>
           <div class="modal-actions">
+            <button type="button" @click="closeEditPassword">{{ $t('common.cancel') }}</button>
             <button type="submit" class="btn-primary" :disabled="!canSubmitEdit">
               {{ $t('admins.btn_save') }}
             </button>
-            <button type="button" @click="closeEditPassword">{{ $t('common.cancel') }}</button>
           </div>
         </form>
       </div>
@@ -439,10 +439,10 @@
             </span>
           </div>
           <div class="modal-actions">
+            <button type="button" @click="closeEdit">{{ $t('common.cancel') }}</button>
             <button type="submit" class="btn-primary">
               {{ $t('admins.btn_save') }}
             </button>
-            <button type="button" @click="closeEdit">{{ $t('common.cancel') }}</button>
           </div>
         </form>
       </div>

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -200,7 +200,9 @@
         </div>
         <p>{{ $t('admins.disable_modal_text', { username: disableTarget }) }}</p>
         <div class="modal-actions">
-          <button @click="disableTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="disableTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-danger" @click="confirmDisable">
             {{ $t('admins.btn_disable_confirm') }}
           </button>
@@ -219,7 +221,9 @@
         </div>
         <p>{{ $t('admins.enable_modal_text', { username: enableTarget }) }}</p>
         <div class="modal-actions">
-          <button @click="enableTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="enableTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-success" @click="confirmEnable">
             {{ $t('admins.btn_enable_confirm') }}
           </button>
@@ -238,7 +242,9 @@
         </div>
         <p>{{ $t('admins.delete_modal_text', { username: deleteTarget }) }}</p>
         <div class="modal-actions">
-          <button @click="deleteTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="deleteTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-danger" @click="confirmDelete">
             {{ $t('admins.btn_delete_confirm') }}
           </button>
@@ -385,7 +391,9 @@
             </span>
           </div>
           <div class="modal-actions">
-            <button type="button" @click="closeEditPassword">{{ $t('common.cancel') }}</button>
+            <button type="button" class="btn-secondary" @click="closeEditPassword">
+              {{ $t('common.cancel') }}
+            </button>
             <button type="submit" class="btn-primary" :disabled="!canSubmitEdit">
               {{ $t('admins.btn_save') }}
             </button>
@@ -439,7 +447,9 @@
             </span>
           </div>
           <div class="modal-actions">
-            <button type="button" @click="closeEdit">{{ $t('common.cancel') }}</button>
+            <button type="button" class="btn-secondary" @click="closeEdit">
+              {{ $t('common.cancel') }}
+            </button>
             <button type="submit" class="btn-primary">
               {{ $t('admins.btn_save') }}
             </button>

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -67,7 +67,9 @@
           :placeholder="$t('anomalies.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
-          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="revokeTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-danger" :disabled="!revokeReason.trim()" @click="confirmRevoke">
             {{ $t('anomalies.btn_revoke_confirm') }}
           </button>

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -67,10 +67,10 @@
           :placeholder="$t('anomalies.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
+          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-danger" :disabled="!revokeReason.trim()" @click="confirmRevoke">
             {{ $t('anomalies.btn_revoke_confirm') }}
           </button>
-          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -104,7 +104,7 @@
           />
 
           <div class="modal-actions">
-            <button @click="closeAddServer">{{ $t('common.cancel') }}</button>
+            <button class="btn-secondary" @click="closeAddServer">{{ $t('common.cancel') }}</button>
             <button
               class="btn-primary"
               :disabled="!addFormValid || adding"
@@ -179,7 +179,7 @@
         />
 
         <div class="modal-actions">
-          <button @click="closeEditServer">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="closeEditServer">{{ $t('common.cancel') }}</button>
           <button
             class="btn-primary"
             :disabled="!editFormValid || editing"

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -104,6 +104,7 @@
           />
 
           <div class="modal-actions">
+            <button @click="closeAddServer">{{ $t('common.cancel') }}</button>
             <button
               class="btn-primary"
               :disabled="!addFormValid || adding"
@@ -111,7 +112,6 @@
             >
               {{ adding ? $t('add_server.submitting') : $t('add_server.submit') }}
             </button>
-            <button @click="closeAddServer">{{ $t('common.cancel') }}</button>
           </div>
         </template>
 
@@ -179,6 +179,7 @@
         />
 
         <div class="modal-actions">
+          <button @click="closeEditServer">{{ $t('common.cancel') }}</button>
           <button
             class="btn-primary"
             :disabled="!editFormValid || editing"
@@ -186,7 +187,6 @@
           >
             {{ editing ? $t('edit_server.submitting') : $t('edit_server.submit') }}
           </button>
-          <button @click="closeEditServer">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -104,10 +104,10 @@
         </div>
         <p class="warn-text" v-html="$t('server_detail.delete_modal_warning', { hostname })"></p>
         <div class="modal-actions">
+          <button @click="showDeleteModal = false">{{ $t('common.cancel') }}</button>
           <button class="btn-danger" @click="deleteServer">
             {{ $t('server_detail.delete_confirm') }}
           </button>
-          <button @click="showDeleteModal = false">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -138,10 +138,10 @@
           :placeholder="$t('server_detail.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
+          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-danger" :disabled="!revokeReason.trim()" @click="confirmRevoke">
             {{ $t('server_detail.revoke_confirm') }}
           </button>
-          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -168,10 +168,10 @@
           :placeholder="$t('server_detail.assign_username_placeholder')"
         />
         <div class="modal-actions">
+          <button @click="assignTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-primary" :disabled="!assignUsername.trim()" @click="confirmAssign">
             {{ $t('server_detail.assign_confirm') }}
           </button>
-          <button @click="assignTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>
@@ -207,10 +207,10 @@
         />
         <input v-else v-model="expiryDate" type="datetime-local" />
         <div class="modal-actions">
+          <button @click="expiryTarget = null">{{ $t('common.cancel') }}</button>
           <button class="btn-primary" :disabled="!expiryValid" @click="confirmExpiry">
             {{ $t('server_detail.expiry_confirm') }}
           </button>
-          <button @click="expiryTarget = null">{{ $t('common.cancel') }}</button>
         </div>
       </div>
     </div>

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -104,7 +104,9 @@
         </div>
         <p class="warn-text" v-html="$t('server_detail.delete_modal_warning', { hostname })"></p>
         <div class="modal-actions">
-          <button @click="showDeleteModal = false">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="showDeleteModal = false">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-danger" @click="deleteServer">
             {{ $t('server_detail.delete_confirm') }}
           </button>
@@ -138,7 +140,9 @@
           :placeholder="$t('server_detail.revoke_reason_placeholder')"
         ></textarea>
         <div class="modal-actions">
-          <button @click="revokeTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="revokeTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-danger" :disabled="!revokeReason.trim()" @click="confirmRevoke">
             {{ $t('server_detail.revoke_confirm') }}
           </button>
@@ -168,7 +172,9 @@
           :placeholder="$t('server_detail.assign_username_placeholder')"
         />
         <div class="modal-actions">
-          <button @click="assignTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="assignTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-primary" :disabled="!assignUsername.trim()" @click="confirmAssign">
             {{ $t('server_detail.assign_confirm') }}
           </button>
@@ -207,7 +213,9 @@
         />
         <input v-else v-model="expiryDate" type="datetime-local" />
         <div class="modal-actions">
-          <button @click="expiryTarget = null">{{ $t('common.cancel') }}</button>
+          <button class="btn-secondary" @click="expiryTarget = null">
+            {{ $t('common.cancel') }}
+          </button>
           <button class="btn-primary" :disabled="!expiryValid" @click="confirmExpiry">
             {{ $t('server_detail.expiry_confirm') }}
           </button>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -112,11 +112,9 @@
     <section class="card">
       <h3>{{ $t('settings.smtp_section') }}</h3>
       <div class="field">
-        <div class="input-row">
-          <button class="btn-primary" :disabled="smtpTesting" @click="testSmtp">
-            {{ smtpTesting ? $t('settings.smtp_testing') : $t('settings.smtp_test_btn') }}
-          </button>
-        </div>
+        <button class="btn-primary" :disabled="smtpTesting" @click="testSmtp">
+          {{ smtpTesting ? $t('settings.smtp_testing') : $t('settings.smtp_test_btn') }}
+        </button>
         <p class="hint">{{ $t('settings.smtp_hint') }}</p>
         <p v-if="smtpSuccess" class="success-msg">{{ smtpSuccess }}</p>
         <p v-if="smtpError" class="error-msg">{{ smtpError }}</p>
@@ -302,6 +300,9 @@ h2 {
 
 .field {
   margin-top: 1rem;
+}
+.field .btn-primary {
+  min-width: 6rem;
 }
 
 .field label {

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -301,9 +301,6 @@ h2 {
 .field {
   margin-top: 1rem;
 }
-.field .btn-primary {
-  min-width: 6rem;
-}
 
 .field label {
   display: block;


### PR DESCRIPTION
## Summary

All modal dialogs had the wrong button order: primary action (Save/Confirm) on the left, Cancel on the right.

Standard web convention (Material Design, GitHub, Bootstrap): Cancel on the left, primary action on the right.

13 modal-actions blocks corrected across 5 files:
- `views/Admins.vue` — 5 modals
- `views/Dashboard.vue` — 2 modals
- `views/ServerDetail.vue` — 4 modals
- `views/Anomalies.vue` — 1 modal
- `components/KeyActions.vue` — 1 modal

## Test plan
- [x] vitest 248 passed
- [x] Prettier clean