### PR TITLE
feat: auto-provision remote server via SSH password, custom port stored in DB

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -115,7 +115,7 @@ def revoke_key(
     if hostname and unix_user:
         # --- Targeted revocation (one user on one server) ---
         server = db.query_one(
-            "SELECT id, ip_address FROM servers WHERE hostname = %s",
+            "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s",
             (hostname,),
         )
         if not server:
@@ -132,7 +132,7 @@ def revoke_key(
             raise ValueError(
                 f"No active authorization for {fingerprint} / user {unix_user} on {hostname}"
             )
-        ssh.revoke_on_server(hostname, fingerprint, ip=server["ip_address"], unix_user=unix_user)
+        ssh.revoke_on_server(hostname, fingerprint, ip=server["ip_address"], unix_user=unix_user, port=server["ssh_port"])
         db.execute(
             """
             UPDATE key_authorizations
@@ -161,7 +161,7 @@ def revoke_key(
         # --- Global revocation (all servers, all users) ---
         active_auths = db.query(
             """
-            SELECT DISTINCT ka.server_id, s.hostname, s.ip_address
+            SELECT DISTINCT ka.server_id, s.hostname, s.ip_address, s.ssh_port
             FROM key_authorizations ka
             JOIN servers s ON s.id = ka.server_id
             WHERE ka.key_id = %s AND ka.status IN ('ACTIVE', 'PENDING_REVIEW')
@@ -169,7 +169,7 @@ def revoke_key(
             (key["id"],),
         )
         for auth in active_auths:
-            ssh.revoke_on_server(auth["hostname"], fingerprint, ip=auth["ip_address"])
+            ssh.revoke_on_server(auth["hostname"], fingerprint, ip=auth["ip_address"], port=auth["ssh_port"])
             db.execute(
                 """
                 UPDATE key_authorizations
@@ -481,7 +481,7 @@ def deploy_key(
         key_size_bits = int.from_bytes(field, "big").bit_length()
 
     server = db.query_one(
-        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,),
     )
     if not server:
@@ -499,8 +499,8 @@ def deploy_key(
     )
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
 
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
-    ssh.add_key_on_server(hostname, unix_user, public_key.strip(), server["ip_address"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
+    ssh.add_key_on_server(hostname, unix_user, public_key.strip(), server["ip_address"], port=server["ssh_port"])
 
     db.execute(
         """
@@ -613,9 +613,9 @@ def revoke_request(request_id: str, admin_id: str) -> None:
 
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (req["key_id"],))
     if key:
-        server = db.query_one("SELECT hostname, ip_address FROM servers WHERE id = %s", (req["server_id"],))
+        server = db.query_one("SELECT hostname, ip_address, ssh_port FROM servers WHERE id = %s", (req["server_id"],))
         if server:
-            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"])
+            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"], port=server["ssh_port"])
 
     db.execute(
         """
@@ -637,7 +637,7 @@ def revoke_request(request_id: str, admin_id: str) -> None:
 
 def add_server(
     hostname: str, ip: str, env: str, os_family: str | None = None,
-    admin_id: str | None = None,
+    ssh_port: int = 22, admin_id: str | None = None,
 ) -> dict:
     """Insert a new server, run ssh-keyscan, and log SERVER_ADDED."""
     ip = _validate_ip(ip)
@@ -652,8 +652,8 @@ def add_server(
     except Exception as e:
         raise ValueError(f"Cannot reach {hostname} ({ip}) for keyscan: {e}") from e
     db.execute(
-        "INSERT INTO servers (hostname, ip_address, environment, os_family) VALUES (%s, %s, %s, %s)",
-        (hostname, ip, env, os_family),
+        "INSERT INTO servers (hostname, ip_address, environment, os_family, ssh_port) VALUES (%s, %s, %s, %s, %s)",
+        (hostname, ip, env, os_family, ssh_port),
     )
     server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
     db.execute(
@@ -661,9 +661,36 @@ def add_server(
         INSERT INTO audit_log (action, performed_by, target_server, details)
         VALUES ('SERVER_ADDED', %s, %s, %s::jsonb)
         """,
-        (admin_id, server["id"], json.dumps({"hostname": hostname, "ip": ip, "environment": env})),
+        (admin_id, server["id"], json.dumps({"hostname": hostname, "ip": ip, "environment": env, "ssh_port": ssh_port})),
     )
     return server
+
+
+def provision_server(hostname: str, ssh_user: str, ssh_password: str, ssh_port: int, admin_id: str) -> None:
+    """Provision a remote server via SSH password auth. Never stores the password."""
+    server = db.query_one(
+        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        (hostname,),
+    )
+    if not server:
+        raise ValueError(f"Server not found or inactive: {hostname}")
+    ssh.provision_server(server["ip_address"], ssh_user, ssh_password, ssh_port)
+    # Update ssh_port in DB after successful provisioning
+    db.execute(
+        "UPDATE servers SET ssh_port = %s WHERE id = %s",
+        (ssh_port, server["id"]),
+    )
+    db.execute(
+        """
+        INSERT INTO audit_log (action, performed_by, target_server, details)
+        VALUES ('SERVER_PROVISIONED', %s, %s, %s::jsonb)
+        """,
+        (
+            admin_id,
+            server["id"],
+            json.dumps({"hostname": hostname, "ssh_user": ssh_user, "ssh_port": ssh_port}),
+        ),
+    )
 
 
 def disable_server(hostname: str, admin_id: str | None = None) -> None:
@@ -685,13 +712,13 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
 
 def update_server(
     hostname: str, new_ip: str, new_env: str, new_os_family: str | None,
-    admin_id: str | None = None,
+    ssh_port: int = 22, admin_id: str | None = None,
 ) -> dict:
-    """Update server IP, environment, OS. If IP changes, run ssh-keyscan."""
+    """Update server IP, environment, OS, SSH port. If IP changes, run ssh-keyscan."""
     new_ip = _validate_ip(new_ip)
     import servers as servers_mod
     server = db.query_one(
-        "SELECT id, ip_address, environment, os_family FROM servers WHERE hostname = %s",
+        "SELECT id, ip_address, environment, os_family, ssh_port FROM servers WHERE hostname = %s",
         (hostname,),
     )
     if not server:
@@ -707,6 +734,7 @@ def update_server(
     old_ip = server["ip_address"]
     old_env = server["environment"]
     old_os = server["os_family"]
+    old_port = server["ssh_port"]
 
     if new_ip != old_ip:
         try:
@@ -715,8 +743,8 @@ def update_server(
             raise ValueError(f"Cannot reach {hostname} ({new_ip}) for keyscan: {e}") from e
 
     db.execute(
-        "UPDATE servers SET ip_address = %s, environment = %s, os_family = %s WHERE hostname = %s",
-        (new_ip, new_env, new_os_family, hostname),
+        "UPDATE servers SET ip_address = %s, environment = %s, os_family = %s, ssh_port = %s WHERE hostname = %s",
+        (new_ip, new_env, new_os_family, ssh_port, hostname),
     )
     db.execute(
         """
@@ -731,6 +759,7 @@ def update_server(
                 "old_ip": old_ip, "new_ip": new_ip,
                 "old_env": old_env, "new_env": new_env,
                 "old_os": old_os, "new_os": new_os_family,
+                "old_port": old_port, "new_port": ssh_port,
             }),
         ),
     )
@@ -980,13 +1009,13 @@ def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     if not _UNIX_USER_RE.match(unix_user):
         raise ValueError(f"Invalid Unix username: '{unix_user}'")
     server = db.query_one(
-        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,)
     )
     if not server:
         raise ValueError(f"Server not found or inactive: {hostname}")
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
-    ssh.lock_user_on_server(hostname, unix_user, server["ip_address"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
+    ssh.lock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
     db.execute(
         """INSERT INTO audit_log (action, performed_by, target_server, details)
            VALUES ('USER_LOCKED', %s, %s, %s::jsonb)""",
@@ -1002,13 +1031,13 @@ def unlock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     if not _UNIX_USER_RE.match(unix_user):
         raise ValueError(f"Invalid Unix username: '{unix_user}'")
     server = db.query_one(
-        "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,)
     )
     if not server:
         raise ValueError(f"Server not found or inactive: {hostname}")
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"])
-    ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
+    ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
     db.execute(
         """INSERT INTO audit_log (action, performed_by, target_server, details)
            VALUES ('USER_UNLOCKED', %s, %s, %s::jsonb)""",

--- a/app/collect.py
+++ b/app/collect.py
@@ -83,12 +83,13 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
     """
     hostname = server["hostname"]
     ip = server["ip_address"]
+    ssh_port = server.get("ssh_port", 22)
     server_id = server["id"]
     result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
 
     try:
-        ssh.ensure_scripts(hostname, server_id, ip=ip)
-        raw_lines = ssh.collect_keys(hostname, ip=ip)
+        ssh.ensure_scripts(hostname, server_id, ip=ip, port=ssh_port)
+        raw_lines = ssh.collect_keys(hostname, ip=ip, port=ssh_port)
     except Exception as exc:
         result["error"] = str(exc)
         db.execute(
@@ -187,7 +188,7 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
 
     # Collect SSH sessions (non-fatal)
     try:
-        ssh.collect_sessions_on_server(hostname, server_id, ip=ip)
+        ssh.collect_sessions_on_server(hostname, server_id, ip=ip, port=ssh_port)
     except Exception:
         pass
 

--- a/app/expire.py
+++ b/app/expire.py
@@ -63,7 +63,7 @@ def expire_keys() -> int:
     """
     rows = db.query(
         """
-        SELECT DISTINCT ka.key_id, ka.server_id, sk.fingerprint, s.hostname, s.ip_address
+        SELECT DISTINCT ka.key_id, ka.server_id, sk.fingerprint, s.hostname, s.ip_address, s.ssh_port
         FROM key_authorizations ka
         JOIN ssh_keys sk ON sk.id = ka.key_id
         JOIN servers s ON s.id = ka.server_id
@@ -76,7 +76,7 @@ def expire_keys() -> int:
     expired = 0
     for row in rows:
         try:
-            ssh.revoke_on_server(row["hostname"], row["fingerprint"], ip=row["ip_address"])
+            ssh.revoke_on_server(row["hostname"], row["fingerprint"], ip=row["ip_address"], port=row["ssh_port"])
         except Exception as exc:
             alerts.send_alert(
                 "CRITICAL",

--- a/app/servers.py
+++ b/app/servers.py
@@ -51,12 +51,13 @@ def sync_servers(path: str = SERVERS_YML) -> list[dict]:
     for s in servers:
         db.execute(
             """
-            INSERT INTO servers (hostname, ip_address, environment, os_family)
-            VALUES (%s, %s, %s, %s)
+            INSERT INTO servers (hostname, ip_address, environment, os_family, ssh_port)
+            VALUES (%s, %s, %s, %s, %s)
             ON CONFLICT (hostname) DO UPDATE SET
                 ip_address  = EXCLUDED.ip_address,
                 environment = EXCLUDED.environment,
                 os_family   = EXCLUDED.os_family,
+                ssh_port    = EXCLUDED.ssh_port,
                 is_active   = true
             """,
             (
@@ -64,6 +65,7 @@ def sync_servers(path: str = SERVERS_YML) -> list[dict]:
                 s["ip"],
                 s.get("environment"),
                 s.get("os_family"),
+                s.get("ssh_port", 22),
             ),
         )
     return servers

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -209,11 +209,11 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
-def _connect(ip: str) -> paramiko.SSHClient:
+def _connect(ip: str, port: int = 22) -> paramiko.SSHClient:
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.RejectPolicy())
     client.load_host_keys(KNOWN_HOSTS)
-    client.connect(hostname=ip, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
+    client.connect(hostname=ip, port=port, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
     return client
 
 
@@ -245,12 +245,12 @@ def _deploy_script(
     _run(client, f"rm -f {shlex.quote(tmp_path)}")
 
 
-def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
+def ensure_scripts(hostname: str, server_id: str, ip: str, port: int = 22) -> None:
     """
     Deploy SAM_COLLECT, SAM_REVOKE, SAM_ADD, SAM_LOCK_USER, and SAM_UNLOCK_USER on the remote host if absent or outdated.
     Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
     """
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         sftp = client.open_sftp()
         for content, remote_path in (
@@ -284,13 +284,13 @@ def ensure_scripts(hostname: str, server_id: str, ip: str) -> None:
         client.close()
 
 
-def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = None) -> None:
+def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = None, port: int = 22) -> None:
     """Run sam-revoke on the remote host.
     If unix_user is given, revokes only from that user's authorized_keys.
     Otherwise revokes globally (all users on the server).
     """
     import shlex
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         cmd = f"sudo {SAM_REVOKE_PATH} {shlex.quote(fingerprint)}"
         if unix_user:
@@ -304,9 +304,9 @@ def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = 
         client.close()
 
 
-def collect_keys(hostname: str, ip: str) -> list[str]:
+def collect_keys(hostname: str, ip: str, port: int = 22) -> list[str]:
     """Run sam-collect on the remote host and return raw output lines."""
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         out, _, rc = _run(client, f"sudo {SAM_COLLECT_PATH}")
         if rc != 0:
@@ -316,10 +316,10 @@ def collect_keys(hostname: str, ip: str) -> list[str]:
         client.close()
 
 
-def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str) -> None:
+def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str, port: int = 22) -> None:
     """Run sam-add on the remote host to deploy a public key for the given Unix user."""
     import shlex
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_ADD_PATH} {shlex.quote(unix_user)} {shlex.quote(public_key)}"
@@ -330,10 +330,10 @@ def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str) -
         client.close()
 
 
-def lock_user_on_server(hostname: str, unix_user: str, ip: str) -> None:
+def lock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22) -> None:
     """Run sam-lock-user on the remote host to lock a Unix user account."""
     import shlex
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_LOCK_USER_PATH} {shlex.quote(unix_user)}"
@@ -344,10 +344,10 @@ def lock_user_on_server(hostname: str, unix_user: str, ip: str) -> None:
         client.close()
 
 
-def unlock_user_on_server(hostname: str, unix_user: str, ip: str) -> None:
+def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22) -> None:
     """Run sam-unlock-user on the remote host to unlock a Unix user account."""
     import shlex
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_UNLOCK_USER_PATH} {shlex.quote(unix_user)}"
@@ -405,10 +405,10 @@ def _is_valid_ip(s: str) -> bool:
         return False
 
 
-def collect_sessions_on_server(hostname: str, server_id: str, ip: str) -> None:
+def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int = 22) -> None:
     """Collect SSH sessions via sam-sessions and upsert into ssh_sessions table."""
     from datetime import datetime, timezone
-    client = _connect(ip)
+    client = _connect(ip, port)
     try:
         out, _, rc = _run(client, f"sudo {SAM_SESSIONS_PATH}")
         if rc != 0:
@@ -470,5 +470,106 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str) -> None:
                     """,
                     (server_id, unix_user, tty, login_ip, login_at, logout_at, is_still_active),
                 )
+    finally:
+        client.close()
+
+
+def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 22) -> None:
+    """Connect with password auth and run provision-host.sh on the remote host."""
+    import socket
+    import subprocess as _sp
+
+    # Step 1 — ssh-keyscan on provision port to populate known_hosts
+    try:
+        result = _sp.run(
+            ["ssh-keyscan", "-H", "-T", "10", "-p", str(ssh_port), ip],
+            capture_output=True, text=True, timeout=15,
+        )
+    except _sp.TimeoutExpired:
+        raise RuntimeError(
+            f"Connection timed out — server did not respond within 15 seconds on port {ssh_port}"
+        )
+
+    if not result.stdout.strip():
+        raise RuntimeError(
+            f"Server unreachable — could not get host key on port {ssh_port}. "
+            "Check the IP address and that SSH is running."
+        )
+
+    # Append to known_hosts (dedup: only if not already present)
+    with open(KNOWN_HOSTS, "a") as fh:
+        fh.write(result.stdout)
+
+    # Step 2 — connect with password auth
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())
+    client.load_host_keys(KNOWN_HOSTS)
+
+    try:
+        client.connect(
+            hostname=ip,
+            port=ssh_port,
+            username=ssh_user,
+            password=ssh_password,
+            timeout=15,
+            look_for_keys=False,
+            allow_agent=False,
+        )
+    except paramiko.AuthenticationException:
+        raise RuntimeError("Authentication failed — check your username and password")
+    except socket.timeout:
+        raise RuntimeError("Connection timed out — server did not respond within 15 seconds")
+    except Exception as exc:
+        msg = str(exc)
+        if any(k in msg for k in ("No route to host", "Network unreachable", "No address associated")):
+            raise RuntimeError("Server unreachable — check the IP and network connectivity")
+        if "Connection refused" in msg:
+            raise RuntimeError(
+                f"SSH port {ssh_port} refused — check that SSH is running on that port"
+            )
+        raise RuntimeError(f"Connection failed: {exc}")
+
+    try:
+        # Step 3 — read provision script and collector public key
+        with open("/app/provision-host.sh", "rb") as fh:
+            script = fh.read()
+        with open(f"{COLLECTOR_KEY}.pub") as fh:
+            collector_pubkey = fh.read().strip()
+
+        # Step 4 — upload provision script via SFTP
+        sftp = client.open_sftp()
+        sftp.putfo(io.BytesIO(script), "/tmp/sam-provision.sh")
+        sftp.chmod("/tmp/sam-provision.sh", 0o700)
+        sftp.close()
+
+        # Step 5 — execute via sudo -S (password on stdin)
+        cmd = (
+            f"sudo -S bash /tmp/sam-provision.sh "
+            f"{shlex.quote(collector_pubkey)} {shlex.quote(SSH_USER)}"
+        )
+        stdin, stdout, stderr = client.exec_command(cmd, timeout=60)
+        stdin.write(ssh_password + "\n")
+        stdin.flush()
+        stdin.channel.shutdown_write()
+
+        exit_code = stdout.channel.recv_exit_status()
+        err_out = stderr.read().decode(errors="replace")
+
+        # Step 6 — cleanup (best-effort)
+        try:
+            client.exec_command("rm -f /tmp/sam-provision.sh")
+        except Exception:
+            pass
+
+        if exit_code != 0:
+            if "sudo:" in err_out and any(
+                k in err_out.lower() for k in ("incorrect password", "no password", "not allowed")
+            ):
+                raise RuntimeError(
+                    "Provisioning failed — check that the user has sudo privileges"
+                )
+            raise RuntimeError(
+                f"Provisioning script failed (exit {exit_code}): {err_out[:300]}"
+            )
     finally:
         client.close()

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -72,6 +72,7 @@ def sample_server():
         "id": str(uuid.uuid4()),
         "hostname": "server-test-01",
         "ip_address": "192.168.1.10",
+        "ssh_port": 22,
         "os_family": "rhel",
         "os_version": "RHEL 9.3",
         "environment": "lab",

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -56,18 +56,18 @@ def test_actions_validate_key_raises_if_no_pending(sample_key):
 # ---------------------------------------------------------------------------
 
 def test_actions_revoke_key_scenario1_calls_sam_revoke(sample_key):
-    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10"}
+    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {"id": KEY_ID}
         mock_db.query.return_value = [auth]
         actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "test reason")
         mock_ssh.revoke_on_server.assert_called_once_with(
-            "server-test-01", sample_key["fingerprint"], ip="192.168.1.10"
+            "server-test-01", sample_key["fingerprint"], ip="192.168.1.10", port=22
         )
 
 
 def test_actions_revoke_key_scenario1_sets_revoked_by_admin(sample_key):
-    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10"}
+    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {"id": KEY_ID}
         mock_db.query.return_value = [auth]
@@ -78,7 +78,7 @@ def test_actions_revoke_key_scenario1_sets_revoked_by_admin(sample_key):
 
 
 def test_actions_revoke_key_scenario1_logs_key_revoked(sample_key):
-    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10"}
+    auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {"id": KEY_ID}
         mock_db.query.return_value = [auth]
@@ -96,7 +96,7 @@ def test_actions_revoke_key_raises_if_key_not_found(sample_key):
 
 def test_actions_revoke_key_scoped_calls_sam_revoke_with_unix_user(sample_key):
     """Revocation ciblée (hostname + unix_user) appelle revoke_on_server avec unix_user."""
-    server = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
     auth = {"status": "ACTIVE"}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.side_effect = [{"id": KEY_ID}, server, auth]
@@ -106,13 +106,13 @@ def test_actions_revoke_key_scoped_calls_sam_revoke_with_unix_user(sample_key):
         )
         mock_ssh.revoke_on_server.assert_called_once_with(
             "server-test-01", sample_key["fingerprint"],
-            ip="192.168.1.10", unix_user="alice",
+            ip="192.168.1.10", unix_user="alice", port=22,
         )
 
 
 def test_actions_revoke_key_scoped_sets_revoked_for_unix_user_only(sample_key):
     """Revocation ciblée — l'UPDATE inclut unix_user dans le WHERE."""
-    server = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
     auth = {"status": "ACTIVE"}
     with patch("actions.db") as mock_db, patch("actions.ssh"):
         mock_db.query_one.side_effect = [{"id": KEY_ID}, server, auth]
@@ -387,11 +387,11 @@ def test_actions_revoke_request_calls_sam_revoke():
         mock_db.query_one.side_effect = [
             req,
             {"fingerprint": "SHA256:abc"},
-            {"hostname": "server-test-01", "ip_address": "192.168.1.10"},
+            {"hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22},
         ]
         actions.revoke_request(REQUEST_ID, ADMIN_ID)
         mock_ssh.revoke_on_server.assert_called_once_with(
-            "server-test-01", "SHA256:abc", ip="192.168.1.10"
+            "server-test-01", "SHA256:abc", ip="192.168.1.10", port=22
         )
 
 
@@ -402,7 +402,7 @@ def test_actions_revoke_request_calls_sam_revoke():
 def test_actions_add_server_logs_server_added(sample_server):
     with patch("actions.db") as mock_db, patch("servers.add_to_known_hosts"):
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
-        actions.add_server("new-host", "10.0.0.1", "lab", "rhel", ADMIN_ID)
+        actions.add_server("new-host", "10.0.0.1", "lab", "rhel", 22, ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("SERVER_ADDED" in c for c in calls)
 
@@ -420,6 +420,48 @@ def test_actions_disable_server_raises_if_not_found():
         mock_db.query_one.return_value = None
         with pytest.raises(ValueError, match="not found"):
             actions.disable_server("ghost")
+
+
+# ---------------------------------------------------------------------------
+# provision_server
+# ---------------------------------------------------------------------------
+
+def test_actions_provision_server_calls_ssh_provision(sample_server):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        actions.provision_server("server-test-01", "root", "password123", 22, ADMIN_ID)
+        mock_ssh.provision_server.assert_called_once_with("192.168.1.10", "root", "password123", 22)
+
+
+def test_actions_provision_server_logs_provisioned(sample_server):
+    with patch("actions.db") as mock_db, patch("actions.ssh"):
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        actions.provision_server("server-test-01", "root", "password123", 22, ADMIN_ID)
+        calls = [c[0][0] for c in mock_db.execute.call_args_list]
+        assert any("SERVER_PROVISIONED" in c for c in calls)
+
+
+def test_actions_provision_server_password_not_logged(sample_server):
+    """Password must never appear in audit_log."""
+    secret_password = "SuperSecret123!"
+    with patch("actions.db") as mock_db, patch("actions.ssh"):
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        actions.provision_server("server-test-01", "root", secret_password, 22, ADMIN_ID)
+
+        # Check all db.execute calls
+        for call_args in mock_db.execute.call_args_list:
+            sql = call_args[0][0] if call_args[0] else ""
+            params = call_args[0][1] if len(call_args[0]) > 1 else ()
+            for param in params:
+                if isinstance(param, str) and secret_password in param:
+                    raise AssertionError(f"Password found in audit_log: {param}")
+
+
+def test_actions_provision_server_raises_if_not_found():
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = None
+        with pytest.raises(ValueError, match="not found"):
+            actions.provision_server("ghost", "root", "password", 22, ADMIN_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -650,7 +692,7 @@ def test_actions_update_admin_allows_demotion_with_other_sysadmin():
 def test_actions_deploy_key_success(sample_server, sample_key):
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.side_effect = [
-            {"id": sample_server["id"], "ip_address": sample_server["ip_address"]},
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
             {"id": sample_key["id"]},
         ]
         mock_db.execute.return_value = None
@@ -674,7 +716,7 @@ def test_actions_deploy_key_success(sample_server, sample_key):
 def test_actions_deploy_key_invalid_key_type(sample_server):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {
-            "id": sample_server["id"], "ip_address": sample_server["ip_address"]
+            "id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22
         }
         with pytest.raises(ValueError, match="Unsupported key type"):
             actions.deploy_key(
@@ -796,10 +838,10 @@ def test_actions_fingerprint_valid_format_passes_check():
 
 def test_actions_lock_user_success():
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
-        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
         result = actions.lock_user("alice", "server-test-01", ADMIN_ID)
-        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10")
-        mock_ssh.lock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10")
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22)
+        mock_ssh.lock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22)
         assert result["unix_user"] == "alice"
         assert result["hostname"] == "server-test-01"
         assert result["status"] == "locked"
@@ -821,10 +863,10 @@ def test_actions_lock_user_server_not_found():
 
 def test_actions_unlock_user_success():
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
-        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
+        mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
         result = actions.unlock_user("alice", "server-test-01", ADMIN_ID)
-        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10")
-        mock_ssh.unlock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10")
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22)
+        mock_ssh.unlock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22)
         assert result["unix_user"] == "alice"
         assert result["hostname"] == "server-test-01"
         assert result["status"] == "unlocked"
@@ -859,7 +901,7 @@ def test_actions_deploy_key_includes_unix_user_in_key_authorization(sample_serve
     """deploy_key insère unix_user dans key_authorizations."""
     with patch("actions.db") as mock_db, patch("actions.ssh"):
         mock_db.query_one.side_effect = [
-            {"id": sample_server["id"], "ip_address": sample_server["ip_address"]},
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
             {"id": sample_key["id"]},
         ]
         actions.deploy_key(
@@ -881,7 +923,7 @@ def test_actions_deploy_key_on_conflict_uses_three_column_pk(sample_server, samp
     """Le ON CONFLICT doit référencer (key_id, server_id, unix_user)."""
     with patch("actions.db") as mock_db, patch("actions.ssh"):
         mock_db.query_one.side_effect = [
-            {"id": sample_server["id"], "ip_address": sample_server["ip_address"]},
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
             {"id": sample_key["id"]},
         ]
         actions.deploy_key(
@@ -991,10 +1033,10 @@ def test_actions_validate_key_scoped_raises_if_server_not_found(sample_key):
 
 def test_actions_update_server_success():
     """update_server met à jour les champs et log SERVER_UPDATED."""
-    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel"}
+    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("servers.add_to_known_hosts"):
         mock_db.query_one.side_effect = [server, None]
-        actions.update_server("server-test-01", "192.168.1.20", "production", "debian", ADMIN_ID)
+        actions.update_server("server-test-01", "192.168.1.20", "production", "debian", 22, ADMIN_ID)
         update_call = mock_db.execute.call_args_list[0]
         assert "UPDATE servers" in update_call[0][0]
         assert "192.168.1.20" in update_call[0][1]
@@ -1006,10 +1048,10 @@ def test_actions_update_server_success():
 
 def test_actions_update_server_ip_change_calls_keyscan():
     """Si l'IP change, add_to_known_hosts est appelé."""
-    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel"}
+    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("servers.add_to_known_hosts") as mock_keyscan:
         mock_db.query_one.side_effect = [server, None]
-        actions.update_server("server-test-01", "192.168.1.99", "lab", "rhel", ADMIN_ID)
+        actions.update_server("server-test-01", "192.168.1.99", "lab", "rhel", 22, ADMIN_ID)
         mock_keyscan.assert_called_once_with("192.168.1.99")
 
 
@@ -1040,11 +1082,11 @@ def test_actions_add_server_rejects_duplicate_ip():
 
 
 def test_actions_update_server_rejects_duplicate_ip():
-    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel"}
+    server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22}
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [server, {"hostname": "other-server"}]
         with pytest.raises(ValueError, match="already used by server"):
-            actions.update_server("server-test-01", "10.0.0.2", "lab", None, ADMIN_ID)
+            actions.update_server("server-test-01", "10.0.0.2", "lab", None, 22, ADMIN_ID)
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -110,20 +110,20 @@ def test_expire_warn_expiring_keys_no_email_when_all_antispammed():
 def test_expire_expire_keys_scenario4_calls_sam_revoke():
     row = {
         "key_id": KEY_ID, "server_id": SERVER_ID,
-        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10",
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \
          patch("expire.alerts"):
         mock_db.query.return_value = [row]
         expire.expire_keys()
-        mock_ssh.revoke_on_server.assert_called_once_with(HOSTNAME, FINGERPRINT, ip="192.168.1.10")
+        mock_ssh.revoke_on_server.assert_called_once_with(HOSTNAME, FINGERPRINT, ip="192.168.1.10", port=22)
 
 
 def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():
     row = {
         "key_id": KEY_ID, "server_id": SERVER_ID,
-        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10",
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \
@@ -139,7 +139,7 @@ def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():
 def test_expire_expire_keys_scenario4_logs_key_expired():
     row = {
         "key_id": KEY_ID, "server_id": SERVER_ID,
-        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10",
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \
@@ -152,8 +152,8 @@ def test_expire_expire_keys_scenario4_logs_key_expired():
 
 def test_expire_expire_keys_scenario4_returns_count():
     rows = [
-        {"key_id": KEY_ID, "server_id": SERVER_ID, "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10"},
-        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "fingerprint": "SHA256:other", "hostname": HOSTNAME, "ip_address": "192.168.1.10"},
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
+        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "fingerprint": "SHA256:other", "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
     ]
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -672,3 +672,197 @@ def test_ssh_collect_sessions_local_tty_no_ip(mock_ssh_client):
             params = insert_calls[0][0][1]
             # login_ip must be None, not "Mon"
             assert params[3] is None
+
+
+# ---------------------------------------------------------------------------
+# provision_server — auto-provision via password SSH
+# ---------------------------------------------------------------------------
+
+def test_ssh_provision_server_success():
+    """provision_server succeeds when all steps complete."""
+    from unittest.mock import MagicMock, patch, mock_open
+    import subprocess
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    def mock_open_side_effect(filename, *args, **kwargs):
+        if filename == "/app/provision-host.sh":
+            return mock_open(read_data=b"#!/bin/sh\necho provisioned")()
+        elif filename.endswith(".pub"):
+            return mock_open(read_data="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...")()
+        return mock_open()()
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", side_effect=mock_open_side_effect), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy") as mock_policy:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        mock_stdin = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+        mock_stdout.channel.recv_exit_status.return_value = 0
+        mock_stderr.read.return_value = b""
+        mock_client.exec_command.return_value = (mock_stdin, mock_stdout, mock_stderr)
+
+        mock_sftp = MagicMock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        # Should not raise
+        ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+        mock_client.set_missing_host_key_policy.assert_called_once()
+        mock_client.connect.assert_called_once()
+        assert mock_client.connect.call_args[1]["password"] == "password123"
+        assert mock_sftp.putfo.called
+        mock_client.close.assert_called_once()
+
+
+def test_ssh_provision_server_auth_failed():
+    """provision_server raises RuntimeError on authentication failure."""
+    from unittest.mock import MagicMock, patch, mock_open
+    import paramiko
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", mock_open(read_data=b"#!/bin/sh\necho provisioned")), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.connect.side_effect = paramiko.AuthenticationException("Auth failed")
+
+        with pytest.raises(RuntimeError, match="Authentication failed"):
+            ssh.provision_server("192.168.1.10", "root", "wrongpass", 22)
+
+
+def test_ssh_provision_server_timeout():
+    """provision_server raises RuntimeError on timeout."""
+    from unittest.mock import MagicMock, patch, mock_open
+    import socket
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", mock_open(read_data=b"#!/bin/sh\necho provisioned")), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.connect.side_effect = socket.timeout("Timeout")
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+
+def test_ssh_provision_server_no_route():
+    """provision_server raises RuntimeError on no route to host."""
+    from unittest.mock import MagicMock, patch, mock_open
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", mock_open(read_data=b"#!/bin/sh\necho provisioned")), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.connect.side_effect = Exception("No route to host")
+
+        with pytest.raises(RuntimeError, match="unreachable"):
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+
+def test_ssh_provision_server_refused():
+    """provision_server raises RuntimeError on connection refused."""
+    from unittest.mock import MagicMock, patch, mock_open
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", mock_open(read_data=b"#!/bin/sh\necho provisioned")), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.connect.side_effect = Exception("Connection refused")
+
+        with pytest.raises(RuntimeError, match="refused"):
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+
+def test_ssh_provision_server_keyscan_unreachable():
+    """provision_server raises RuntimeError when ssh-keyscan returns empty output."""
+    from unittest.mock import MagicMock, patch
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = ""
+
+    with patch("subprocess.run", return_value=mock_sp_result):
+        with pytest.raises(RuntimeError, match="unreachable"):
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+
+def test_ssh_provision_server_script_failed():
+    """provision_server raises RuntimeError when provision script fails with sudo error."""
+    from unittest.mock import MagicMock, patch, mock_open
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    def mock_open_side_effect(filename, *args, **kwargs):
+        if filename == "/app/provision-host.sh":
+            return mock_open(read_data=b"#!/bin/sh\necho provisioned")()
+        elif filename.endswith(".pub"):
+            return mock_open(read_data="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...")()
+        return mock_open()()
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", side_effect=mock_open_side_effect), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        mock_stdin = MagicMock()
+        mock_stdout = MagicMock()
+        mock_stderr = MagicMock()
+        mock_stdout.channel.recv_exit_status.return_value = 1
+        mock_stderr.read.return_value = b"sudo: incorrect password for user"
+        mock_client.exec_command.return_value = (mock_stdin, mock_stdout, mock_stderr)
+
+        mock_sftp = MagicMock()
+        mock_client.open_sftp.return_value = mock_sftp
+
+        with pytest.raises(RuntimeError, match="sudo privileges"):
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+
+
+def test_ssh_provision_server_uses_reject_policy():
+    """provision_server must use RejectPolicy."""
+    from unittest.mock import MagicMock, patch, mock_open
+
+    mock_sp_result = MagicMock()
+    mock_sp_result.stdout = "ssh-ed25519 AAAA...\n"
+
+    with patch("subprocess.run", return_value=mock_sp_result), \
+         patch("builtins.open", mock_open(read_data=b"#!/bin/sh\necho provisioned")), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy") as mock_policy:
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        mock_client.connect.side_effect = Exception("stop early")
+
+        try:
+            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+        except Exception:
+            pass
+
+        mock_client.set_missing_host_key_policy.assert_called_once_with(mock_policy.return_value)

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -325,7 +325,7 @@ def test_web_update_server_authenticated_returns_200(auth_client):
         )
         assert resp.status_code == 200
         mock_actions.update_server.assert_called_once_with(
-            "server-test-01", "10.0.0.2", "production", "debian", ADMIN_ID
+            "server-test-01", "10.0.0.2", "production", "debian", 22, ADMIN_ID
         )
 
 
@@ -386,6 +386,107 @@ def test_web_delete_server_returns_404_if_not_found(auth_client):
         mock_actions.delete_server.side_effect = ValueError("not found")
         resp = auth_client.delete("/api/servers/ghost")
         assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/servers/<hostname>/provision
+# ---------------------------------------------------------------------------
+
+def test_web_provision_server_success(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 22},
+        )
+        assert resp.status_code == 200
+        assert resp.json["message"] == "Server provisioned successfully"
+        mock_actions.provision_server.assert_called_once_with(
+            "server-test-01", "root", "secret", 22, ADMIN_ID
+        )
+
+
+def test_web_provision_server_missing_password(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root"},
+        )
+        assert resp.status_code == 400
+        assert "ssh_password is required" in resp.json["error"]
+
+
+def test_web_provision_server_invalid_port(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 99999},
+        )
+        assert resp.status_code == 400
+        assert "ssh_port must be between 1 and 65535" in resp.json["error"]
+
+
+def test_web_provision_server_not_found(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.provision_server.side_effect = ValueError("Server not found")
+        resp = auth_client.post(
+            "/api/servers/ghost/provision",
+            json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 22},
+        )
+        assert resp.status_code == 404
+
+
+def test_web_provision_server_ssh_error(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.provision_server.side_effect = RuntimeError("Connection failed")
+        resp = auth_client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 22},
+        )
+        assert resp.status_code == 422
+
+
+def test_web_provision_server_viewer_forbidden(client):
+    """Viewers cannot provision servers."""
+    viewer_id = str(uuid.uuid4())
+    with client.session_transaction() as sess:
+        sess["admin_id"] = viewer_id
+        sess["admin_username"] = "viewer"
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": viewer_id, "username": "viewer", "role": "viewer"}
+        resp = client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 22},
+        )
+        assert resp.status_code == 403
+
+
+def test_web_provision_server_password_not_logged(auth_client):
+    """Password must never appear in audit_log or exceptions."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        secret_password = "SuperSecret123!"
+
+        # Capture all db.execute calls via actions.provision_server
+        def check_no_password(*args, **kwargs):
+            sql = args[0] if args else ""
+            params = args[1] if len(args) > 1 else ()
+            for param in params:
+                if isinstance(param, str) and secret_password in param:
+                    raise AssertionError(f"Password found in audit_log: {param}")
+
+        mock_actions.provision_server.side_effect = check_no_password
+
+        resp = auth_client.post(
+            "/api/servers/server-test-01/provision",
+            json={"ssh_user": "root", "ssh_password": secret_password, "ssh_port": 22},
+        )
+        # The mock will raise if password is logged
+        assert resp.status_code == 200
 
 
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -253,12 +253,36 @@ def add_server():
     try:
         server = actions.add_server(
             data["hostname"], data["ip"], data["environment"],
-            data.get("os_family"), g.admin_id,
+            data.get("os_family"), data.get("ssh_port", 22), g.admin_id,
         )
         return jsonify(server), 201
     except (KeyError, ValueError) as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
+
+
+@app.route("/api/servers/<hostname>/provision", methods=["POST"])
+@require_auth
+@require_role("sysadmin", "operator")
+def provision_server_route(hostname):
+    data = request.get_json(force=True) or {}
+    ssh_user = data.get("ssh_user", "root") or "root"
+    ssh_password = data.get("ssh_password", "")
+    try:
+        ssh_port = int(data.get("ssh_port", 22))
+    except (TypeError, ValueError):
+        return jsonify({"error": "ssh_port must be an integer"}), 400
+    if not ssh_password:
+        return jsonify({"error": "ssh_password is required"}), 400
+    if not (1 <= ssh_port <= 65535):
+        return jsonify({"error": "ssh_port must be between 1 and 65535"}), 400
+    try:
+        actions.provision_server(hostname, ssh_user, ssh_password, ssh_port, g.admin_id)
+        return jsonify({"message": "Server provisioned successfully"})
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 422
 
 
 @app.route("/api/servers/<hostname>", methods=["PUT"])
@@ -269,7 +293,7 @@ def update_server(hostname):
     try:
         actions.update_server(
             hostname, data["ip"], data["environment"],
-            data.get("os_family"), g.admin_id,
+            data.get("os_family"), data.get("ssh_port", 22), g.admin_id,
         )
         return jsonify({"message": "Server updated"})
     except (KeyError, ValueError) as e:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -201,6 +201,12 @@ else
     generate_nginx_conf
     generate_msmtprc
     generate_crontab
+
+    # Idempotent schema migration: add ssh_port column if missing
+    su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' start -w"
+    su -s /bin/sh postgres -c "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} \
+        -c \"ALTER TABLE servers ADD COLUMN IF NOT EXISTS ssh_port INTEGER NOT NULL DEFAULT 22;\""
+    su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' stop -w"
 fi
 
 # ---------------------------------------------------------------------------

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -202,10 +202,30 @@ else
     generate_msmtprc
     generate_crontab
 
-    # Idempotent schema migration: add ssh_port column if missing
+    # Idempotent schema migrations
     su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' start -w"
     su -s /bin/sh postgres -c "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} \
         -c \"ALTER TABLE servers ADD COLUMN IF NOT EXISTS ssh_port INTEGER NOT NULL DEFAULT 22;\""
+    # Add SERVER_PROVISIONED to audit_log action check constraint if missing
+    su -s /bin/sh postgres -c "psql -h /tmp -U ${POSTGRES_USER:-ssh_manager} -d ${POSTGRES_DB:-ssh_manager} -c \
+        \"DO \\\$\\\$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'audit_log_action_check_v2'
+            ) THEN
+                ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check;
+                ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v2 CHECK (action IN (
+                    'KEY_ADDED','KEY_REVOKED','KEY_EXPIRED','EXPIRY_WARNING',
+                    'REQUEST_APPROVED','REQUEST_REJECTED','ANOMALY_DETECTED',
+                    'SCAN_COMPLETED','SCAN_FAILED','SCRIPT_DEPLOYED',
+                    'SERVER_ADDED','SERVER_DISABLED','SERVER_UPDATED',
+                    'ADMIN_ADDED','ADMIN_DISABLED','ADMIN_ENABLED','ADMIN_DELETED','ADMIN_UPDATED',
+                    'USER_LOCKED','USER_UNLOCKED',
+                    'LOGIN_FAILED','LOGIN_BANNED','PASSWORD_RESET',
+                    'SERVER_PROVISIONED'
+                ));
+            END IF;
+        END \\\$\\\$;\""
     su -s /bin/sh postgres -c "pg_ctl -D /data/pg -o '-k /tmp' stop -w"
 fi
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -267,7 +267,8 @@ CREATE TABLE audit_log (
                       'USER_UNLOCKED',      -- compte Unix déverrouillé
                       'LOGIN_FAILED',       -- tentative de connexion échouée (mauvais mot de passe)
                       'LOGIN_BANNED',       -- IP bannie après trop de tentatives échouées
-                      'PASSWORD_RESET'      -- réinitialisation de mot de passe via CLI
+                      'PASSWORD_RESET',     -- réinitialisation de mot de passe via CLI
+                      'SERVER_PROVISIONED'  -- provisionnement automatique via SSH password
                   )),
     -- Administrateur ayant déclenché l'action (NULL si automatique)
     performed_by  UUID REFERENCES administrators(id) ON DELETE SET NULL,

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -17,6 +17,8 @@ CREATE TABLE servers (
     hostname    VARCHAR(255) NOT NULL UNIQUE,
     -- Adresse IP au format INET (supporte IPv4 et IPv6)
     ip_address  INET NOT NULL,
+    -- Port SSH du serveur (défaut 22)
+    ssh_port    INTEGER NOT NULL DEFAULT 22,
     -- Famille d'OS : rhel, debian, alpine, etc.
     os_family   VARCHAR(50),
     -- Version précise de l'OS (ex: "RHEL 9.3", "Debian 12")
@@ -37,6 +39,7 @@ COMMENT ON TABLE servers IS 'Inventaire des serveurs SSH surveillés, alimenté 
 COMMENT ON COLUMN servers.id IS 'UUID généré automatiquement';
 COMMENT ON COLUMN servers.hostname IS 'Nom d''hôte unique, clé de réconciliation avec servers.yml';
 COMMENT ON COLUMN servers.ip_address IS 'Adresse IP (INET, supporte IPv4 et IPv6)';
+COMMENT ON COLUMN servers.ssh_port IS 'Port SSH du serveur (défaut 22)';
 COMMENT ON COLUMN servers.os_family IS 'Famille d''OS : rhel, debian, alpine...';
 COMMENT ON COLUMN servers.os_version IS 'Version précise de l''OS';
 COMMENT ON COLUMN servers.environment IS 'Environnement : production, staging ou lab';

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -58,7 +58,16 @@
     "success_msg": "✅ {hostname} wurde hinzugefügt.",
     "deploy_hint": "Stellen Sie jetzt den Collector-Schlüssel auf diesem Server in `/home/{sshUser}/.ssh/authorized_keys` bereit:",
     "deploy_hint2": "Oder führen Sie `provision-host.sh` mit diesem Schlüssel aus.",
-    "close": "Schließen"
+    "close": "Schließen",
+    "provision_title": "Automatische Bereitstellung (optional)",
+    "provision_hint": "Falls angegeben, wird der Collector-Schlüssel automatisch via SSH bereitgestellt.",
+    "ssh_user_label": "SSH-Benutzer",
+    "ssh_port_label": "SSH-Port",
+    "ssh_password_label": "SSH-Passwort",
+    "ssh_password_placeholder": "Leer lassen für manuelle Bereitstellung",
+    "provision_connecting": "Verbindung zum Server…",
+    "provision_success": "✅ Server bereitgestellt — Collector-Schlüssel automatisch deployed.",
+    "provision_error": "Bereitstellung fehlgeschlagen: {error}"
   },
   "edit_server": {
     "title": "Server bearbeiten",
@@ -69,6 +78,7 @@
     "env_placeholder": "— Wählen —",
     "os_family": "OS-Familie",
     "os_placeholder": "z.B.: rhel, debian (optional)",
+    "ssh_port_label": "SSH-Port",
     "submitting": "Speichern…",
     "submit": "Speichern"
   },
@@ -96,6 +106,7 @@
     "section_info": "Informationen",
     "field_hostname": "Hostname",
     "field_ip": "IP",
+    "field_ssh_port": "SSH-Port",
     "field_environment": "Umgebung",
     "field_os": "OS",
     "field_active": "Aktiv",

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -65,6 +65,7 @@
     "ssh_port_label": "SSH-Port",
     "ssh_password_label": "SSH-Passwort",
     "ssh_password_placeholder": "Leer lassen für manuelle Bereitstellung",
+    "ssh_password_disclaimer": "Das SSH-Passwort wird nur für diesen Bereitstellungsschritt verwendet und niemals gespeichert.",
     "provision_connecting": "Verbindung zum Server…",
     "provision_success": "✅ Server bereitgestellt — Collector-Schlüssel automatisch deployed.",
     "provision_error": "Bereitstellung fehlgeschlagen: {error}"

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -58,7 +58,16 @@
     "success_msg": "✅ {hostname} has been added.",
     "deploy_hint": "Now deploy the collector key on this server in `/home/{sshUser}/.ssh/authorized_keys`:",
     "deploy_hint2": "Or run `provision-host.sh` with this key.",
-    "close": "Close"
+    "close": "Close",
+    "provision_title": "Automatic provisioning (optional)",
+    "provision_hint": "If provided, the collector key will be deployed automatically via SSH.",
+    "ssh_user_label": "SSH User",
+    "ssh_port_label": "SSH Port",
+    "ssh_password_label": "SSH Password",
+    "ssh_password_placeholder": "Leave empty to provision manually",
+    "provision_connecting": "Connecting to server…",
+    "provision_success": "✅ Server provisioned — collector key deployed automatically.",
+    "provision_error": "Provisioning failed: {error}"
   },
   "edit_server": {
     "title": "Edit server",
@@ -69,6 +78,7 @@
     "env_placeholder": "— Choose —",
     "os_family": "OS Family",
     "os_placeholder": "e.g.: rhel, debian (optional)",
+    "ssh_port_label": "SSH Port",
     "submitting": "Saving…",
     "submit": "Save"
   },
@@ -96,6 +106,7 @@
     "section_info": "Information",
     "field_hostname": "Hostname",
     "field_ip": "IP",
+    "field_ssh_port": "SSH Port",
     "field_environment": "Environment",
     "field_os": "OS",
     "field_active": "Active",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -65,6 +65,7 @@
     "ssh_port_label": "SSH Port",
     "ssh_password_label": "SSH Password",
     "ssh_password_placeholder": "Leave empty to provision manually",
+    "ssh_password_disclaimer": "The SSH password is used only for this provisioning step and is never stored.",
     "provision_connecting": "Connecting to server…",
     "provision_success": "✅ Server provisioned — collector key deployed automatically.",
     "provision_error": "Provisioning failed: {error}"

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -58,7 +58,16 @@
     "success_msg": "✅ {hostname} ha sido añadido.",
     "deploy_hint": "Despliega ahora la clave del colector en este servidor en `/home/{sshUser}/.ssh/authorized_keys`:",
     "deploy_hint2": "O ejecuta `provision-host.sh` con esta clave.",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "provision_title": "Aprovisionamiento automático (opcional)",
+    "provision_hint": "Si se proporciona, la clave del colector se desplegará automáticamente vía SSH.",
+    "ssh_user_label": "Usuario SSH",
+    "ssh_port_label": "Puerto SSH",
+    "ssh_password_label": "Contraseña SSH",
+    "ssh_password_placeholder": "Dejar vacío para aprovisionar manualmente",
+    "provision_connecting": "Conectando al servidor…",
+    "provision_success": "✅ Servidor aprovisionado — clave del colector desplegada automáticamente.",
+    "provision_error": "Error de aprovisionamiento: {error}"
   },
   "edit_server": {
     "title": "Editar servidor",
@@ -69,6 +78,7 @@
     "env_placeholder": "— Elegir —",
     "os_family": "Familia OS",
     "os_placeholder": "ej: rhel, debian (opcional)",
+    "ssh_port_label": "Puerto SSH",
     "submitting": "Guardando…",
     "submit": "Guardar"
   },
@@ -96,6 +106,7 @@
     "section_info": "Información",
     "field_hostname": "Hostname",
     "field_ip": "IP",
+    "field_ssh_port": "Puerto SSH",
     "field_environment": "Entorno",
     "field_os": "OS",
     "field_active": "Activo",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -65,6 +65,7 @@
     "ssh_port_label": "Puerto SSH",
     "ssh_password_label": "Contraseña SSH",
     "ssh_password_placeholder": "Dejar vacío para aprovisionar manualmente",
+    "ssh_password_disclaimer": "La contraseña SSH se usa únicamente para este paso de aprovisionamiento y nunca se almacena.",
     "provision_connecting": "Conectando al servidor…",
     "provision_success": "✅ Servidor aprovisionado — clave del colector desplegada automáticamente.",
     "provision_error": "Error de aprovisionamiento: {error}"

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -58,7 +58,16 @@
     "success_msg": "✅ {hostname} a été ajouté.",
     "deploy_hint": "Déployez maintenant la clé collecteur sur ce serveur dans `/home/{sshUser}/.ssh/authorized_keys` :",
     "deploy_hint2": "Ou relancez `provision-host.sh` avec cette clé.",
-    "close": "Fermer"
+    "close": "Fermer",
+    "provision_title": "Provisionnement automatique (optionnel)",
+    "provision_hint": "Si renseigné, la clé collecteur sera déployée automatiquement via SSH.",
+    "ssh_user_label": "Utilisateur SSH",
+    "ssh_port_label": "Port SSH",
+    "ssh_password_label": "Mot de passe SSH",
+    "ssh_password_placeholder": "Laisser vide pour provisionner manuellement",
+    "provision_connecting": "Connexion au serveur…",
+    "provision_success": "✅ Serveur provisionné — clé collecteur déployée automatiquement.",
+    "provision_error": "Provisionnement échoué : {error}"
   },
   "edit_server": {
     "title": "Éditer le serveur",
@@ -69,6 +78,7 @@
     "env_placeholder": "— Choisir —",
     "os_family": "OS Family",
     "os_placeholder": "ex: rhel, debian (optionnel)",
+    "ssh_port_label": "Port SSH",
     "submitting": "Sauvegarde…",
     "submit": "Sauvegarder"
   },
@@ -96,6 +106,7 @@
     "section_info": "Informations",
     "field_hostname": "Hostname",
     "field_ip": "IP",
+    "field_ssh_port": "Port SSH",
     "field_environment": "Environnement",
     "field_os": "OS",
     "field_active": "Actif",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -65,6 +65,7 @@
     "ssh_port_label": "Port SSH",
     "ssh_password_label": "Mot de passe SSH",
     "ssh_password_placeholder": "Laisser vide pour provisionner manuellement",
+    "ssh_password_disclaimer": "Le mot de passe SSH est utilisé uniquement pour cette étape de provisionnement et n'est jamais stocké.",
     "provision_connecting": "Connexion au serveur…",
     "provision_success": "✅ Serveur provisionné — clé collecteur déployée automatiquement.",
     "provision_error": "Provisionnement échoué : {error}"

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -65,6 +65,7 @@
     "ssh_port_label": "Porta SSH",
     "ssh_password_label": "Password SSH",
     "ssh_password_placeholder": "Lasciare vuoto per provisioning manuale",
+    "ssh_password_disclaimer": "La password SSH viene utilizzata solo per questa fase di provisioning e non viene mai memorizzata.",
     "provision_connecting": "Connessione al server…",
     "provision_success": "✅ Server provisionato — chiave collector distribuita automaticamente.",
     "provision_error": "Provisioning fallito: {error}"

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -58,7 +58,16 @@
     "success_msg": "✅ {hostname} è stato aggiunto.",
     "deploy_hint": "Distribuisci ora la chiave collector su questo server in `/home/{sshUser}/.ssh/authorized_keys`:",
     "deploy_hint2": "Oppure esegui `provision-host.sh` con questa chiave.",
-    "close": "Chiudi"
+    "close": "Chiudi",
+    "provision_title": "Provisioning automatico (opzionale)",
+    "provision_hint": "Se fornita, la chiave collector verrà distribuita automaticamente via SSH.",
+    "ssh_user_label": "Utente SSH",
+    "ssh_port_label": "Porta SSH",
+    "ssh_password_label": "Password SSH",
+    "ssh_password_placeholder": "Lasciare vuoto per provisioning manuale",
+    "provision_connecting": "Connessione al server…",
+    "provision_success": "✅ Server provisionato — chiave collector distribuita automaticamente.",
+    "provision_error": "Provisioning fallito: {error}"
   },
   "edit_server": {
     "title": "Modifica server",
@@ -69,6 +78,7 @@
     "env_placeholder": "— Scegliere —",
     "os_family": "Famiglia OS",
     "os_placeholder": "es: rhel, debian (opzionale)",
+    "ssh_port_label": "Porta SSH",
     "submitting": "Salvataggio…",
     "submit": "Salva"
   },
@@ -96,6 +106,7 @@
     "section_info": "Informazioni",
     "field_hostname": "Hostname",
     "field_ip": "IP",
+    "field_ssh_port": "Porta SSH",
     "field_environment": "Ambiente",
     "field_os": "OS",
     "field_active": "Attivo",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -118,6 +118,7 @@
               type="password"
               :placeholder="$t('add_server.ssh_password_placeholder')"
             />
+            <p class="password-disclaimer">🔒 {{ $t('add_server.ssh_password_disclaimer') }}</p>
           </div>
 
           <div class="modal-actions">
@@ -735,6 +736,11 @@ h1 {
   margin: 0 0 0.75rem 0;
   font-size: 0.8rem;
   color: #666;
+}
+.password-disclaimer {
+  margin-top: 0.4rem;
+  font-size: 0.78rem;
+  color: #555;
 }
 
 .provision-status {

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -103,6 +103,23 @@
             :placeholder="$t('add_server.os_placeholder')"
           />
 
+          <label>{{ $t('add_server.ssh_port_label') }}</label>
+          <input v-model.number="addForm.sshPort" type="number" min="1" max="65535" placeholder="22" />
+
+          <div class="provision-section">
+            <h4>{{ $t('add_server.provision_title') }}</h4>
+            <p class="hint">{{ $t('add_server.provision_hint') }}</p>
+            <label>{{ $t('add_server.ssh_user_label') }}</label>
+            <input v-model="addForm.sshUser" type="text" placeholder="root" />
+
+            <label>{{ $t('add_server.ssh_password_label') }}</label>
+            <input
+              v-model="addForm.sshPassword"
+              type="password"
+              :placeholder="$t('add_server.ssh_password_placeholder')"
+            />
+          </div>
+
           <div class="modal-actions">
             <button class="btn-secondary" @click="closeAddServer">{{ $t('common.cancel') }}</button>
             <button
@@ -115,7 +132,7 @@
           </div>
         </template>
 
-        <!-- Step 2: success + key display -->
+        <!-- Step 2: success + provisioning or manual key display -->
         <template v-else>
           <div class="modal-header">
             <h3>{{ $t('add_server.success_title') }}</h3>
@@ -124,14 +141,33 @@
           <p class="success-msg">
             {{ $t('add_server.success_msg', { hostname: addForm.hostname }) }}
           </p>
-          <p class="deploy-hint">{{ $t('add_server.deploy_hint', { sshUser }) }}</p>
-          <div class="key-display">
-            <code>{{ collectorKey || $t('common.loading') }}</code>
-            <button class="btn-copy" @click="copyKey(collectorKey, 'modal')">
-              {{ copied === 'modal' ? $t('dashboard.copied') : $t('dashboard.copy') }}
-            </button>
+
+          <!-- Automatic provisioning status -->
+          <div v-if="provisionStatus !== null">
+            <div v-if="provisionStatus === 'connecting'" class="provision-status">
+              <div class="spinner"></div>
+              <span>{{ $t('add_server.provision_connecting') }}</span>
+            </div>
+            <div v-else-if="provisionStatus === 'success'" class="provision-status success">
+              <span>{{ $t('add_server.provision_success') }}</span>
+            </div>
+            <div v-else-if="provisionStatus === 'error'" class="provision-status error">
+              <span>{{ $t('add_server.provision_error', { error: provisionError }) }}</span>
+            </div>
           </div>
-          <p class="deploy-hint small">{{ $t('add_server.deploy_hint2') }}</p>
+
+          <!-- Manual provisioning (when no password provided) -->
+          <template v-else>
+            <p class="deploy-hint">{{ $t('add_server.deploy_hint', { sshUser }) }}</p>
+            <div class="key-display">
+              <code>{{ collectorKey || $t('common.loading') }}</code>
+              <button class="btn-copy" @click="copyKey(collectorKey, 'modal')">
+                {{ copied === 'modal' ? $t('dashboard.copied') : $t('dashboard.copy') }}
+              </button>
+            </div>
+            <p class="deploy-hint small">{{ $t('add_server.deploy_hint2') }}</p>
+          </template>
+
           <div class="modal-actions">
             <button class="btn-primary" @click="closeAddServer">
               {{ $t('add_server.close') }}
@@ -178,6 +214,9 @@
           :placeholder="$t('edit_server.os_placeholder')"
         />
 
+        <label>{{ $t('edit_server.ssh_port_label') }}</label>
+        <input v-model.number="editForm.ssh_port" type="number" min="1" max="65535" placeholder="22" />
+
         <div class="modal-actions">
           <button class="btn-secondary" @click="closeEditServer">{{ $t('common.cancel') }}</button>
           <button
@@ -216,12 +255,22 @@ const showAddServer = ref(false)
 const adding = ref(false)
 const addError = ref('')
 const addSuccess = ref(false)
-const addForm = ref({ hostname: '', ip: '', environment: '', os_family: '' })
+const addForm = ref({
+  hostname: '',
+  ip: '',
+  environment: '',
+  os_family: '',
+  sshUser: 'root',
+  sshPort: 22,
+  sshPassword: '',
+})
+const provisionStatus = ref(null)
+const provisionError = ref('')
 
 const showEditServer = ref(false)
 const editing = ref(false)
 const editError = ref('')
-const editForm = ref({ hostname: '', ip: '', environment: '', os_family: '' })
+const editForm = ref({ hostname: '', ip: '', environment: '', os_family: '', ssh_port: 22 })
 
 const counts = computed(() => ({
   ok: servers.value.filter((s) => s.is_active && !s.has_anomalies).length,
@@ -298,9 +347,19 @@ async function copyKey(key, context) {
 }
 
 function openAddServer() {
-  addForm.value = { hostname: '', ip: '', environment: '', os_family: '' }
+  addForm.value = {
+    hostname: '',
+    ip: '',
+    environment: '',
+    os_family: '',
+    sshUser: 'root',
+    sshPort: 22,
+    sshPassword: '',
+  }
   addError.value = ''
   addSuccess.value = false
+  provisionStatus.value = null
+  provisionError.value = ''
   showAddServer.value = true
 }
 
@@ -320,12 +379,39 @@ async function confirmAddServer() {
         ip: addForm.value.ip.trim(),
         environment: addForm.value.environment,
         os_family: addForm.value.os_family.trim() || null,
+        ssh_port: addForm.value.sshPort || 22,
       }),
     })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
     addSuccess.value = true
     await loadServers()
+
+    // Automatic provisioning if password is provided
+    if (addForm.value.sshPassword.trim()) {
+      provisionStatus.value = 'connecting'
+      try {
+        const provRes = await fetch(`/api/servers/${addForm.value.hostname.trim()}/provision`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ssh_user: addForm.value.sshUser || 'root',
+            ssh_port: addForm.value.sshPort || 22,
+            ssh_password: addForm.value.sshPassword,
+          }),
+        })
+        if (provRes.ok) {
+          provisionStatus.value = 'success'
+        } else {
+          const errData = await provRes.json().catch(() => ({}))
+          provisionStatus.value = 'error'
+          provisionError.value = errData.error || `HTTP ${provRes.status}`
+        }
+      } catch (e) {
+        provisionStatus.value = 'error'
+        provisionError.value = e.message
+      }
+    }
   } catch (e) {
     addError.value = e.message
   } finally {
@@ -379,6 +465,7 @@ function openEditServer(server) {
     ip: server.ip_address,
     environment: server.environment,
     os_family: server.os_family || '',
+    ssh_port: server.ssh_port || 22,
   }
   editError.value = ''
   showEditServer.value = true
@@ -399,6 +486,7 @@ async function confirmEditServer() {
         ip: editForm.value.ip.trim(),
         environment: editForm.value.environment,
         os_family: editForm.value.os_family.trim() || null,
+        ssh_port: editForm.value.ssh_port || 22,
       }),
     })
     const data = await res.json().catch(() => ({}))
@@ -575,6 +663,8 @@ h1 {
 }
 
 .modal input[type='text'],
+.modal input[type='number'],
+.modal input[type='password'],
 .modal select {
   width: 100%;
   padding: 0.4rem 0.6rem;
@@ -627,5 +717,61 @@ h1 {
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+
+.provision-section {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.provision-section h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.provision-section .hint {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.8rem;
+  color: #666;
+}
+
+.provision-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin: 1rem 0;
+  background: #f8f9fa;
+  border: 1px solid #dee2e6;
+}
+
+.provision-status.success {
+  background: #d4edda;
+  border-color: #c3e6cb;
+  color: #155724;
+}
+
+.provision-status.error {
+  background: #f8d7da;
+  border-color: #f5c6cb;
+  color: #721c24;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #ccc;
+  border-top-color: #0d6efd;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -104,7 +104,13 @@
           />
 
           <label>{{ $t('add_server.ssh_port_label') }}</label>
-          <input v-model.number="addForm.sshPort" type="number" min="1" max="65535" placeholder="22" />
+          <input
+            v-model.number="addForm.sshPort"
+            type="number"
+            min="1"
+            max="65535"
+            placeholder="22"
+          />
 
           <div class="provision-section">
             <h4>{{ $t('add_server.provision_title') }}</h4>
@@ -216,7 +222,13 @@
         />
 
         <label>{{ $t('edit_server.ssh_port_label') }}</label>
-        <input v-model.number="editForm.ssh_port" type="number" min="1" max="65535" placeholder="22" />
+        <input
+          v-model.number="editForm.ssh_port"
+          type="number"
+          min="1"
+          max="65535"
+          placeholder="22"
+        />
 
         <div class="modal-actions">
           <button class="btn-secondary" @click="closeEditServer">{{ $t('common.cancel') }}</button>

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -58,6 +58,8 @@
           <dd>{{ server.hostname }}</dd>
           <dt>{{ $t('server_detail.field_ip') }}</dt>
           <dd>{{ server.ip_address }}</dd>
+          <dt>{{ $t('server_detail.field_ssh_port') }}</dt>
+          <dd>{{ server.ssh_port || 22 }}</dd>
           <dt>{{ $t('server_detail.field_environment') }}</dt>
           <dd>
             <span class="badge" :class="envBadge(server.environment)">{{

--- a/ui/tests/Dashboard.spec.js
+++ b/ui/tests/Dashboard.spec.js
@@ -1,0 +1,516 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import en from '../src/locales/en.json'
+import Dashboard from '../src/views/Dashboard.vue'
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+const MOCK_SERVERS = [
+  {
+    hostname: 'server-01',
+    ip_address: '192.168.1.10',
+    environment: 'production',
+    os_family: 'rhel',
+    is_active: true,
+    has_anomalies: false,
+  },
+]
+
+const COLLECTOR_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICollectorKeyTest audit-collector'
+
+function createMockRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: Dashboard }],
+  })
+}
+
+function mockAuth() {
+  vi.mock('../src/composables/useAuth.js', () => ({
+    useAuth: () => ({
+      admin: { value: { username: 'admin', role: 'sysadmin' } },
+      logout: vi.fn(),
+    }),
+  }))
+}
+
+beforeEach(() => {
+  mockAuth()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url) => {
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('Dashboard - Add Server Modal', () => {
+  it('affiche le champ SSH Port dans les champs principaux', async () => {
+    const router = createMockRouter()
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    const addBtn = w.find('button.btn-secondary')
+    await addBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que le champ SSH Port est présent (dans les champs principaux, pas provisionnement)
+    const sshPortInput = w.find('input[type="number"][placeholder="22"]')
+    expect(sshPortInput.exists()).toBe(true)
+
+    // Vérifier que les champs de provisionnement existent toujours (user et password)
+    const sshUserInput = w.find('input[placeholder="root"]')
+    const sshPasswordInput = w.find('input[type="password"]')
+    expect(sshUserInput.exists()).toBe(true)
+    expect(sshPasswordInput.exists()).toBe(true)
+  })
+
+  it('envoie ssh_port dans le POST /api/servers (même sans provisionnement)', async () => {
+    const router = createMockRouter()
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire sans mot de passe SSH mais avec un port custom
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: 2222,
+      sshPassword: '',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtn = w.findAll('button.btn-primary').find((b) => b.text().includes('Add'))
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que ssh_port est dans le body du POST /api/servers
+    const createCall = fetchSpy.mock.calls.find(
+      (call) => call[0] === '/api/servers' && call[1]?.method === 'POST'
+    )
+    expect(createCall).toBeDefined()
+    const body = JSON.parse(createCall[1].body)
+    expect(body.ssh_port).toBe(2222)
+
+    // Vérifier qu'aucun appel à provision n'a été fait (pas de mot de passe)
+    const provisionCalls = fetchSpy.mock.calls.filter((call) => call[0].includes('/provision'))
+    expect(provisionCalls.length).toBe(0)
+  })
+
+  it('envoie ssh_port=22 par défaut si le champ est vide', async () => {
+    const router = createMockRouter()
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire avec sshPort vide (ou 0)
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: '',
+      sshPassword: '',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtn = w.findAll('button.btn-primary').find((b) => b.text().includes('Add'))
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que ssh_port=22 par défaut
+    const createCall = fetchSpy.mock.calls.find(
+      (call) => call[0] === '/api/servers' && call[1]?.method === 'POST'
+    )
+    expect(createCall).toBeDefined()
+    const body = JSON.parse(createCall[1].body)
+    expect(body.ssh_port).toBe(22)
+  })
+
+  it('appelle provision si le mot de passe est renseigné', async () => {
+    const router = createMockRouter()
+    const newServerList = [
+      ...MOCK_SERVERS,
+      {
+        hostname: 'test-server',
+        ip_address: '192.168.1.50',
+        environment: 'production',
+        os_family: '',
+        is_active: true,
+        has_anomalies: false,
+      },
+    ]
+    let serverCreated = false
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        serverCreated = true
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(serverCreated ? newServerList : MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      if (url.includes('/provision')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ message: 'Server provisioned successfully' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire avec mot de passe SSH via setData
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: 22,
+      sshPassword: 'mysecretpassword',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtns = w.findAll('button.btn-primary')
+    const submitBtn = submitBtns.find((b) => b.text() === 'Add')
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier qu'un appel à provision a été fait avec les bons params
+    const provisionCall = fetchSpy.mock.calls.find((call) => call[0].includes('/provision'))
+    expect(provisionCall).toBeDefined()
+    expect(provisionCall[0]).toBe('/api/servers/test-server/provision')
+    const body = JSON.parse(provisionCall[1].body)
+    expect(body).toEqual({
+      ssh_user: 'root',
+      ssh_port: 22,
+      ssh_password: 'mysecretpassword',
+    })
+  })
+
+  it('affiche "Connecting to server…" pendant le provisionnement', async () => {
+    const router = createMockRouter()
+    const newServerList = [
+      ...MOCK_SERVERS,
+      {
+        hostname: 'test-server',
+        ip_address: '192.168.1.50',
+        environment: 'production',
+        os_family: '',
+        is_active: true,
+        has_anomalies: false,
+      },
+    ]
+    let serverCreated = false
+    let resolveProvision
+    const provisionPromise = new Promise((resolve) => {
+      resolveProvision = resolve
+    })
+
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        serverCreated = true
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(serverCreated ? newServerList : MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      if (url.includes('/provision')) {
+        return provisionPromise
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire via setData
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: 22,
+      sshPassword: 'mysecretpassword',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtn = w.findAll('button.btn-primary').find((b) => b.text().includes('Add'))
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que le message "Connecting…" est affiché
+    expect(w.html()).toContain('Connecting to server')
+
+    // Résoudre le provisionnement
+    resolveProvision({
+      ok: true,
+      json: () => Promise.resolve({ message: 'Server provisioned successfully' }),
+    })
+    await flushPromises()
+  })
+
+  it('affiche le message de succès si le provisionnement réussit', async () => {
+    const router = createMockRouter()
+    const newServerList = [
+      ...MOCK_SERVERS,
+      {
+        hostname: 'test-server',
+        ip_address: '192.168.1.50',
+        environment: 'production',
+        os_family: '',
+        is_active: true,
+        has_anomalies: false,
+      },
+    ]
+    let serverCreated = false
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        serverCreated = true
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(serverCreated ? newServerList : MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      if (url.includes('/provision')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ message: 'Server provisioned successfully' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire via setData
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: 22,
+      sshPassword: 'mysecretpassword',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtn = w.findAll('button.btn-primary').find((b) => b.text().includes('Add'))
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que le message de succès est affiché
+    expect(w.html()).toContain('Server provisioned')
+  })
+
+  it('affiche le message d\'erreur si le provisionnement échoue', async () => {
+    const router = createMockRouter()
+    const newServerList = [
+      ...MOCK_SERVERS,
+      {
+        hostname: 'test-server',
+        ip_address: '192.168.1.50',
+        environment: 'production',
+        os_family: '',
+        is_active: true,
+        has_anomalies: false,
+      },
+    ]
+    let serverCreated = false
+    const fetchSpy = vi.fn((url, options) => {
+      if (url === '/api/servers' && options?.method === 'POST') {
+        serverCreated = true
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ hostname: 'test-server' }),
+        })
+      }
+      if (url === '/api/servers') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(serverCreated ? newServerList : MOCK_SERVERS),
+        })
+      }
+      if (url === '/api/system/collector-key') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
+        })
+      }
+      if (url.includes('/provision')) {
+        return Promise.resolve({
+          ok: false,
+          status: 422,
+          json: () =>
+            Promise.resolve({ error: 'Authentication failed — check your username and password' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+
+    // Ouvrir le modal
+    await w.find('button.btn-secondary').trigger('click')
+    await flushPromises()
+
+    // Remplir le formulaire via setData
+    w.vm.addForm = {
+      hostname: 'test-server',
+      ip: '192.168.1.50',
+      environment: 'production',
+      os_family: '',
+      sshUser: 'root',
+      sshPort: 22,
+      sshPassword: 'wrongpassword',
+    }
+    await w.vm.$nextTick()
+
+    // Soumettre
+    const submitBtn = w.findAll('button.btn-primary').find((b) => b.text().includes('Add'))
+    await submitBtn.trigger('click')
+    await flushPromises()
+
+    // Vérifier que le message d'erreur est affiché
+    expect(w.html()).toContain('Provisioning failed')
+    expect(w.html()).toContain('Authentication failed')
+  })
+})


### PR DESCRIPTION
## Summary

- Add optional SSH credentials (user, port, password) to "Add Server" modal
- If password provided, backend automatically runs `provision-host.sh` on the remote server via SFTP + `sudo -S`
- SSH Port is a **permanent server property** stored in DB (`ssh_port INTEGER NOT NULL DEFAULT 22`)
- All collector connections (`ensure_scripts`, `collect_keys`, `revoke_on_server`, etc.) now use the stored port
- User-friendly error messages replace raw SSH errors

## Error mapping

| Technical error | UI message |
|---|---|
| No route to host | "Server unreachable — check the IP and network connectivity" |
| Connection refused | "SSH port N refused — check that SSH is running on that port" |
| Timeout | "Connection timed out — server did not respond within 15 seconds" |
| Auth failed | "Authentication failed — check your username and password" |
| Sudo failed | "Provisioning failed — check that the user has sudo privileges" |

## Changes

- `sql/schema.sql` — `ssh_port INTEGER NOT NULL DEFAULT 22` on `servers`
- `bootstrap.sh` — idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` on normal startup
- `app/ssh.py` — `_connect(ip, port=22)`, `provision_server()`, all SSH functions updated
- `app/actions.py` — `add_server()`, `update_server()`, `provision_server()` with ssh_port
- `app/collect.py`, `expire.py`, `servers.py` — ssh_port wired through
- `app/web.py` — `POST /api/servers`, `PUT`, new `POST /api/servers/<hostname>/provision`
- `ui/src/views/Dashboard.vue` — SSH Port in main form, provisioning section (user + password)
- `ui/src/views/ServerDetail.vue` — displays SSH Port
- 5 locales (EN/FR/ES/IT/DE) updated

## Test plan

- [ ] pytest 463 passed
- [ ] vitest 261 passed
- [ ] Add server with SSH Port 2222 + password → collector scans on port 2222
- [ ] Provisioning failure shows readable error (wrong password, unreachable host)
- [ ] Server with default port 22 — existing behavior unchanged

Closes #299