### PR TITLE
docs: update README, DESIGN and CLAUDE.md for provision-first onboarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Projet "ssh-access-manager" — audit et gestion des accès SSH dans un containe
 VAE RNCP41330 "Expert en développement logiciel" Niveau 7 — C.1.6.
 Développeur : Stéphane de Labrusse.
 
-## État du projet — toutes issues fermées (53/53)
+## État du projet — toutes issues fermées (57/57)
 
-Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260) ✅
+Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303) ✅
 
 ## Stack vérifiée et figée
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1142,13 +1142,15 @@ coûteuse en temps).
 
 | Module | Tests | Couverture |
 |---|---|---|
-| `actions.py` | 62+ | ≥ 80 % (imposé CI) |
-| `test_ssh.py` | 15 | RejectPolicy, ensure_scripts (5 scripts), revoke, lock/unlock, SAM bytes |
-| `test_web.py` | 50+ | Toutes les routes critiques, auth 401/200, lock/unlock routes |
-| `test_manage.py` | 42+ | Toutes les commandes CLI, lock/unlock |
-| `test_collect.py` | 15 | 4 scénarios détection, RSA parsing |
+| `test_actions.py` | 114 | ≥ 80 % (imposé CI) — provision-first, password non stocké, scénarios révocation |
+| `test_ssh.py` | 49 | RejectPolicy, ensure_scripts (6 scripts), revoke, lock/unlock, SAM bytes |
+| `test_web.py` | 130 | Toutes les routes critiques, auth 401/200, lock/unlock, provision endpoint, error_code |
+| `test_rbac.py` | 54 | Couverture complète de la matrice RBAC (sysadmin/operator/viewer) |
+| `test_manage.py` | 38 | Toutes les commandes CLI, lock/unlock, servers add avec SSH creds |
+| `test_collect.py` | 35 | 4 scénarios détection, RSA parsing |
 | `test_expire.py` | 12 | Anti-spam 24h, expiration auto |
-| Vue.js specs | 137 | KeyActions, ExpiryPicker, KeyTable, ServerTable, UserLockForm, Anomalies, DeployedUsersTable |
+| `test_alerts.py` | 23 | Niveaux CRITICAL/WARNING/INFO, anti-spam |
+| Vue.js specs | 262 | 18 fichiers : Dashboard (provisionnement, validation hostname), ServerDetail (re-provision), KeyTable, ServerTable, Admins, SessionsCard, et tous composants |
 
 ---
 
@@ -1354,6 +1356,9 @@ permet de modifier `NGINX_PORT` ou `SMTP_HOST` sans reconstruire l'image — un
 | vue-i18n 5 langues | Accessibilité internationale | 5 fichiers JSON à synchroniser |
 | `freeze_time` tests | Déterminisme des tests d'expiration | Dépendance à `freezegun` |
 | Tag semver sans `v` | Uniformité git tag = Docker tag | Convention moins répandue |
+| Provisionnement atomique (provision-first) | Aucun serveur zombie en DB — INSERT uniquement si SSH réussit | SSH obligatoire à l'ajout (pas de déclaration purement déclarative via UI) |
+| SSH password non stocké | Sécurité : credential éphémère, jamais en base ni en audit | Pas de re-connexion automatique — re-provisionnement via bouton UI si nécessaire |
+| `error_code` API + traduction frontend | Messages d'erreur SSH dans la langue du navigateur sans hard-coder les traductions côté serveur | 7 codes à maintenir synchronisés entre backend et fichiers i18n |
 
 ---
 
@@ -1370,7 +1375,7 @@ d'ingénierie logicielle niveau 7 :
 - **Idempotence** : sync YAML, keyscan, bootstrap, déploiement de scripts.
 - **Traçabilité complète** : les 4 scénarios de révocation sont distingués par des
   colonnes dédiées et des entrées `audit_log` de types différents.
-- **Qualité mesurée** : couverture ≥ 80 % imposée par CI, 226 tests (156 Python +
-  70 Vue.js), isolation totale.
+- **Qualité mesurée** : couverture ≥ 80 % imposée par CI, 733 tests (471 Python +
+  262 Vue.js), isolation totale.
 - **Déploiement continu** : 5 workflows GitHub Actions (tests, build PR, build main,
   publication semver, nettoyage GHCR).

--- a/README.md
+++ b/README.md
@@ -138,38 +138,51 @@ Les durées sont des constantes dans `web.py` — pas de redémarrage nécessair
 
 ## Workflow — Ajout d'un serveur distant
 
-### 1. Provisionner l'hôte distant
+### Via l'interface web (recommandé — provisionnement automatique)
 
-Sur chaque serveur à auditer, depuis la machine hébergeant le container.
-`<user>` peut être `root` ou tout utilisateur avec `sudo ALL` — c'est le `sudo bash -s` qui élève les privilèges :
+Dashboard → bouton **+ Ajouter un serveur** → remplir :
 
-```bash
-ssh <user>@<ip-du-serveur> "sudo bash -s '$(podman exec sam-server cat /data/keys/collector_key.pub)'" \
-    < <(podman exec sam-server cat /app/provision-host.sh)
-```
+| Champ | Obligatoire | Description |
+|---|---|---|
+| Hostname | ✓ | Nom RFC 1123 (`server-01`, `web.prod.example.com`) |
+| Adresse IP | ✓ | IPv4 ou IPv6 — doit être unique |
+| Utilisateur SSH | ✓ | Compte avec sudo sur le serveur cible (`root` ou tout compte `sudo ALL`) |
+| Mot de passe SSH | ✓ | Utilisé **une seule fois** pour le provisionnement — jamais stocké en base |
+| Port SSH | — | Défaut : 22 |
+| Environnement | — | `production` / `staging` / `lab` — modifiable ultérieurement |
+| OS | — | Famille d'OS (`rhel`, `debian`…) — modifiable ultérieurement |
 
-Cette commande est **identique** pour un premier provisionnement ou une mise à jour (ex. après un rebuild ou un changement des règles sudoers). Le script est **idempotent** : il crée l'utilisateur `audit-collector` (réutilise s'il existe), ajoute la clé publique dans `authorized_keys` si elle est absente, et écrase `/etc/sudoers.d/audit-collector` avec les règles courantes.
+Le serveur n'est enregistré en base **que si la connexion SSH réussit**. En cas d'échec (mauvais mot de passe, port fermé, sudo manquant…), aucune donnée n'est écrite et l'erreur est affichée dans la langue du navigateur. Le script `provision-host.sh` est exécuté à distance : il crée l'utilisateur `audit-collector`, déploie la clé publique collecteur et configure les règles sudoers.
 
-### 2. Déclarer le serveur
+Le script est **idempotent** : il peut être rejoué sans risque (après rebuild, changement de clé ou de règles sudoers). Un bouton **Re-provisionner** est disponible sur la vue détail d'un serveur existant (rôle `sysadmin` uniquement).
 
-**Via l'interface web (recommandé)** : Dashboard → bouton **+ Ajouter un serveur** → remplir hostname, IP, environnement, OS. La clé publique collecteur est affichée directement après l'ajout pour faciliter le déploiement.
-
-**Via la CLI** :
+### Via la CLI
 
 ```bash
 podman exec sam-server python3 /app/app/manage.py servers add \
-  --hostname server-prod-01 --ip 192.168.1.10 --env production --os rhel
+  --hostname server-prod-01 --ip 192.168.1.10 \
+  --ssh-user root --ssh-password SECRET \
+  [--env production] [--os rhel] [--port 22]
 ```
 
-**Via `servers.yml`** (déclaratif, chargé au démarrage) :
+Le mot de passe est demandé interactivement si `--ssh-password` est absent.
+
+### Via `servers.yml` (déclaratif — provisionnement manuel requis)
 
 ```yaml
 # /data/config/servers.yml
 servers:
   - hostname: server-prod-01
     ip: 192.168.1.10
-    environment: production
-    os_family: rhel
+    environment: production   # optionnel
+    os_family: rhel           # optionnel
+```
+
+Cette méthode ajoute le serveur en base sans provisionnement SSH automatique. Il faut exécuter le script manuellement sur la cible depuis la machine hébergeant le container :
+
+```bash
+ssh <user>@<ip-du-serveur> "sudo bash -s '$(podman exec sam-server cat /data/keys/collector_key.pub)'" \
+    < <(podman exec sam-server cat /app/provision-host.sh)
 ```
 
 > **Note** : La connexion SSH utilise toujours l'adresse IP déclarée, jamais la résolution DNS, pour éviter les ambiguïtés réseau.
@@ -359,7 +372,7 @@ EXEC="podman exec sam-server python3 /app/app/manage.py"
 
 # Serveurs
 $EXEC servers list
-$EXEC servers add --hostname HOST --ip IP --env production --os rhel
+$EXEC servers add --hostname HOST --ip IP --ssh-user USER --ssh-password PASS [--env production] [--os rhel] [--port 22]
 $EXEC servers scan
 $EXEC servers scan --server HOST
 $EXEC servers disable HOST

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -167,7 +167,8 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - `unlock_user(unix_user, hostname, admin_id)` — valide username POSIX, sam-unlock-user, USER_UNLOCKED (#181)
 
 ### Serveurs
-- `add_server(hostname, ip, env, os_family, db)` — appelle add_to_known_hosts(ip) avant INSERT (#70)
+- `add_server(hostname, ip, ssh_user, ssh_password, env=None, os_family=None, ssh_port=22, admin_id=None)` — provisionnement atomique : `add_to_known_hosts(ip)` → `ssh.provision_server()` → INSERT servers → audit SERVER_ADDED + SERVER_PROVISIONED. Si le SSH échoue, aucune donnée n'est écrite (#299, #301). Le SSH password n'est jamais stocké.
+- `provision_server(hostname, ip, ssh_user, ssh_password, ssh_port)` — re-provisionne un serveur existant (#302). Même garantie : ssh password non stocké.
 - `disable_server`, `enable_server` (#88), `delete_server` (#88 — hard delete + cascade)
 
 ### Administrateurs
@@ -183,6 +184,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 |-------|----------|----------|--------|
 | GET /api/servers, /api/keys, /api/access, /api/admins, /api/audit, /api/system/status, /api/system/config, /api/system/collector-key | ✓ | ✓ | ✓ |
 | POST /api/servers | ✓ | 403 | 403 |
+| POST /api/servers/\*/provision | ✓ | 403 | 403 |
 | PUT/DELETE /api/servers/\*/disable, enable, DELETE | ✓ | 403 | 403 |
 | POST /api/servers/\*/scan, /api/system/scan | ✓ | ✓ | 403 |
 | GET /api/servers/\*/sessions, /api/servers/\*/sessions/history | ✓ | ✓ | 403 |
@@ -207,7 +209,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - Couverture minimale actions.py : 80%
 - pytest doit passer avant tout commit
 
-Fichiers : conftest.py, test_db.py (7), test_servers.py (9), test_ssh.py (41), test_actions.py (97), test_collect.py (34), test_expire.py (12), test_alerts.py (19), test_web.py (115), test_manage.py (35).
+Fichiers : conftest.py, test_db.py (7), test_servers.py (9), test_ssh.py (49), test_actions.py (114), test_collect.py (35), test_expire.py (12), test_alerts.py (23), test_web.py (130), test_manage.py (38), test_rbac.py (54).
 
 Fixtures obligatoires dans conftest.py : `mock_db`, `mock_ssh_client`, `mock_smtp`, `sample_server`, `sample_key`.
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -5,8 +5,8 @@
 | Vue | Rôle |
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
-| Dashboard.vue | Tableau serveurs + recherche + compteurs + modal ajout serveur (#71) + clé collecteur (#74) |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91) |
+| Dashboard.vue | Tableau serveurs + recherche + compteurs + modal ajout serveur (#71) + clé collecteur (#74). Provisionnement atomique via SSH (#299, #301) : SSH user/password obligatoires, serveur créé uniquement si SSH réussit. Validation hostname RFC 1123 (#303). Layout 2 colonnes. |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + colonne unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
 | Audit.vue | Historique filtrable |
@@ -70,5 +70,8 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | AuditTable.spec.js | 8 | filtres serveur/action/date, pagination, row classes (#250) |
 | AnomaliesTable.spec.js | 13 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
 | SessionsCard.spec.js | 17 | sessions actives, modal historique, filtres, pagination, CSV export, RBAC (#253) |
+| Dashboard.spec.js | 8 | champs SSH obligatoires, submit désactivé sans password/hostname invalide, POST avec ssh_user/password/port, port 22 par défaut, fermeture modal, validation RFC 1123 (#299, #303) |
+| PaginationBar.spec.js | 10 | sélecteur taille, navigation pages, désactivation limites |
+| App.spec.js | 6 | sélecteur langue, persistance localStorage |
 
 vitest doit passer avant tout commit.


### PR DESCRIPTION
## Summary

- **README.md** — refonte du workflow "Ajout d'un serveur" : provisionnement automatique via SSH depuis l'UI, CLI avec `--ssh-user`/`--ssh-password`, `servers.yml` repositionné comme méthode manuelle. Mise à jour de la commande `servers add` dans la référence CLI.
- **DESIGN.md** — métriques de tests mises à jour (733 tests : 471 Python + 262 Vue.js), tableau de synthèse enrichi (provision-first, password non stocké, error_code), section 12 précisée par module.
- **app/CLAUDE.md** — signature `add_server()` et `provision_server()` reflétant le flux atomique, endpoint `POST /api/servers/*/provision` ajouté à la matrice RBAC, compteurs tests corrects (test_rbac.py ajouté).
- **ui/CLAUDE.md** — Dashboard.vue et ServerDetail.vue décrits (provisionnement, validation hostname RFC 1123, re-provision), 3 fichiers de tests manquants ajoutés (Dashboard.spec.js, PaginationBar.spec.js, App.spec.js).
- **CLAUDE.md** — compteur issues mis à jour (57/57, ajout 299, 301, 302, 303).

## Test plan

- [ ] Pas de code modifié — lecture seule, aucun test à faire passer
- [ ] Vérifier que les compteurs de tests correspondent : `python3 -m pytest app/tests/ --co -q | tail -1` → 471, `npx vitest run` → 262

🤖 Generated with [Claude Code](https://claude.com/claude-code)