### PR TITLE
feat: redirect to login on 401 session expiry via apiFetch wrapper

### DIFF
--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -139,6 +139,7 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { apiFetch } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
 
 const { t } = useI18n()
@@ -163,7 +164,7 @@ const result = ref(null)
 onMounted(async () => {
   serversLoading.value = true
   try {
-    const res = await fetch('/api/servers')
+    const res = await apiFetch('/api/servers')
     if (res.ok) {
       const data = await res.json()
       servers.value = data.filter((s) => s.is_active)
@@ -233,7 +234,7 @@ async function submit() {
   }
 
   try {
-    const res = await fetch('/api/access/deploy', {
+    const res = await apiFetch('/api/access/deploy', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -170,7 +170,7 @@
 import { ref, computed, onMounted, defineExpose } from 'vue'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from '../composables/useAuth.js'
+import { useAuth, apiFetch } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
 import { useSort } from '../composables/useSort.js'
@@ -222,7 +222,7 @@ async function loadUsers() {
   loading.value = true
   loadError.value = ''
   try {
-    const res = await fetch('/api/access/deployed-users')
+    const res = await apiFetch('/api/access/deployed-users')
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -259,7 +259,7 @@ async function performAction(user, endpoint, actionType) {
   errorMessages.value[key] = ''
 
   try {
-    const res = await fetch(endpoint, {
+    const res = await apiFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ unix_user: user.unix_user, hostname: user.hostname }),

--- a/ui/src/components/SessionsCard.vue
+++ b/ui/src/components/SessionsCard.vue
@@ -170,6 +170,7 @@
 
 <script setup>
 import { ref, computed, onMounted, watch } from 'vue'
+import { apiFetch } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
 import PaginationBar from './PaginationBar.vue'
@@ -218,7 +219,7 @@ async function loadSessions() {
   loading.value = true
   error.value = ''
   try {
-    const res = await fetch(`/api/servers/${props.hostname}/sessions`)
+    const res = await apiFetch(`/api/servers/${props.hostname}/sessions`)
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`)
     }
@@ -238,7 +239,9 @@ async function refreshSessions() {
   refreshing.value = true
   error.value = ''
   try {
-    const res = await fetch(`/api/servers/${props.hostname}/sessions/refresh`, { method: 'POST' })
+    const res = await apiFetch(`/api/servers/${props.hostname}/sessions/refresh`, {
+      method: 'POST',
+    })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -261,7 +264,7 @@ async function loadHistory() {
     if (filterSince.value) params.append('since', filterSince.value)
 
     const url = `/api/servers/${props.hostname}/sessions/history${params.toString() ? '?' + params.toString() : ''}`
-    const res = await fetch(url)
+    const res = await apiFetch(url)
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`)
     }

--- a/ui/src/components/UserLockForm.vue
+++ b/ui/src/components/UserLockForm.vue
@@ -69,6 +69,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { apiFetch } from '../composables/useAuth.js'
 
 const { t } = useI18n()
 
@@ -84,7 +85,7 @@ const success = ref('')
 onMounted(async () => {
   serversLoading.value = true
   try {
-    const res = await fetch('/api/servers')
+    const res = await apiFetch('/api/servers')
     if (res.ok) {
       const data = await res.json()
       servers.value = data.filter((s) => s.is_active)
@@ -119,7 +120,7 @@ async function performAction(endpoint, action) {
   }
 
   try {
-    const res = await fetch(endpoint, {
+    const res = await apiFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/ui/src/composables/useAuth.js
+++ b/ui/src/composables/useAuth.js
@@ -2,6 +2,16 @@ import { ref } from 'vue'
 
 const admin = ref(null)
 
+export async function apiFetch(url, options = {}) {
+  const res = await fetch(url, options)
+  if (res.status === 401) {
+    admin.value = null
+    window.location.replace('/login')
+    return new Promise(() => {})
+  }
+  return res
+}
+
 export function useAuth() {
   async function fetchMe() {
     try {

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -464,7 +464,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
-import { useAuth } from '../composables/useAuth'
+import { useAuth, apiFetch } from '../composables/useAuth'
 import AdminsTable from '../components/AdminsTable.vue'
 
 const { t } = useI18n()
@@ -539,7 +539,7 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const [adminsRes, meRes] = await Promise.all([fetch('/api/admins'), fetch('/api/auth/me')])
+    const [adminsRes, meRes] = await Promise.all([apiFetch('/api/admins'), fetch('/api/auth/me')])
     if (!adminsRes.ok) throw new Error(`HTTP ${adminsRes.status}`)
     admins.value = await adminsRes.json()
     if (meRes.ok) {
@@ -559,7 +559,7 @@ async function submitAdd() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch('/api/admins', {
+    const res = await apiFetch('/api/admins', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -600,7 +600,7 @@ function openDelete(username) {
 async function toggleAlerts(username, receive_alerts) {
   error.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}/alerts`, {
+    const res = await apiFetch(`/api/admins/${username}/alerts`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ receive_alerts }),
@@ -624,7 +624,7 @@ async function confirmDisable() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}/disable`, { method: 'PUT' })
+    const res = await apiFetch(`/api/admins/${username}/disable`, { method: 'PUT' })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -642,7 +642,7 @@ async function confirmEnable() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}/enable`, { method: 'PUT' })
+    const res = await apiFetch(`/api/admins/${username}/enable`, { method: 'PUT' })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -660,7 +660,7 @@ async function confirmDelete() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}`, { method: 'DELETE' })
+    const res = await apiFetch(`/api/admins/${username}`, { method: 'DELETE' })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -696,7 +696,7 @@ async function confirmEditPassword() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}/password`, {
+    const res = await apiFetch(`/api/admins/${username}/password`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ password }),
@@ -734,7 +734,7 @@ async function confirmEdit() {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(`/api/admins/${username}`, {
+    const res = await apiFetch(`/api/admins/${username}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, role }),

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -82,7 +82,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from '../composables/useAuth.js'
+import { useAuth, apiFetch } from '../composables/useAuth.js'
 import AnomaliesTable from '../components/AnomaliesTable.vue'
 
 const { t } = useI18n()
@@ -115,7 +115,7 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const res = await fetch('/api/keys')
+    const res = await apiFetch('/api/keys')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     allKeys.value = await res.json()
   } catch (e) {
@@ -157,7 +157,7 @@ async function apiAction(url, body, successMsg) {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(url, {
+    const res = await apiFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/ui/src/views/Audit.vue
+++ b/ui/src/views/Audit.vue
@@ -12,6 +12,7 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { apiFetch } from '../composables/useAuth.js'
 import AuditTable from '../components/AuditTable.vue'
 
 const { t } = useI18n()
@@ -25,7 +26,7 @@ async function load() {
   loading.value = true
   error.value = ''
   try {
-    const res = await fetch('/api/audit')
+    const res = await apiFetch('/api/audit')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     entries.value = await res.json()
   } catch (e) {

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -280,7 +280,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from '../composables/useAuth.js'
+import { useAuth, apiFetch } from '../composables/useAuth.js'
 import ServerTable from '../components/ServerTable.vue'
 
 const { t, te } = useI18n()
@@ -382,7 +382,7 @@ const editFormValid = computed(
 
 async function loadCollectorKey() {
   try {
-    const res = await fetch('/api/system/collector-key')
+    const res = await apiFetch('/api/system/collector-key')
     if (res.ok) {
       const data = await res.json()
       collectorKey.value = data.public_key
@@ -424,7 +424,7 @@ async function confirmAddServer() {
   adding.value = true
   addError.value = ''
   try {
-    const res = await fetch('/api/servers', {
+    const res = await apiFetch('/api/servers', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -457,7 +457,7 @@ async function loadServers() {
   loading.value = true
   error.value = ''
   try {
-    const res = await fetch('/api/servers')
+    const res = await apiFetch('/api/servers')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     servers.value = await res.json()
   } catch (e) {
@@ -480,7 +480,7 @@ async function triggerScan(url, hostname) {
   scanMessage.value = ''
   error.value = ''
   try {
-    const res = await fetch(url, { method: 'POST' })
+    const res = await apiFetch(url, { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     scanMessage.value = hostname
       ? t('dashboard.scan_success', { hostname })
@@ -513,7 +513,7 @@ async function confirmEditServer() {
   editing.value = true
   editError.value = ''
   try {
-    const res = await fetch(`/api/servers/${editForm.value.hostname}`, {
+    const res = await apiFetch(`/api/servers/${editForm.value.hostname}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -327,7 +327,7 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from '../composables/useAuth.js'
+import { useAuth, apiFetch } from '../composables/useAuth.js'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import KeyTable from '../components/KeyTable.vue'
 import SessionsCard from '../components/SessionsCard.vue'
@@ -373,8 +373,8 @@ async function load() {
   error.value = ''
   try {
     const [sRes, kRes] = await Promise.all([
-      fetch(`/api/servers/${hostname}`),
-      fetch(`/api/keys?server=${hostname}`),
+      apiFetch(`/api/servers/${hostname}`),
+      apiFetch(`/api/keys?server=${hostname}`),
     ])
     if (!sRes.ok) throw new Error(t('server_detail.load_error', { status: sRes.status }))
     server.value = await sRes.json()
@@ -409,7 +409,7 @@ async function deleteServer() {
   showDeleteModal.value = false
   error.value = ''
   try {
-    const res = await fetch(`/api/servers/${hostname}`, { method: 'DELETE' })
+    const res = await apiFetch(`/api/servers/${hostname}`, { method: 'DELETE' })
     if (!res.ok) {
       const data = await res.json().catch(() => ({}))
       throw new Error(data.error || `HTTP ${res.status}`)
@@ -425,7 +425,7 @@ async function scanServer() {
   message.value = ''
   error.value = ''
   try {
-    const res = await fetch(`/api/servers/${hostname}/scan`, { method: 'POST' })
+    const res = await apiFetch(`/api/servers/${hostname}/scan`, { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     message.value = t('server_detail.scan_success')
     await load()
@@ -511,7 +511,7 @@ async function apiAction(url, body, method = 'POST', successMsg) {
   error.value = ''
   message.value = ''
   try {
-    const res = await fetch(url, {
+    const res = await apiFetch(url, {
       method,
       headers: { 'Content-Type': 'application/json' },
       body: body != null ? JSON.stringify(body) : undefined,
@@ -537,7 +537,7 @@ async function confirmReprovision() {
   reprovisioning.value = true
   reprovisionError.value = ''
   try {
-    const res = await fetch(`/api/servers/${hostname}/provision`, {
+    const res = await apiFetch(`/api/servers/${hostname}/provision`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -126,7 +126,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from '../composables/useAuth.js'
+import { useAuth, apiFetch } from '../composables/useAuth.js'
 
 const { t } = useI18n()
 const { admin } = useAuth()
@@ -150,7 +150,7 @@ const smtpError = ref('')
 
 onMounted(async () => {
   try {
-    const res = await fetch('/api/system/config')
+    const res = await apiFetch('/api/system/config')
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
     const data = await res.json()
     intervalHours.value = parseInt(data.scan_interval_hours)
@@ -168,7 +168,7 @@ async function testSmtp() {
   smtpSuccess.value = ''
   smtpError.value = ''
   try {
-    const res = await fetch('/api/system/test-smtp', { method: 'POST' })
+    const res = await apiFetch('/api/system/test-smtp', { method: 'POST' })
     const data = await res.json().catch(() => ({}))
     if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
     smtpSuccess.value = t('settings.smtp_sent', { to: data.to })
@@ -205,7 +205,7 @@ async function save() {
   error.value = ''
 
   try {
-    const res = await fetch('/api/system/config', {
+    const res = await apiFetch('/api/system/config', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -246,7 +246,7 @@ async function saveSecurity() {
   errorSecurity.value = ''
 
   try {
-    const res = await fetch('/api/system/config', {
+    const res = await apiFetch('/api/system/config', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/ui/tests/App.spec.js
+++ b/ui/tests/App.spec.js
@@ -43,6 +43,7 @@ vi.mock('../src/composables/useAuth.js', () => ({
     admin: mockAdmin,
     logout: vi.fn(),
   }),
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
 }))
 
 describe('App.vue — SMTP banner', () => {

--- a/ui/tests/Dashboard.spec.js
+++ b/ui/tests/Dashboard.spec.js
@@ -33,6 +33,7 @@ function mockAuth() {
       admin: { value: { username: 'admin', role: 'sysadmin' } },
       logout: vi.fn(),
     }),
+    apiFetch: async (url, options = {}) => global.fetch(url, options),
   }))
 }
 

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -8,6 +8,7 @@ const mockAdmin = vi.hoisted(() => ({ value: { username: 'admin', role: 'sysadmi
 
 vi.mock('../src/composables/useAuth.js', () => ({
   useAuth: () => ({ admin: mockAdmin }),
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
@@ -61,7 +62,7 @@ describe('DeployedUsersTable', () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
-    expect(fetchSpy).toHaveBeenCalledWith('/api/access/deployed-users')
+    expect(fetchSpy).toHaveBeenCalledWith('/api/access/deployed-users', {})
     expect(w.find('[data-testid="table-deployed-users"]').exists()).toBe(true)
   })
 

--- a/ui/tests/Login.spec.js
+++ b/ui/tests/Login.spec.js
@@ -11,6 +11,7 @@ vi.mock('../src/composables/useAuth.js', () => ({
   useAuth: () => ({
     login: loginMock,
   }),
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
 }))
 
 const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })

--- a/ui/tests/SessionsCard.spec.js
+++ b/ui/tests/SessionsCard.spec.js
@@ -12,6 +12,10 @@ const i18n = createI18n({
 
 global.fetch = vi.fn()
 
+vi.mock('../src/composables/useAuth.js', () => ({
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
+}))
+
 describe('SessionsCard.vue', () => {
   beforeEach(() => {
     fetch.mockReset()
@@ -63,7 +67,7 @@ describe('SessionsCard.vue', () => {
     await new Promise((r) => setTimeout(r, 10))
 
     expect(wrapper.find('h2').text()).toContain('SSH Sessions')
-    expect(fetch).toHaveBeenCalledWith('/api/servers/server01/sessions')
+    expect(fetch).toHaveBeenCalledWith('/api/servers/server01/sessions', {})
   })
 
   it('renders when currentRole is operator', async () => {
@@ -107,7 +111,7 @@ describe('SessionsCard.vue', () => {
 
     await new Promise((r) => setTimeout(r, 10))
 
-    expect(fetch).toHaveBeenCalledWith('/api/servers/server04/sessions')
+    expect(fetch).toHaveBeenCalledWith('/api/servers/server04/sessions', {})
   })
 
   it('shows active sessions table when active sessions exist', async () => {
@@ -258,7 +262,7 @@ describe('SessionsCard.vue', () => {
 
     expect(wrapper.find('.modal').exists()).toBe(true)
     expect(wrapper.find('.modal h3').text()).toContain('Session History')
-    expect(fetch).toHaveBeenCalledWith('/api/servers/server10/sessions/history')
+    expect(fetch).toHaveBeenCalledWith('/api/servers/server10/sessions/history', {})
   })
 
   it('auto-loads history with data when modal is opened', async () => {
@@ -334,7 +338,8 @@ describe('SessionsCard.vue', () => {
     await flushPromises()
 
     expect(fetch).toHaveBeenCalledWith(
-      '/api/servers/server11/sessions/history?user=dave&ip=192.168.1.200&since=2026-04-01'
+      '/api/servers/server11/sessions/history?user=dave&ip=192.168.1.200&since=2026-04-01',
+      {}
     )
     expect(wrapper.vm.historyData).toHaveLength(1)
     expect(wrapper.vm.historyData[0].unix_user).toBe('dave')

--- a/ui/tests/Settings.spec.js
+++ b/ui/tests/Settings.spec.js
@@ -54,6 +54,7 @@ vi.mock('../src/composables/useAuth.js', () => ({
     login: vi.fn(),
     logout: vi.fn(),
   }),
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
 }))
 
 describe('Settings.vue', () => {


### PR DESCRIPTION
## Summary

- Adds `apiFetch` exported from `useAuth.js`: wraps `fetch`, intercepts 401 responses by clearing `admin` state and calling `window.location.replace('/login')`
- Returns a never-resolving Promise on 401 so calling code stops execution cleanly
- Replaces all protected `fetch('/api/...')` calls across views and components with `apiFetch`
- Auth routes (`/api/auth/login`, `/api/auth/logout`, `/api/auth/me`) keep raw `fetch` — a 401 there means wrong credentials, not session expiry
- Updates test mocks to export `apiFetch` alongside `useAuth`

## Test plan

- [ ] Session expires → any API call returns 401 → user is redirected to `/login` (no error flash)
- [ ] Wrong credentials at login still shows error message (not redirect)
- [ ] All 289 Vitest tests pass
- [ ] Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)