### PR TITLE
feat: add sortable columns to all table components (closes #306)

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -349,4 +349,23 @@ button:disabled {
 .btn-purple {
   min-width: 6rem;
 }
+
+.th-sortable {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.th-sortable:hover {
+  color: #2563eb;
+}
+.sort-indicator {
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 0.7em;
+  opacity: 0.6;
+}
+.th-sortable.active .sort-indicator {
+  opacity: 1;
+  color: #2563eb;
+}
 </style>

--- a/ui/src/components/AdminsTable.vue
+++ b/ui/src/components/AdminsTable.vue
@@ -13,10 +13,38 @@
     <table>
       <thead>
         <tr>
-          <th>{{ $t('admins.col_username') }}</th>
-          <th>{{ $t('admins.col_email') }}</th>
-          <th>{{ $t('admins.col_role') }}</th>
-          <th>{{ $t('admins.col_active') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'username' }"
+            @click="toggleSort('username')"
+          >
+            {{ $t('admins.col_username') }}
+            <span class="sort-indicator">{{ sortIndicator('username') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'email' }"
+            @click="toggleSort('email')"
+          >
+            {{ $t('admins.col_email') }}
+            <span class="sort-indicator">{{ sortIndicator('email') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'role' }"
+            @click="toggleSort('role')"
+          >
+            {{ $t('admins.col_role') }}
+            <span class="sort-indicator">{{ sortIndicator('role') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'is_active' }"
+            @click="toggleSort('is_active')"
+          >
+            {{ $t('admins.col_active') }}
+            <span class="sort-indicator">{{ sortIndicator('is_active') }}</span>
+          </th>
           <th>{{ $t('admins.col_created') }}</th>
           <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_alerts') }}</th>
           <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_actions') }}</th>
@@ -135,9 +163,11 @@
 import { ref, computed } from 'vue'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { formatDateOnly } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
 const props = defineProps({
   admins: { type: Array, default: () => [] },
@@ -161,7 +191,7 @@ const filtered = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filtered)
+  usePagination(computed(() => sorted(filtered.value)))
 </script>
 
 <style scoped>

--- a/ui/src/components/AdminsTable.vue
+++ b/ui/src/components/AdminsTable.vue
@@ -45,7 +45,14 @@
             {{ $t('admins.col_active') }}
             <span class="sort-indicator">{{ sortIndicator('is_active') }}</span>
           </th>
-          <th>{{ $t('admins.col_created') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'created_at' }"
+            @click="toggleSort('created_at')"
+          >
+            {{ $t('admins.col_created') }}
+            <span class="sort-indicator">{{ sortIndicator('created_at') }}</span>
+          </th>
           <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_alerts') }}</th>
           <th v-if="props.currentRole === 'sysadmin'">{{ $t('admins.col_actions') }}</th>
         </tr>

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -63,7 +63,14 @@
             {{ colDate }}
             <span class="sort-indicator">{{ sortIndicator(dateField) }}</span>
           </th>
-          <th>{{ $t('anomalies.col_compliant') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'is_compliant' }"
+            @click="toggleSort('is_compliant')"
+          >
+            {{ $t('anomalies.col_compliant') }}
+            <span class="sort-indicator">{{ sortIndicator('is_compliant') }}</span>
+          </th>
           <th v-if="props.currentRole !== 'viewer'">{{ $t('anomalies.col_actions') }}</th>
         </tr>
       </thead>

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -31,10 +31,38 @@
       <thead>
         <tr>
           <th>{{ $t('anomalies.col_fingerprint') }}</th>
-          <th>{{ $t('anomalies.col_type') }}</th>
-          <th>{{ $t('anomalies.col_server') }}</th>
-          <th>{{ $t('anomalies.col_unix_user') }}</th>
-          <th>{{ colDate }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'key_type' }"
+            @click="toggleSort('key_type')"
+          >
+            {{ $t('anomalies.col_type') }}
+            <span class="sort-indicator">{{ sortIndicator('key_type') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'server_hostname' }"
+            @click="toggleSort('server_hostname')"
+          >
+            {{ $t('anomalies.col_server') }}
+            <span class="sort-indicator">{{ sortIndicator('server_hostname') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'unix_user' }"
+            @click="toggleSort('unix_user')"
+          >
+            {{ $t('anomalies.col_unix_user') }}
+            <span class="sort-indicator">{{ sortIndicator('unix_user') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === dateField }"
+            @click="toggleSort(dateField)"
+          >
+            {{ colDate }}
+            <span class="sort-indicator">{{ sortIndicator(dateField) }}</span>
+          </th>
           <th>{{ $t('anomalies.col_compliant') }}</th>
           <th v-if="props.currentRole !== 'viewer'">{{ $t('anomalies.col_actions') }}</th>
         </tr>
@@ -108,10 +136,12 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { t } = useI18n()
 const { formatDate } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
 const props = defineProps({
   anomalies: { type: Array, default: () => [] },
@@ -155,7 +185,7 @@ const filtered = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filtered)
+  usePagination(computed(() => sorted(filtered.value)))
 
 const colDate = computed(() => {
   return props.type === 'pending' ? t('anomalies.col_first_seen') : t('anomalies.col_revoked_at')

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -34,10 +34,38 @@
         </colgroup>
         <thead>
           <tr>
-            <th>{{ $t('audit.col_date') }}</th>
-            <th>{{ $t('audit.col_action') }}</th>
-            <th>{{ $t('audit.col_by') }}</th>
-            <th>{{ $t('audit.col_server') }}</th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'performed_at' }"
+              @click="toggleSort('performed_at')"
+            >
+              {{ $t('audit.col_date') }}
+              <span class="sort-indicator">{{ sortIndicator('performed_at') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'action' }"
+              @click="toggleSort('action')"
+            >
+              {{ $t('audit.col_action') }}
+              <span class="sort-indicator">{{ sortIndicator('action') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'performed_by_username' }"
+              @click="toggleSort('performed_by_username')"
+            >
+              {{ $t('audit.col_by') }}
+              <span class="sort-indicator">{{ sortIndicator('performed_by_username') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'server_hostname' }"
+              @click="toggleSort('server_hostname')"
+            >
+              {{ $t('audit.col_server') }}
+              <span class="sort-indicator">{{ sortIndicator('server_hostname') }}</span>
+            </th>
             <th>{{ $t('audit.col_key') }}</th>
             <th>{{ $t('audit.col_details') }}</th>
           </tr>
@@ -81,9 +109,11 @@
 import { ref, computed } from 'vue'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { formatDate } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
 const props = defineProps({
   logs: { type: Array, default: () => [] },
@@ -130,7 +160,7 @@ const filtered = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filtered)
+  usePagination(computed(() => sorted(filtered.value)))
 
 function rowClass(action) {
   if (CRITICAL_ACTIONS.has(action)) return 'row-danger'

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -31,11 +31,46 @@
       <table data-testid="table-deployed-users">
         <thead>
           <tr>
-            <th>{{ $t('deployedUsers.col_user') }}</th>
-            <th>{{ $t('deployedUsers.col_server') }}</th>
-            <th>{{ $t('deployedUsers.col_ip') }}</th>
-            <th>{{ $t('deployedUsers.col_expires') }}</th>
-            <th>{{ $t('deployedUsers.col_status') }}</th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'unix_user' }"
+              @click="toggleSort('unix_user')"
+            >
+              {{ $t('deployedUsers.col_user') }}
+              <span class="sort-indicator">{{ sortIndicator('unix_user') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'hostname' }"
+              @click="toggleSort('hostname')"
+            >
+              {{ $t('deployedUsers.col_server') }}
+              <span class="sort-indicator">{{ sortIndicator('hostname') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'ip_address' }"
+              @click="toggleSort('ip_address')"
+            >
+              {{ $t('deployedUsers.col_ip') }}
+              <span class="sort-indicator">{{ sortIndicator('ip_address') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'expires_at' }"
+              @click="toggleSort('expires_at')"
+            >
+              {{ $t('deployedUsers.col_expires') }}
+              <span class="sort-indicator">{{ sortIndicator('expires_at') }}</span>
+            </th>
+            <th
+              class="th-sortable"
+              :class="{ active: sortKey === 'lock_status' }"
+              @click="toggleSort('lock_status')"
+            >
+              {{ $t('deployedUsers.col_status') }}
+              <span class="sort-indicator">{{ sortIndicator('lock_status') }}</span>
+            </th>
             <th v-if="currentRole !== 'viewer'">{{ $t('deployedUsers.col_actions') }}</th>
           </tr>
         </thead>
@@ -138,11 +173,13 @@ import { useI18n } from 'vue-i18n'
 import { useAuth } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { t } = useI18n()
 const { admin } = useAuth()
 const { formatDate } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const users = ref([])
@@ -173,7 +210,7 @@ const filteredUsers = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filteredUsers)
+  usePagination(computed(() => sorted(filteredUsers.value)))
 
 onMounted(async () => {
   await loadUsers()

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -38,7 +38,14 @@
             <span class="sort-indicator">{{ sortIndicator('key_type') }}</span>
           </th>
           <th>{{ $t('key_table.col_fingerprint') }}</th>
-          <th>{{ $t('key_table.col_unix_user') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'unix_user' }"
+            @click="toggleSort('unix_user')"
+          >
+            {{ $t('key_table.col_unix_user') }}
+            <span class="sort-indicator">{{ sortIndicator('unix_user') }}</span>
+          </th>
           <th
             class="th-sortable"
             :class="{ active: sortKey === 'comment' }"
@@ -63,7 +70,14 @@
             {{ $t('key_table.col_expires') }}
             <span class="sort-indicator">{{ sortIndicator('expires_at') }}</span>
           </th>
-          <th>{{ $t('key_table.col_compliant') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'is_compliant' }"
+            @click="toggleSort('is_compliant')"
+          >
+            {{ $t('key_table.col_compliant') }}
+            <span class="sort-indicator">{{ sortIndicator('is_compliant') }}</span>
+          </th>
           <th>{{ $t('key_table.col_actions') }}</th>
         </tr>
       </thead>

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -21,13 +21,48 @@
     <table>
       <thead>
         <tr>
-          <th>{{ $t('key_table.col_status') }}</th>
-          <th>{{ $t('key_table.col_type') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'status' }"
+            @click="toggleSort('status')"
+          >
+            {{ $t('key_table.col_status') }}
+            <span class="sort-indicator">{{ sortIndicator('status') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'key_type' }"
+            @click="toggleSort('key_type')"
+          >
+            {{ $t('key_table.col_type') }}
+            <span class="sort-indicator">{{ sortIndicator('key_type') }}</span>
+          </th>
           <th>{{ $t('key_table.col_fingerprint') }}</th>
           <th>{{ $t('key_table.col_unix_user') }}</th>
-          <th>{{ $t('key_table.col_comment') }}</th>
-          <th>{{ $t('key_table.col_owner') }}</th>
-          <th>{{ $t('key_table.col_expires') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'comment' }"
+            @click="toggleSort('comment')"
+          >
+            {{ $t('key_table.col_comment') }}
+            <span class="sort-indicator">{{ sortIndicator('comment') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'owner' }"
+            @click="toggleSort('owner')"
+          >
+            {{ $t('key_table.col_owner') }}
+            <span class="sort-indicator">{{ sortIndicator('owner') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'expires_at' }"
+            @click="toggleSort('expires_at')"
+          >
+            {{ $t('key_table.col_expires') }}
+            <span class="sort-indicator">{{ sortIndicator('expires_at') }}</span>
+          </th>
           <th>{{ $t('key_table.col_compliant') }}</th>
           <th>{{ $t('key_table.col_actions') }}</th>
         </tr>
@@ -127,10 +162,12 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { t } = useI18n()
 const { formatDate } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
 const props = defineProps({
   keys: { type: Array, default: () => [] },
@@ -156,7 +193,7 @@ const filteredKeys = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filteredKeys)
+  usePagination(computed(() => sorted(filteredKeys.value)))
 
 function complianceTooltip(k) {
   if (k.key_type === 'ssh-rsa') {

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -12,11 +12,46 @@
     <table>
       <thead>
         <tr>
-          <th>{{ $t('server_table.col_status') }}</th>
-          <th>{{ $t('server_table.col_hostname') }}</th>
-          <th>{{ $t('server_table.col_ip') }}</th>
-          <th>{{ $t('server_table.col_environment') }}</th>
-          <th>{{ $t('server_table.col_os') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'is_active' }"
+            @click="toggleSort('is_active')"
+          >
+            {{ $t('server_table.col_status') }}
+            <span class="sort-indicator">{{ sortIndicator('is_active') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'hostname' }"
+            @click="toggleSort('hostname')"
+          >
+            {{ $t('server_table.col_hostname') }}
+            <span class="sort-indicator">{{ sortIndicator('hostname') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'ip_address' }"
+            @click="toggleSort('ip_address')"
+          >
+            {{ $t('server_table.col_ip') }}
+            <span class="sort-indicator">{{ sortIndicator('ip_address') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'environment' }"
+            @click="toggleSort('environment')"
+          >
+            {{ $t('server_table.col_environment') }}
+            <span class="sort-indicator">{{ sortIndicator('environment') }}</span>
+          </th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'os_family' }"
+            @click="toggleSort('os_family')"
+          >
+            {{ $t('server_table.col_os') }}
+            <span class="sort-indicator">{{ sortIndicator('os_family') }}</span>
+          </th>
           <th>{{ $t('server_table.col_added') }}</th>
           <th>{{ $t('server_table.col_actions') }}</th>
         </tr>
@@ -85,9 +120,11 @@
 import { ref, computed } from 'vue'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
+import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
 const { formatDateOnly } = useFormatDate()
+const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
 const props = defineProps({
   servers: { type: Array, default: () => [] },
@@ -110,7 +147,7 @@ const filtered = computed(() => {
 })
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
-  usePagination(filtered)
+  usePagination(computed(() => sorted(filtered.value)))
 
 function statusIcon(s) {
   if (!s.is_active) return '🔴'

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -52,7 +52,14 @@
             {{ $t('server_table.col_os') }}
             <span class="sort-indicator">{{ sortIndicator('os_family') }}</span>
           </th>
-          <th>{{ $t('server_table.col_added') }}</th>
+          <th
+            class="th-sortable"
+            :class="{ active: sortKey === 'added_at' }"
+            @click="toggleSort('added_at')"
+          >
+            {{ $t('server_table.col_added') }}
+            <span class="sort-indicator">{{ sortIndicator('added_at') }}</span>
+          </th>
           <th>{{ $t('server_table.col_actions') }}</th>
         </tr>
       </thead>

--- a/ui/src/composables/useSort.js
+++ b/ui/src/composables/useSort.js
@@ -1,0 +1,63 @@
+import { ref, computed } from 'vue'
+
+/**
+ * Composable for client-side column sorting.
+ * @returns {Object} - Sort state and methods
+ */
+export function useSort() {
+  const sortKey = ref('')
+  const sortDir = ref(0) // 0=unsorted, 1=asc, -1=desc
+
+  /**
+   * Toggle sort direction for a given column key.
+   * Cycles through: unsorted → asc → desc → unsorted
+   */
+  function toggleSort(key) {
+    if (sortKey.value !== key) {
+      sortKey.value = key
+      sortDir.value = 1
+    } else if (sortDir.value === 1) {
+      sortDir.value = -1
+    } else {
+      sortKey.value = ''
+      sortDir.value = 0
+    }
+  }
+
+  /**
+   * Returns a sorted copy of the items array.
+   * @param {Array} items - Items to sort
+   * @returns {Array} - Sorted copy
+   */
+  function sorted(items) {
+    if (!sortKey.value || sortDir.value === 0) return items
+    return [...items].sort((a, b) => {
+      const av = a[sortKey.value]
+      const bv = b[sortKey.value]
+      // nulls last
+      if (av == null && bv == null) return 0
+      if (av == null) return 1
+      if (bv == null) return -1
+      // date strings (ISO 8601 or null)
+      if (typeof av === 'string' && /^\d{4}-\d{2}-\d{2}/.test(av)) {
+        return sortDir.value * (new Date(av) - new Date(bv))
+      }
+      // numbers
+      if (typeof av === 'number') return sortDir.value * (av - bv)
+      // booleans (false < true in ascending order)
+      if (typeof av === 'boolean') return sortDir.value * (av === bv ? 0 : av ? 1 : -1)
+      // strings
+      return sortDir.value * String(av).localeCompare(String(bv))
+    })
+  }
+
+  /**
+   * Returns the appropriate sort indicator for a column.
+   */
+  const sortIndicator = computed(() => (key) => {
+    if (sortKey.value !== key) return '↕'
+    return sortDir.value === 1 ? '▲' : '▼'
+  })
+
+  return { sortKey, sortDir, toggleSort, sorted, sortIndicator }
+}

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -148,4 +148,73 @@ describe('ServerTable', () => {
     const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
     expect(rows.length).toBe(10)
   })
+
+  it('sorts by hostname ascending on first click', async () => {
+    const servers = [
+      { ...SERVERS[0], hostname: 'zulu' },
+      { ...SERVERS[1], hostname: 'alpha' },
+      { ...SERVERS[2], hostname: 'bravo' },
+    ]
+    const w = mountTable(servers)
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    await hostnameHeader.trigger('click')
+    const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
+    expect(rows[0].text()).toContain('alpha')
+    expect(rows[1].text()).toContain('bravo')
+    expect(rows[2].text()).toContain('zulu')
+  })
+
+  it('sorts by hostname descending on second click', async () => {
+    const servers = [
+      { ...SERVERS[0], hostname: 'zulu' },
+      { ...SERVERS[1], hostname: 'alpha' },
+      { ...SERVERS[2], hostname: 'bravo' },
+    ]
+    const w = mountTable(servers)
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    await hostnameHeader.trigger('click')
+    await hostnameHeader.trigger('click')
+    const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
+    expect(rows[0].text()).toContain('zulu')
+    expect(rows[1].text()).toContain('bravo')
+    expect(rows[2].text()).toContain('alpha')
+  })
+
+  it('returns to unsorted on third click', async () => {
+    const servers = [
+      { ...SERVERS[0], hostname: 'zulu' },
+      { ...SERVERS[1], hostname: 'alpha' },
+      { ...SERVERS[2], hostname: 'bravo' },
+    ]
+    const w = mountTable(servers)
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    await hostnameHeader.trigger('click')
+    await hostnameHeader.trigger('click')
+    await hostnameHeader.trigger('click')
+    const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
+    expect(rows[0].text()).toContain('zulu')
+    expect(rows[1].text()).toContain('alpha')
+    expect(rows[2].text()).toContain('bravo')
+  })
+
+  it('displays sort indicator ▲ when sorted ascending', async () => {
+    const w = mountTable()
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    await hostnameHeader.trigger('click')
+    expect(hostnameHeader.text()).toContain('▲')
+  })
+
+  it('displays sort indicator ▼ when sorted descending', async () => {
+    const w = mountTable()
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    await hostnameHeader.trigger('click')
+    await hostnameHeader.trigger('click')
+    expect(hostnameHeader.text()).toContain('▼')
+  })
+
+  it('displays sort indicator ↕ when unsorted', () => {
+    const w = mountTable()
+    const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
+    expect(hostnameHeader.text()).toContain('↕')
+  })
 })

--- a/ui/tests/useSort.spec.js
+++ b/ui/tests/useSort.spec.js
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import { useSort } from '../src/composables/useSort.js'
+
+describe('useSort', () => {
+  it('initializes with unsorted state', () => {
+    const { sortKey, sortDir } = useSort()
+    expect(sortKey.value).toBe('')
+    expect(sortDir.value).toBe(0)
+  })
+
+  it('toggleSort cycles: unsorted → asc → desc → unsorted', () => {
+    const { sortKey, sortDir, toggleSort } = useSort()
+
+    toggleSort('name')
+    expect(sortKey.value).toBe('name')
+    expect(sortDir.value).toBe(1) // asc
+
+    toggleSort('name')
+    expect(sortKey.value).toBe('name')
+    expect(sortDir.value).toBe(-1) // desc
+
+    toggleSort('name')
+    expect(sortKey.value).toBe('')
+    expect(sortDir.value).toBe(0) // unsorted
+  })
+
+  it('toggleSort resets to asc when changing column', () => {
+    const { sortKey, sortDir, toggleSort } = useSort()
+
+    toggleSort('name')
+    expect(sortKey.value).toBe('name')
+    expect(sortDir.value).toBe(1)
+
+    toggleSort('age')
+    expect(sortKey.value).toBe('age')
+    expect(sortDir.value).toBe(1) // reset to asc
+  })
+
+  it('sorted() returns original array when unsorted', () => {
+    const { sorted } = useSort()
+    const items = [{ id: 3 }, { id: 1 }, { id: 2 }]
+    const result = sorted(items)
+    expect(result).toEqual(items)
+    expect(result).toBe(items) // same reference
+  })
+
+  it('sorted() returns a new array (no mutation)', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('id')
+    const items = [{ id: 3 }, { id: 1 }, { id: 2 }]
+    const result = sorted(items)
+    expect(result).not.toBe(items) // different reference
+    expect(items).toEqual([{ id: 3 }, { id: 1 }, { id: 2 }]) // original unchanged
+  })
+
+  it('sorted() handles numbers ascending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('age')
+    const items = [{ age: 30 }, { age: 10 }, { age: 20 }]
+    const result = sorted(items)
+    expect(result.map((x) => x.age)).toEqual([10, 20, 30])
+  })
+
+  it('sorted() handles numbers descending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('age')
+    toggleSort('age') // desc
+    const items = [{ age: 30 }, { age: 10 }, { age: 20 }]
+    const result = sorted(items)
+    expect(result.map((x) => x.age)).toEqual([30, 20, 10])
+  })
+
+  it('sorted() handles strings ascending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('name')
+    const items = [{ name: 'Charlie' }, { name: 'Alice' }, { name: 'Bob' }]
+    const result = sorted(items)
+    expect(result.map((x) => x.name)).toEqual(['Alice', 'Bob', 'Charlie'])
+  })
+
+  it('sorted() handles strings descending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('name')
+    toggleSort('name') // desc
+    const items = [{ name: 'Charlie' }, { name: 'Alice' }, { name: 'Bob' }]
+    const result = sorted(items)
+    expect(result.map((x) => x.name)).toEqual(['Charlie', 'Bob', 'Alice'])
+  })
+
+  it('sorted() handles ISO date strings ascending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('date')
+    const items = [
+      { date: '2024-03-15T10:00:00Z' },
+      { date: '2024-01-10T10:00:00Z' },
+      { date: '2024-02-20T10:00:00Z' },
+    ]
+    const result = sorted(items)
+    expect(result.map((x) => x.date)).toEqual([
+      '2024-01-10T10:00:00Z',
+      '2024-02-20T10:00:00Z',
+      '2024-03-15T10:00:00Z',
+    ])
+  })
+
+  it('sorted() handles ISO date strings descending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('date')
+    toggleSort('date') // desc
+    const items = [
+      { date: '2024-03-15T10:00:00Z' },
+      { date: '2024-01-10T10:00:00Z' },
+      { date: '2024-02-20T10:00:00Z' },
+    ]
+    const result = sorted(items)
+    expect(result.map((x) => x.date)).toEqual([
+      '2024-03-15T10:00:00Z',
+      '2024-02-20T10:00:00Z',
+      '2024-01-10T10:00:00Z',
+    ])
+  })
+
+  it('sorted() handles booleans ascending (false < true)', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('active')
+    const items = [{ active: true }, { active: false }, { active: true }]
+    const result = sorted(items)
+    expect(result.map((x) => x.active)).toEqual([false, true, true])
+  })
+
+  it('sorted() handles booleans descending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('active')
+    toggleSort('active') // desc
+    const items = [{ active: false }, { active: true }, { active: false }]
+    const result = sorted(items)
+    expect(result.map((x) => x.active)).toEqual([true, false, false])
+  })
+
+  it('sorted() places nulls last ascending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('value')
+    const items = [{ value: 3 }, { value: null }, { value: 1 }]
+    const result = sorted(items)
+    expect(result.map((x) => x.value)).toEqual([1, 3, null])
+  })
+
+  it('sorted() places nulls last descending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('value')
+    toggleSort('value') // desc
+    const items = [{ value: 3 }, { value: null }, { value: 1 }]
+    const result = sorted(items)
+    expect(result.map((x) => x.value)).toEqual([3, 1, null])
+  })
+
+  it('sorted() places undefined last ascending', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('value')
+    const items = [{ value: 3 }, { value: undefined }, { value: 1 }]
+    const result = sorted(items)
+    expect(result.map((x) => x.value)).toEqual([1, 3, undefined])
+  })
+
+  it('sorted() handles multiple nulls', () => {
+    const { sorted, toggleSort } = useSort()
+    toggleSort('value')
+    const items = [{ value: null }, { value: 2 }, { value: null }]
+    const result = sorted(items)
+    expect(result.map((x) => x.value)).toEqual([2, null, null])
+  })
+
+  it('sortIndicator returns ↕ for inactive column', () => {
+    const { sortIndicator } = useSort()
+    expect(sortIndicator.value('name')).toBe('↕')
+  })
+
+  it('sortIndicator returns ▲ for ascending', () => {
+    const { sortIndicator, toggleSort } = useSort()
+    toggleSort('name')
+    expect(sortIndicator.value('name')).toBe('▲')
+  })
+
+  it('sortIndicator returns ▼ for descending', () => {
+    const { sortIndicator, toggleSort } = useSort()
+    toggleSort('name')
+    toggleSort('name') // desc
+    expect(sortIndicator.value('name')).toBe('▼')
+  })
+
+  it('sortIndicator returns ↕ after cycling back to unsorted', () => {
+    const { sortIndicator, toggleSort } = useSort()
+    toggleSort('name')
+    toggleSort('name')
+    toggleSort('name') // back to unsorted
+    expect(sortIndicator.value('name')).toBe('↕')
+  })
+})


### PR DESCRIPTION
## Summary

- New `useSort.js` composable — client-side sorting shared across all tables
- Sortable columns in: `ServerTable`, `KeyTable`, `AdminsTable`, `AuditTable`, `AnomaliesTable`, `DeployedUsersTable`
- Global CSS classes `th-sortable` / `sort-indicator` in `App.vue`
- 21 new tests in `useSort.spec.js` + 6 sort tests in `ServerTable.spec.js`

## Behaviour

- Click column header → ascending ▲
- Click again → descending ▼
- Click a third time → reset ↕
- Sort applied after filtering, before pagination
- Nulls always sorted last
- Type-aware comparator: string (`localeCompare`), number, ISO date, boolean

## Test plan

- [ ] 289 Vitest tests passing ✅
- [ ] Prettier clean ✅
- [ ] Click hostname in ServerTable → rows reorder
- [ ] Click expires_at in KeyTable → dates sort correctly, nulls at bottom
- [ ] Click performed_at in AuditTable → chronological sort
- [ ] Third click resets to original filter order

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)