### PR TITLE
fix: resolve 22 CodeQL stack-trace-exposure alerts via UserError

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -16,16 +16,20 @@ _UNIX_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 VALID_ROLES = {"sysadmin", "operator", "viewer"}
 
 
+class UserError(Exception):
+    """User-facing error — safe to include in HTTP response."""
+
+
 def _validate_ip(ip: str) -> str:
     try:
         return str(ipaddress.ip_address(ip.strip()))
     except ValueError:
-        raise ValueError(f"Invalid IP address: {ip!r} (expected IPv4 or IPv6)")
+        raise UserError(f"Invalid IP address: {ip!r} (expected IPv4 or IPv6)")
 
 
 def _check_fingerprint(fp: str) -> None:
     if not _FP_RE.match(fp):
-        raise ValueError(f"Invalid fingerprint format: {fp}")
+        raise UserError(f"Invalid fingerprint format: {fp}")
 
 
 # ---------------------------------------------------------------------------
@@ -47,12 +51,12 @@ def validate_key(
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
-        raise ValueError(f"Key not found: {fingerprint}")
+        raise UserError(f"Key not found: {fingerprint}")
 
     if unix_user is not None and hostname is not None:
         server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
         if not server:
-            raise ValueError(f"Server not found: {hostname}")
+            raise UserError(f"Server not found: {hostname}")
         rows = db.query(
             """
             SELECT key_id, server_id, unix_user FROM key_authorizations
@@ -70,7 +74,7 @@ def validate_key(
             (key["id"],),
         )
     if not rows:
-        raise ValueError(f"No PENDING_REVIEW authorization for key: {fingerprint}")
+        raise UserError(f"No PENDING_REVIEW authorization for key: {fingerprint}")
 
     for row in rows:
         db.execute(
@@ -110,7 +114,7 @@ def revoke_key(
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
-        raise ValueError(f"Key not found: {fingerprint}")
+        raise UserError(f"Key not found: {fingerprint}")
 
     if hostname and unix_user:
         # --- Targeted revocation (one user on one server) ---
@@ -119,7 +123,7 @@ def revoke_key(
             (hostname,),
         )
         if not server:
-            raise ValueError(f"Server not found: {hostname}")
+            raise UserError(f"Server not found: {hostname}")
         auth = db.query_one(
             """
             SELECT status FROM key_authorizations
@@ -129,7 +133,7 @@ def revoke_key(
             (key["id"], server["id"], unix_user),
         )
         if not auth:
-            raise ValueError(
+            raise UserError(
                 f"No active authorization for {fingerprint} / user {unix_user} on {hostname}"
             )
         ssh.revoke_on_server(hostname, fingerprint, ip=server["ip_address"], unix_user=unix_user, port=server["ssh_port"])
@@ -359,7 +363,7 @@ def assign_key(fingerprint: str, owner_name: str) -> None:
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
-        raise ValueError(f"Key not found: {fingerprint}")
+        raise UserError(f"Key not found: {fingerprint}")
     db.execute(
         "UPDATE ssh_keys SET owner = %s WHERE id = %s",
         (owner_name, key["id"]),
@@ -371,7 +375,7 @@ def set_key_expiry(fingerprint: str, expires_at: datetime) -> None:
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
-        raise ValueError(f"Key not found: {fingerprint}")
+        raise UserError(f"Key not found: {fingerprint}")
     db.execute(
         "UPDATE key_authorizations SET expires_at = %s WHERE key_id = %s AND status = 'ACTIVE'",
         (expires_at, key["id"]),
@@ -383,7 +387,7 @@ def remove_key_expiry(fingerprint: str) -> None:
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
-        raise ValueError(f"Key not found: {fingerprint}")
+        raise UserError(f"Key not found: {fingerprint}")
     db.execute(
         "UPDATE key_authorizations SET expires_at = NULL WHERE key_id = %s AND status = 'ACTIVE'",
         (key["id"],),
@@ -404,12 +408,12 @@ def grant_access(
     """Create or update a key_authorization as ACTIVE for a given server."""
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (key_fp,))
     if not key:
-        raise ValueError(f"Key not found: {key_fp}")
+        raise UserError(f"Key not found: {key_fp}")
     server = db.query_one(
         "SELECT id FROM servers WHERE hostname = %s AND is_active = true", (hostname,)
     )
     if not server:
-        raise ValueError(f"Server not found: {hostname}")
+        raise UserError(f"Server not found: {hostname}")
 
     db.execute(
         """
@@ -447,20 +451,20 @@ def deploy_key(
     create key_authorization ACTIVE with optional expiry.
     """
     if not _UNIX_USER_RE.match(unix_user):
-        raise ValueError(
+        raise UserError(
             f"Invalid Unix username: '{unix_user}' "
             "(lowercase letters, digits, _ and - only, max 32 chars)"
         )
     parts = public_key.strip().split()
     if len(parts) < 2:
-        raise ValueError("Invalid key format")
+        raise UserError("Invalid key format")
     key_type = parts[0]
     key_b64 = parts[1]
     comment = parts[2] if len(parts) > 2 else unix_user
 
     valid_types = ("ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256")
     if key_type not in valid_types:
-        raise ValueError(f"Unsupported key type: {key_type}")
+        raise UserError(f"Unsupported key type: {key_type}")
 
     import base64, hashlib
     raw = base64.b64decode(key_b64)
@@ -485,7 +489,7 @@ def deploy_key(
         (hostname,),
     )
     if not server:
-        raise ValueError(f"Server not found or inactive: {hostname}")
+        raise UserError(f"Server not found or inactive: {hostname}")
 
     db.execute(
         """
@@ -542,7 +546,7 @@ def approve_request(request_id: str, admin_id: str) -> None:
         (request_id,),
     )
     if not req:
-        raise ValueError(f"Request not found or not PENDING: {request_id}")
+        raise UserError(f"Request not found or not PENDING: {request_id}")
 
     expires_at = req.get("expires_at_requested")
     if req.get("duration_hours") and not expires_at:
@@ -584,7 +588,7 @@ def reject_request(request_id: str, admin_id: str) -> None:
         (request_id,),
     )
     if not req:
-        raise ValueError(f"Request not found or not PENDING: {request_id}")
+        raise UserError(f"Request not found or not PENDING: {request_id}")
     db.execute(
         """
         UPDATE access_requests
@@ -609,7 +613,7 @@ def revoke_request(request_id: str, admin_id: str) -> None:
         (request_id,),
     )
     if not req:
-        raise ValueError(f"Request not found or not APPROVED: {request_id}")
+        raise UserError(f"Request not found or not APPROVED: {request_id}")
 
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (req["key_id"],))
     if key:
@@ -646,12 +650,12 @@ def add_server(
         "SELECT hostname FROM servers WHERE ip_address = %s", (ip,)
     )
     if existing:
-        raise ValueError(f"IP {ip} is already used by server '{existing['hostname']}'")
+        raise UserError(f"IP {ip} is already used by server '{existing['hostname']}'")
     import servers as servers_mod
     try:
         servers_mod.add_to_known_hosts(ip, ssh_port)
     except Exception as e:
-        raise ValueError(f"Cannot reach {hostname} ({ip}) for keyscan: {e}") from e
+        raise UserError(f"Cannot reach {hostname} ({ip}) for keyscan: {e}") from e
     ssh.provision_server(ip, ssh_user, ssh_password, ssh_port)
     db.execute(
         "INSERT INTO servers (hostname, ip_address, environment, os_family, ssh_port) VALUES (%s, %s, %s, %s, %s)",
@@ -682,7 +686,7 @@ def provision_server(hostname: str, ssh_user: str, ssh_password: str, ssh_port: 
         (hostname,),
     )
     if not server:
-        raise ValueError(f"Server not found or inactive: {hostname}")
+        raise UserError(f"Server not found or inactive: {hostname}")
     ssh.provision_server(server["ip_address"], ssh_user, ssh_password, ssh_port)
     # Update ssh_port in DB after successful provisioning
     db.execute(
@@ -708,7 +712,7 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
         "SELECT id FROM servers WHERE hostname = %s AND is_active = true", (hostname,)
     )
     if not server:
-        raise ValueError(f"Active server not found: {hostname}")
+        raise UserError(f"Active server not found: {hostname}")
     db.execute("UPDATE servers SET is_active = false WHERE id = %s", (server["id"],))
     db.execute(
         """
@@ -731,14 +735,14 @@ def update_server(
         (hostname,),
     )
     if not server:
-        raise ValueError(f"Server not found: {hostname}")
+        raise UserError(f"Server not found: {hostname}")
 
     existing = db.query_one(
         "SELECT hostname FROM servers WHERE ip_address = %s AND hostname != %s",
         (new_ip, hostname),
     )
     if existing:
-        raise ValueError(f"IP {new_ip} is already used by server '{existing['hostname']}'")
+        raise UserError(f"IP {new_ip} is already used by server '{existing['hostname']}'")
 
     old_ip = server["ip_address"]
     old_env = server["environment"]
@@ -749,7 +753,7 @@ def update_server(
         try:
             servers_mod.add_to_known_hosts(new_ip, ssh_port)
         except Exception as e:
-            raise ValueError(f"Cannot reach {hostname} ({new_ip}) for keyscan: {e}") from e
+            raise UserError(f"Cannot reach {hostname} ({new_ip}) for keyscan: {e}") from e
 
     db.execute(
         "UPDATE servers SET ip_address = %s, environment = %s, os_family = %s, ssh_port = %s WHERE hostname = %s",
@@ -781,7 +785,7 @@ def enable_server(hostname: str, admin_id: str | None = None) -> None:
         "SELECT id FROM servers WHERE hostname = %s AND is_active = false", (hostname,)
     )
     if not server:
-        raise ValueError(f"Inactive server not found: {hostname}")
+        raise UserError(f"Inactive server not found: {hostname}")
     db.execute("UPDATE servers SET is_active = true WHERE id = %s", (server["id"],))
     db.execute(
         """
@@ -796,7 +800,7 @@ def delete_server(hostname: str, admin_id: str | None = None) -> None:
     """Hard delete a server and all related data."""
     server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
     if not server:
-        raise ValueError(f"Server not found: {hostname}")
+        raise UserError(f"Server not found: {hostname}")
     sid = server["id"]
     db.execute("DELETE FROM audit_log WHERE target_server = %s", (sid,))
     db.execute("DELETE FROM access_requests WHERE server_id = %s", (sid,))
@@ -809,7 +813,7 @@ def delete_server(hostname: str, admin_id: str | None = None) -> None:
 # ---------------------------------------------------------------------------
 
 def _validate_password_strength(password: str) -> None:
-    """Raise ValueError if password does not meet complexity requirements."""
+    """Raise UserError if password does not meet complexity requirements."""
     import re
     errors = []
     if len(password) < 8:
@@ -823,16 +827,16 @@ def _validate_password_strength(password: str) -> None:
     if not re.search(r"[!@#$%^&*()\-_=+\[\]{}|;:'\",.<>?/\\`~]", password):
         errors.append("at least one special character")
     if errors:
-        raise ValueError("Insufficient password: " + ", ".join(errors))
+        raise UserError("Insufficient password: " + ", ".join(errors))
 
 
 def add_admin(username: str, email: str, password: str, admin_id: str | None = None, role: str = "operator") -> dict:
     """Insert a new administrator and log ADMIN_ADDED."""
     from werkzeug.security import generate_password_hash
     if not email or not email.strip():
-        raise ValueError("email required")
+        raise UserError("email required")
     if role not in VALID_ROLES:
-        raise ValueError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
+        raise UserError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
     _validate_password_strength(password)
     password_hash = generate_password_hash(password)
     db.execute(
@@ -858,7 +862,7 @@ def change_password(username: str, new_password: str) -> None:
         "SELECT id FROM administrators WHERE username = %s AND is_active = true", (username,)
     )
     if not admin:
-        raise ValueError(f"Active admin not found: {username}")
+        raise UserError(f"Active admin not found: {username}")
     db.execute(
         "UPDATE administrators SET password_hash = %s, password_changed_at = now() WHERE id = %s",
         (generate_password_hash(new_password), admin["id"]),
@@ -872,7 +876,7 @@ def reset_password(username: str, new_password: str) -> None:
     _validate_password_strength(new_password)
     admin = db.query_one("SELECT id FROM administrators WHERE username = %s", (username,))
     if not admin:
-        raise ValueError(f"Admin not found: {username}")
+        raise UserError(f"Admin not found: {username}")
     db.execute(
         "UPDATE administrators SET password_hash = %s, password_changed_at = now() WHERE id = %s",
         (generate_password_hash(new_password), admin["id"]),
@@ -886,20 +890,20 @@ def reset_password(username: str, new_password: str) -> None:
 def update_admin(username: str, email: str | None, role: str, admin_id: str) -> dict:
     """Update administrator email and role. Log ADMIN_UPDATED."""
     if not email or not email.strip():
-        raise ValueError("email required")
+        raise UserError("email required")
     if role not in VALID_ROLES:
-        raise ValueError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
+        raise UserError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
     admin = db.query_one(
         "SELECT id, email, role FROM administrators WHERE username = %s", (username,)
     )
     if not admin:
-        raise ValueError(f"Admin not found: {username}")
+        raise UserError(f"Admin not found: {username}")
 
     current_admin = db.query_one(
         "SELECT username FROM administrators WHERE id = %s", (admin_id,)
     )
     if current_admin and current_admin["username"] == username and admin["role"] != role:
-        raise ValueError("Cannot change your own role")
+        raise UserError("Cannot change your own role")
 
     if admin["role"] == "sysadmin" and role != "sysadmin":
         other_sysadmins = db.query_one(
@@ -907,7 +911,7 @@ def update_admin(username: str, email: str | None, role: str, admin_id: str) -> 
             (admin["id"],),
         )
         if not other_sysadmins or other_sysadmins["n"] == 0:
-            raise ValueError("Cannot demote last active sysadmin")
+            raise UserError("Cannot demote last active sysadmin")
 
     old_email = admin["email"]
     old_role = admin["role"]
@@ -941,14 +945,14 @@ def disable_admin(username: str, admin_id: str | None = None) -> None:
         "SELECT id, role FROM administrators WHERE username = %s AND is_active = true", (username,)
     )
     if not admin:
-        raise ValueError(f"Active admin not found: {username}")
+        raise UserError(f"Active admin not found: {username}")
     if admin["role"] == "sysadmin":
         other_sysadmins = db.query_one(
             "SELECT COUNT(*) AS n FROM administrators WHERE role = 'sysadmin' AND is_active = true AND id != %s",
             (admin["id"],),
         )
         if not other_sysadmins or other_sysadmins["n"] == 0:
-            raise ValueError("Cannot disable last active sysadmin")
+            raise UserError("Cannot disable last active sysadmin")
     db.execute("UPDATE administrators SET is_active = false WHERE id = %s", (admin["id"],))
     db.execute(
         """
@@ -965,7 +969,7 @@ def enable_admin(username: str, admin_id: str | None = None) -> None:
         "SELECT id FROM administrators WHERE username = %s AND is_active = false", (username,)
     )
     if not admin:
-        raise ValueError(f"Inactive admin not found: {username}")
+        raise UserError(f"Inactive admin not found: {username}")
     db.execute("UPDATE administrators SET is_active = true WHERE id = %s", (admin["id"],))
     db.execute(
         """
@@ -982,7 +986,7 @@ def toggle_alerts(username: str, receive_alerts: bool) -> dict:
         "SELECT id FROM administrators WHERE username = %s AND is_active = true", (username,)
     )
     if not admin:
-        raise ValueError(f"Active admin not found: {username}")
+        raise UserError(f"Active admin not found: {username}")
     db.execute(
         "UPDATE administrators SET receive_alerts = %s WHERE id = %s",
         (receive_alerts, admin["id"]),
@@ -996,7 +1000,7 @@ def delete_admin(username: str, admin_id: str | None = None) -> None:
         "SELECT id FROM administrators WHERE username = %s", (username,)
     )
     if not admin:
-        raise ValueError(f"Admin not found: {username}")
+        raise UserError(f"Admin not found: {username}")
     db.execute(
         """
         INSERT INTO audit_log (action, performed_by, details)
@@ -1014,15 +1018,15 @@ def delete_admin(username: str, admin_id: str | None = None) -> None:
 def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     """Lock a Unix user account on a remote server."""
     if unix_user == ssh.SSH_USER:
-        raise ValueError(f"Cannot lock the collector account '{ssh.SSH_USER}'")
+        raise UserError(f"Cannot lock the collector account '{ssh.SSH_USER}'")
     if not _UNIX_USER_RE.match(unix_user):
-        raise ValueError(f"Invalid Unix username: '{unix_user}'")
+        raise UserError(f"Invalid Unix username: '{unix_user}'")
     server = db.query_one(
         "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,)
     )
     if not server:
-        raise ValueError(f"Server not found or inactive: {hostname}")
+        raise UserError(f"Server not found or inactive: {hostname}")
     ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
     ssh.lock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
     db.execute(
@@ -1036,15 +1040,15 @@ def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
 def unlock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     """Unlock a Unix user account on a remote server."""
     if unix_user == ssh.SSH_USER:
-        raise ValueError(f"Cannot unlock the collector account '{ssh.SSH_USER}'")
+        raise UserError(f"Cannot unlock the collector account '{ssh.SSH_USER}'")
     if not _UNIX_USER_RE.match(unix_user):
-        raise ValueError(f"Invalid Unix username: '{unix_user}'")
+        raise UserError(f"Invalid Unix username: '{unix_user}'")
     server = db.query_one(
         "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,)
     )
     if not server:
-        raise ValueError(f"Server not found or inactive: {hostname}")
+        raise UserError(f"Server not found or inactive: {hostname}")
     ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
     ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
     db.execute(

--- a/app/servers.py
+++ b/app/servers.py
@@ -1,3 +1,4 @@
+import ipaddress
 import os
 import subprocess
 
@@ -26,6 +27,7 @@ def _hostname_in_known_hosts(hostname: str, known_hosts: str = KNOWN_HOSTS) -> b
 
 def add_to_known_hosts(ip: str, port: int = 22, known_hosts: str = KNOWN_HOSTS) -> None:
     """Run ssh-keyscan on ip (and port) and append to known_hosts if not present."""
+    ip = str(ipaddress.ip_address(ip.strip()))
     if _hostname_in_known_hosts(ip, known_hosts):
         return
     cmd = ["ssh-keyscan", "-H", "-T", "10"]

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -9,6 +9,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import actions
+from actions import UserError
 
 
 ADMIN_ID = str(uuid.uuid4())
@@ -39,7 +40,7 @@ def test_actions_validate_key_sets_active(sample_key, sample_server):
 def test_actions_validate_key_raises_if_key_not_found(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.validate_key(sample_key["fingerprint"], ADMIN_ID)
 
 
@@ -47,7 +48,7 @@ def test_actions_validate_key_raises_if_no_pending(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": KEY_ID}
         mock_db.query.return_value = []
-        with pytest.raises(ValueError, match="PENDING_REVIEW"):
+        with pytest.raises(UserError, match="PENDING_REVIEW"):
             actions.validate_key(sample_key["fingerprint"], ADMIN_ID)
 
 
@@ -90,7 +91,7 @@ def test_actions_revoke_key_scenario1_logs_key_revoked(sample_key):
 def test_actions_revoke_key_raises_if_key_not_found(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "reason")
 
 
@@ -273,7 +274,7 @@ def test_actions_assign_key_updates_owner(sample_key):
 def test_actions_assign_key_raises_if_key_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Key not found"):
+        with pytest.raises(UserError, match="Key not found"):
             actions.assign_key("SHA256:xxx", "Alice Martin")
 
 
@@ -292,7 +293,7 @@ def test_actions_set_key_expiry_updates_active_auths(sample_key):
 def test_actions_set_key_expiry_raises_if_key_not_found(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError):
+        with pytest.raises(UserError):
             actions.set_key_expiry(sample_key["fingerprint"], _future())
 
 
@@ -325,7 +326,7 @@ def test_actions_grant_access_returns_ids(sample_key, sample_server):
 def test_actions_grant_access_raises_if_server_not_found(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [{"id": KEY_ID}, None]
-        with pytest.raises(ValueError, match="Server not found"):
+        with pytest.raises(UserError, match="Server not found"):
             actions.grant_access(sample_key["fingerprint"], "ghost", _future(), "x", ADMIN_ID)
 
 
@@ -349,7 +350,7 @@ def test_actions_approve_request_sets_approved_and_creates_auth():
 def test_actions_approve_request_raises_if_not_pending():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not PENDING"):
+        with pytest.raises(UserError, match="not PENDING"):
             actions.approve_request(REQUEST_ID, ADMIN_ID)
 
 
@@ -377,7 +378,7 @@ def test_actions_reject_request_sets_rejected():
 def test_actions_reject_request_raises_if_not_pending():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError):
+        with pytest.raises(UserError):
             actions.reject_request(REQUEST_ID, ADMIN_ID)
 
 
@@ -484,7 +485,7 @@ def test_actions_disable_server_sets_inactive(sample_server):
 def test_actions_disable_server_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.disable_server("ghost")
 
 
@@ -526,7 +527,7 @@ def test_actions_provision_server_password_not_logged(sample_server):
 def test_actions_provision_server_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.provision_server("ghost", "root", "password", 22, ADMIN_ID)
 
 
@@ -553,7 +554,7 @@ def test_actions_disable_admin_sets_inactive():
 def test_actions_disable_admin_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.disable_admin("ghost")
 
 
@@ -564,7 +565,7 @@ def test_actions_disable_admin_prevents_last_sysadmin():
             {"id": ADMIN_ID, "role": "sysadmin"},
             {"n": 0},
         ]
-        with pytest.raises(ValueError, match="Cannot disable last active sysadmin"):
+        with pytest.raises(UserError, match="Cannot disable last active sysadmin"):
             actions.disable_admin("admin", ADMIN_ID)
 
 
@@ -603,7 +604,7 @@ def test_actions_enable_server_logs_server_added():
 def test_actions_enable_server_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.enable_server("ghost")
 
 
@@ -631,7 +632,7 @@ def test_actions_delete_server_removes_authorizations_and_requests():
 def test_actions_delete_server_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.delete_server("ghost")
 
 
@@ -658,7 +659,7 @@ def test_actions_enable_admin_logs_admin_enabled():
 def test_actions_enable_admin_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(UserError, match="not found"):
             actions.enable_admin("ghost")
 
 
@@ -685,7 +686,7 @@ def test_actions_delete_admin_logs_admin_deleted():
 def test_actions_delete_admin_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Admin not found"):
+        with pytest.raises(UserError, match="Admin not found"):
             actions.delete_admin("ghost")
 
 
@@ -717,7 +718,7 @@ def test_actions_update_admin_not_found():
     """update_admin lève ValueError si admin introuvable."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Admin not found"):
+        with pytest.raises(UserError, match="Admin not found"):
             actions.update_admin("ghost", "new@example.com", "operator", ADMIN_ID)
 
 
@@ -727,7 +728,7 @@ def test_actions_update_admin_self_role_change_raises():
     current_admin = {"username": "admin"}
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [admin, current_admin]
-        with pytest.raises(ValueError, match="Cannot change your own role"):
+        with pytest.raises(UserError, match="Cannot change your own role"):
             actions.update_admin("admin", "admin@example.com", "operator", ADMIN_ID)
 
 
@@ -737,7 +738,7 @@ def test_actions_update_admin_prevents_demoting_last_sysadmin():
     current_admin = {"username": "other-admin"}
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [admin, current_admin, {"n": 0}]
-        with pytest.raises(ValueError, match="Cannot demote last active sysadmin"):
+        with pytest.raises(UserError, match="Cannot demote last active sysadmin"):
             actions.update_admin("admin", "admin@example.com", "operator", ADMIN_ID)
 
 
@@ -784,7 +785,7 @@ def test_actions_deploy_key_invalid_key_type(sample_server):
         mock_db.query_one.return_value = {
             "id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22
         }
-        with pytest.raises(ValueError, match="Unsupported key type"):
+        with pytest.raises(UserError, match="Unsupported key type"):
             actions.deploy_key(
                 public_key="ssh-dss AAAA test",
                 unix_user="alice",
@@ -798,7 +799,7 @@ def test_actions_deploy_key_invalid_key_type(sample_server):
 def test_actions_deploy_key_server_not_found(sample_key):
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Server not found"):
+        with pytest.raises(UserError, match="Server not found"):
             actions.deploy_key(
                 public_key=sample_key["public_key"],
                 unix_user="alice",
@@ -810,7 +811,7 @@ def test_actions_deploy_key_server_not_found(sample_key):
 
 
 def test_actions_deploy_key_invalid_format():
-    with pytest.raises(ValueError, match="Invalid key format"):
+    with pytest.raises(UserError, match="Invalid key format"):
         actions.deploy_key(
             public_key="notakey",
             unix_user="alice",
@@ -822,7 +823,7 @@ def test_actions_deploy_key_invalid_format():
 
 
 def test_actions_deploy_key_invalid_unix_user_with_space():
-    with pytest.raises(ValueError, match="Invalid Unix username"):
+    with pytest.raises(UserError, match="Invalid Unix username"):
         actions.deploy_key(
             public_key="ssh-ed25519 AAAA test",
             unix_user="zoor dupont",
@@ -834,7 +835,7 @@ def test_actions_deploy_key_invalid_unix_user_with_space():
 
 
 def test_actions_deploy_key_invalid_unix_user_uppercase():
-    with pytest.raises(ValueError, match="Invalid Unix username"):
+    with pytest.raises(UserError, match="Invalid Unix username"):
         actions.deploy_key(
             public_key="ssh-ed25519 AAAA test",
             unix_user="Alice",
@@ -867,28 +868,28 @@ def test_actions_deploy_key_valid_unix_user_passes_check(sample_server, sample_k
 # ---------------------------------------------------------------------------
 
 def test_actions_validate_key_rejects_invalid_fingerprint_format():
-    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+    with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.validate_key("not-a-fingerprint", ADMIN_ID)
 
 
 def test_actions_revoke_key_rejects_invalid_fingerprint_format():
-    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+    with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.revoke_key("INVALID:abc", ADMIN_ID, "test")
 
 
 def test_actions_assign_key_rejects_invalid_fingerprint_format():
-    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+    with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.assign_key("sha256:lowercase", "alice")
 
 
 def test_actions_set_expiry_rejects_invalid_fingerprint_format():
     from datetime import datetime, timezone
-    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+    with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.set_key_expiry("bad\nfingerprint", datetime.now(tz=timezone.utc))
 
 
 def test_actions_remove_expiry_rejects_invalid_fingerprint_format():
-    with pytest.raises(ValueError, match="Invalid fingerprint format"):
+    with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.remove_key_expiry("SHA256:bad/char!")
 
 
@@ -916,14 +917,14 @@ def test_actions_lock_user_success():
 
 
 def test_actions_lock_user_invalid_username():
-    with pytest.raises(ValueError, match="Invalid Unix username"):
+    with pytest.raises(UserError, match="Invalid Unix username"):
         actions.lock_user("bad user", "server-test-01", ADMIN_ID)
 
 
 def test_actions_lock_user_server_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Server not found or inactive"):
+        with pytest.raises(UserError, match="Server not found or inactive"):
             actions.lock_user("alice", "unknown-server", ADMIN_ID)
 
 
@@ -941,21 +942,21 @@ def test_actions_unlock_user_success():
 
 
 def test_actions_unlock_user_invalid_username():
-    with pytest.raises(ValueError, match="Invalid Unix username"):
+    with pytest.raises(UserError, match="Invalid Unix username"):
         actions.unlock_user("bad@user", "server-test-01", ADMIN_ID)
 
 
 def test_actions_lock_user_ssh_user_raises():
     with patch("actions.ssh") as mock_ssh:
         mock_ssh.SSH_USER = "audit-collector"
-        with pytest.raises(ValueError, match="Cannot lock the collector account"):
+        with pytest.raises(UserError, match="Cannot lock the collector account"):
             actions.lock_user("audit-collector", "server-test-01", ADMIN_ID)
 
 
 def test_actions_unlock_user_ssh_user_raises():
     with patch("actions.ssh") as mock_ssh:
         mock_ssh.SSH_USER = "audit-collector"
-        with pytest.raises(ValueError, match="Cannot unlock the collector account"):
+        with pytest.raises(UserError, match="Cannot unlock the collector account"):
             actions.unlock_user("audit-collector", "server-test-01", ADMIN_ID)
 
 
@@ -1089,7 +1090,7 @@ def test_actions_validate_key_scoped_raises_if_server_not_found(sample_key):
             {"id": KEY_ID},  # ssh_keys found
             None,            # server not found
         ]
-        with pytest.raises(ValueError, match="Server not found"):
+        with pytest.raises(UserError, match="Server not found"):
             actions.validate_key(sample_key["fingerprint"], ADMIN_ID, unix_user="alice", hostname="unknown")
 
 
@@ -1125,25 +1126,25 @@ def test_actions_update_server_not_found():
     """Si le serveur n'existe pas, ValueError levée."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Server not found"):
+        with pytest.raises(UserError, match="Server not found"):
             actions.update_server("unknown-server", "10.0.0.1", "lab", "rhel", ADMIN_ID)
 
 
 def test_actions_add_server_rejects_invalid_ip():
     for bad in ["notanip", "999.1.1.1", "192.168.1", "hello world"]:
-        with pytest.raises(ValueError, match="Invalid IP"):
+        with pytest.raises(UserError, match="Invalid IP"):
             actions.add_server("h", bad, "root", "x", "lab", None, 22, ADMIN_ID)
 
 
 def test_actions_update_server_rejects_invalid_ip():
-    with pytest.raises(ValueError, match="Invalid IP"):
+    with pytest.raises(UserError, match="Invalid IP"):
         actions.update_server("h", "not-an-ip", "lab", None, ADMIN_ID)
 
 
 def test_actions_add_server_rejects_duplicate_ip():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"hostname": "existing-server"}
-        with pytest.raises(ValueError, match="already used by server"):
+        with pytest.raises(UserError, match="already used by server"):
             actions.add_server("new-host", "10.0.0.1", "root", "x", "lab", None, 22, ADMIN_ID)
 
 
@@ -1151,7 +1152,7 @@ def test_actions_update_server_rejects_duplicate_ip():
     server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22}
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [server, {"hostname": "other-server"}]
-        with pytest.raises(ValueError, match="already used by server"):
+        with pytest.raises(UserError, match="already used by server"):
             actions.update_server("server-test-01", "10.0.0.2", "lab", None, 22, ADMIN_ID)
 
 
@@ -1161,26 +1162,26 @@ def test_actions_update_server_rejects_duplicate_ip():
 
 def test_actions_add_admin_empty_email_raises():
     with patch("actions.db") as mock_db:
-        with pytest.raises(ValueError, match="email required"):
+        with pytest.raises(UserError, match="email required"):
             actions.add_admin("user", "", "P@ssw0rd1!", None)
 
 
 def test_actions_add_admin_invalid_role_raises():
     with patch("actions.db") as mock_db:
-        with pytest.raises(ValueError, match="Invalid role"):
+        with pytest.raises(UserError, match="Invalid role"):
             actions.add_admin("user", "x@x.com", "P@ssw0rd1!", None, role="superadmin")
 
 
 def test_actions_update_admin_empty_email_raises():
     with patch("actions.db") as mock_db:
-        with pytest.raises(ValueError, match="email required"):
+        with pytest.raises(UserError, match="email required"):
             actions.update_admin("user", "", "operator", ADMIN_ID)
 
 
 def test_actions_update_admin_invalid_role_raises():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": ADMIN_ID, "email": "test@example.com", "role": "operator"}
-        with pytest.raises(ValueError, match="Invalid role"):
+        with pytest.raises(UserError, match="Invalid role"):
             actions.update_admin("user", "x@x.com", "superadmin", ADMIN_ID)
 
 
@@ -1212,7 +1213,7 @@ def test_actions_toggle_alerts_disable():
 def test_actions_toggle_alerts_unknown_admin_raises():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Active admin not found"):
+        with pytest.raises(UserError, match="Active admin not found"):
             actions.toggle_alerts("ghost", True)
 
 
@@ -1248,12 +1249,12 @@ def test_actions_reset_password_works_for_disabled_admin():
 def test_actions_reset_password_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
-        with pytest.raises(ValueError, match="Admin not found"):
+        with pytest.raises(UserError, match="Admin not found"):
             actions.reset_password("ghost", "N3wStr0ng#Pass!")
 
 
 def test_actions_reset_password_rejects_weak_password():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": ADMIN_ID}
-        with pytest.raises(ValueError):
+        with pytest.raises(UserError):
             actions.reset_password("alice", "weak")

--- a/app/tests/test_servers.py
+++ b/app/tests/test_servers.py
@@ -63,11 +63,11 @@ def test_servers_load_yml_missing_file_raises():
 
 def test_servers_add_known_hosts_skips_if_already_present():
     with tempfile.NamedTemporaryFile("w", suffix="known_hosts", delete=False) as f:
-        f.write("|1|abc= ssh-ed25519 AAAA server-prod-01\n")
+        f.write("|1|abc= ssh-ed25519 AAAA 192.168.1.10\n")
         path = f.name
     try:
         with patch("subprocess.run") as mock_run:
-            servers.add_to_known_hosts("server-prod-01", known_hosts=path)
+            servers.add_to_known_hosts("192.168.1.10", known_hosts=path)
             mock_run.assert_not_called()
     finally:
         os.unlink(path)
@@ -81,11 +81,11 @@ def test_servers_add_known_hosts_calls_ssh_keyscan_if_absent():
             mock_run.return_value = MagicMock(
                 stdout="|1|hash= ssh-ed25519 AAAA\n", returncode=0
             )
-            servers.add_to_known_hosts("new-host", known_hosts=path)
+            servers.add_to_known_hosts("10.0.0.1", known_hosts=path)
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
             assert "ssh-keyscan" in args
-            assert "new-host" in args
+            assert "10.0.0.1" in args
             assert "-p" not in args
     finally:
         os.unlink(path)
@@ -99,11 +99,11 @@ def test_servers_add_known_hosts_uses_custom_port():
             mock_run.return_value = MagicMock(
                 stdout="|1|hash= ssh-ed25519 AAAA\n", returncode=0
             )
-            servers.add_to_known_hosts("new-host", port=65500, known_hosts=path)
+            servers.add_to_known_hosts("10.0.0.1", port=65500, known_hosts=path)
             args = mock_run.call_args[0][0]
             assert "-p" in args
             assert "65500" in args
-            assert "new-host" in args
+            assert "10.0.0.1" in args
     finally:
         os.unlink(path)
 
@@ -114,12 +114,12 @@ def test_servers_add_known_hosts_appends_output_to_file():
     try:
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(
-                stdout="|1|hash= ssh-ed25519 KEY new-host\n", returncode=0
+                stdout="|1|hash= ssh-ed25519 KEY 10.0.0.1\n", returncode=0
             )
-            servers.add_to_known_hosts("new-host", known_hosts=path)
+            servers.add_to_known_hosts("10.0.0.1", known_hosts=path)
         with open(path) as f:
             content = f.read()
-        assert "new-host" in content
+        assert "10.0.0.1" in content
     finally:
         os.unlink(path)
 

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -10,6 +10,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import web
+from actions import UserError
 
 ADMIN_ID = str(uuid.uuid4())
 KEY_ID = str(uuid.uuid4())
@@ -214,7 +215,7 @@ def test_web_revoke_key_returns_401_if_not_authenticated(client):
 def test_web_revoke_key_returns_404_if_key_not_found(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.revoke_key.side_effect = ValueError("Key not found")
+        mock_actions.revoke_key.side_effect = UserError("Key not found")
         resp = auth_client.post(
             f"/api/keys/revoke/{FINGERPRINT}",
             json={"reason": "x"},
@@ -379,7 +380,7 @@ def test_web_update_server_unauthenticated_returns_401(client):
 def test_web_update_server_not_found_returns_404(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.update_server.side_effect = ValueError("Server not found")
+        mock_actions.update_server.side_effect = UserError("Server not found")
         resp = auth_client.put(
             "/api/servers/ghost",
             json={"ip": "10.0.0.2", "environment": "lab"},
@@ -402,7 +403,7 @@ def test_web_enable_server_returns_200(auth_client):
 def test_web_enable_server_returns_404_if_not_found(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.enable_server.side_effect = ValueError("not found")
+        mock_actions.enable_server.side_effect = UserError("not found")
         resp = auth_client.put("/api/servers/ghost/enable")
         assert resp.status_code == 404
 
@@ -422,7 +423,7 @@ def test_web_delete_server_returns_200(auth_client):
 def test_web_delete_server_returns_404_if_not_found(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.delete_server.side_effect = ValueError("not found")
+        mock_actions.delete_server.side_effect = UserError("not found")
         resp = auth_client.delete("/api/servers/ghost")
         assert resp.status_code == 404
 
@@ -470,7 +471,7 @@ def test_web_provision_server_invalid_port(auth_client):
 def test_web_provision_server_not_found(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.provision_server.side_effect = ValueError("Server not found")
+        mock_actions.provision_server.side_effect = UserError("Server not found")
         resp = auth_client.post(
             "/api/servers/ghost/provision",
             json={"ssh_user": "root", "ssh_password": "secret", "ssh_port": 22},
@@ -727,7 +728,7 @@ def test_web_delete_admin_self_returns_403(auth_client):
 def test_web_delete_admin_with_references_returns_400(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.delete_admin.side_effect = ValueError("existing audit records reference this account")
+        mock_actions.delete_admin.side_effect = UserError("existing audit records reference this account")
         resp = auth_client.delete("/api/admins/someuser")
         assert resp.status_code == 400
 
@@ -764,7 +765,7 @@ def test_web_update_admin_returns_401_unauthenticated(client):
 def test_web_update_admin_returns_404_not_found(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.update_admin.side_effect = ValueError("Admin not found: ghost")
+        mock_actions.update_admin.side_effect = UserError("Admin not found: ghost")
         resp = auth_client.put("/api/admins/ghost", json={
             "email": "new@example.com",
             "role": "operator"
@@ -775,7 +776,7 @@ def test_web_update_admin_returns_404_not_found(auth_client):
 def test_web_update_admin_returns_403_self_role(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.update_admin.side_effect = ValueError("Cannot change your own role")
+        mock_actions.update_admin.side_effect = UserError("Cannot change your own role")
         resp = auth_client.put("/api/admins/admin", json={
             "email": "admin@example.com",
             "role": "operator"
@@ -1029,7 +1030,7 @@ def test_web_log_injection_newlines_sanitized_in_warning(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
          patch("web.logging") as mock_logging:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.revoke_key.side_effect = ValueError(
+        mock_actions.revoke_key.side_effect = UserError(
             "Key not found: SHA256:test\nWARNING:root:FAKE_ALERT"
         )
         resp = auth_client.post(
@@ -1048,7 +1049,7 @@ def test_web_log_injection_carriage_return_sanitized(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
          patch("web.logging") as mock_logging:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.revoke_key.side_effect = ValueError(
+        mock_actions.revoke_key.side_effect = UserError(
             "Key not found: SHA256:test\rINJECTED"
         )
         resp = auth_client.post(
@@ -1341,7 +1342,7 @@ def test_web_toggle_alerts_non_bool_returns_400(auth_client):
 def test_web_toggle_alerts_unknown_admin_returns_404(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
-        mock_actions.toggle_alerts.side_effect = ValueError("Active admin not found")
+        mock_actions.toggle_alerts.side_effect = UserError("Active admin not found")
         resp = auth_client.put("/api/admins/ghost/alerts", json={"receive_alerts": True})
     assert resp.status_code == 404
 
@@ -1388,7 +1389,7 @@ def test_web_test_smtp_returns_502_on_msmtp_error(auth_client):
         mock_alerts.send_test_email.side_effect = RuntimeError("connection refused")
         resp = auth_client.post("/api/system/test-smtp")
     assert resp.status_code == 502
-    assert "connection refused" in resp.get_json()["error"]
+    assert resp.get_json()["error"] == "SMTP test failed"
 
 
 def test_web_test_smtp_returns_500_when_msmtp_not_found(auth_client):

--- a/app/web.py
+++ b/app/web.py
@@ -14,6 +14,7 @@ from flask import Flask, g, jsonify, request, session
 from werkzeug.security import check_password_hash
 
 import actions
+from actions import UserError
 import alerts
 import collect as collect_mod
 import db
@@ -286,12 +287,12 @@ def add_server():
         return jsonify(server), 201
     except KeyError as e:
         return jsonify({"error": f"Missing field: {e}"}), 400
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
     except RuntimeError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
-        return jsonify({"error": str(e), "error_code": _ssh_error_code(str(e))}), 422
+        return jsonify({"error": "SSH operation failed", "error_code": _ssh_error_code(str(e))}), 422
 
 
 @app.route("/api/servers/<hostname>/provision", methods=["POST"])
@@ -312,10 +313,11 @@ def provision_server_route(hostname):
     try:
         actions.provision_server(hostname, ssh_user, ssh_password, ssh_port, g.admin_id)
         return jsonify({"message": "Server provisioned successfully"})
-    except ValueError as exc:
+    except UserError as exc:
         return jsonify({"error": str(exc)}), 404
     except RuntimeError as exc:
-        return jsonify({"error": str(exc), "error_code": _ssh_error_code(str(exc))}), 422
+        logging.warning("%s", str(exc).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": "SSH operation failed", "error_code": _ssh_error_code(str(exc))}), 422
 
 
 @app.route("/api/servers/<hostname>", methods=["PUT"])
@@ -329,9 +331,12 @@ def update_server(hostname):
             data.get("os_family"), data.get("ssh_port", 22), g.admin_id,
         )
         return jsonify({"message": "Server updated"})
-    except (KeyError, ValueError) as e:
+    except KeyError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
-        return jsonify({"error": str(e)}), 404 if isinstance(e, ValueError) else 400
+        return jsonify({"error": str(e)}), 400
+    except UserError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 404
 
 
 @app.route("/api/servers/<hostname>/disable", methods=["PUT"])
@@ -341,7 +346,7 @@ def disable_server(hostname):
     try:
         actions.disable_server(hostname, g.admin_id)
         return jsonify({"status": "disabled"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -353,7 +358,7 @@ def enable_server(hostname):
     try:
         actions.enable_server(hostname, g.admin_id)
         return jsonify({"status": "enabled"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -365,7 +370,7 @@ def delete_server(hostname):
     try:
         actions.delete_server(hostname, g.admin_id)
         return jsonify({"status": "deleted"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -432,9 +437,9 @@ def refresh_server_sessions(hostname):
     try:
         ssh.collect_sessions_on_server(hostname, server["id"], ip)
         return jsonify({"status": "refreshed"})
-    except Exception as e:
+    except Exception:
         logging.exception("collect_sessions_on_server failed on %s (%s)", hostname, ip)
-        return jsonify({"error": str(e) or repr(e)}), 502
+        return jsonify({"error": "Internal server error"}), 502
 
 
 @app.route("/api/servers/<hostname>/sessions/history", methods=["GET"])
@@ -538,7 +543,7 @@ def validate_key(fingerprint):
     try:
         actions.validate_key(fingerprint, g.admin_id, unix_user=unix_user, hostname=hostname)
         return jsonify({"status": "validated"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -556,7 +561,7 @@ def revoke_key(fingerprint):
     try:
         actions.revoke_key(fingerprint, g.admin_id, reason, hostname=hostname, unix_user=unix_user)
         return jsonify({"status": "revoked"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -569,7 +574,10 @@ def assign_key(fingerprint):
     try:
         actions.assign_key(fingerprint, data["owner_name"])
         return jsonify({"status": "assigned"})
-    except (KeyError, ValueError) as e:
+    except KeyError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
@@ -588,7 +596,7 @@ def set_key_expiry(fingerprint):
     try:
         actions.set_key_expiry(fingerprint, expires_at)
         return jsonify({"status": "expiry set", "expires_at": expires_at.isoformat()})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -600,7 +608,7 @@ def remove_key_expiry(fingerprint):
     try:
         actions.remove_key_expiry(fingerprint)
         return jsonify({"status": "expiry removed"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -651,7 +659,10 @@ def grant_access():
         )
         result["expires_at"] = result["expires_at"].isoformat()
         return jsonify(result), 201
-    except (KeyError, ValueError) as e:
+    except KeyError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
@@ -694,12 +705,12 @@ def api_deploy_key():
             admin_id=g.admin_id,
         )
         return jsonify(result), 201
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
-    except Exception as e:
+    except Exception:
         logging.exception("deploy_key failed")
-        return jsonify({"error": "internal server error"}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route("/api/access/lock-user", methods=["POST"])
@@ -714,12 +725,12 @@ def api_lock_user():
     try:
         result = actions.lock_user(unix_user, hostname, g.admin_id)
         return jsonify(result), 200
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
     except Exception:
         logging.exception("lock_user failed")
-        return jsonify({"error": "internal server error"}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route("/api/access/unlock-user", methods=["POST"])
@@ -734,12 +745,12 @@ def api_unlock_user():
     try:
         result = actions.unlock_user(unix_user, hostname, g.admin_id)
         return jsonify(result), 200
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
     except Exception:
         logging.exception("unlock_user failed")
-        return jsonify({"error": "internal server error"}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @app.route("/api/access/deployed-users", methods=["GET"])
@@ -803,9 +814,15 @@ def request_access():
             ),
         )
         return jsonify({"status": "requested"}), 201
-    except (KeyError, Exception) as e:
-        logging.exception("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+    except KeyError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
+    except UserError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logging.exception("request_access failed")
+        return jsonify({"error": "Internal server error"}), 400
 
 
 @app.route("/api/access/<request_id>/approve", methods=["POST"])
@@ -815,7 +832,7 @@ def approve_request(request_id):
     try:
         actions.approve_request(request_id, g.admin_id)
         return jsonify({"status": "approved"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -827,7 +844,7 @@ def reject_request(request_id):
     try:
         actions.reject_request(request_id, g.admin_id)
         return jsonify({"status": "rejected"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -839,7 +856,7 @@ def revoke_request(request_id):
     try:
         actions.revoke_request(request_id, g.admin_id)
         return jsonify({"status": "revoked"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -870,9 +887,15 @@ def add_admin():
             role=data.get("role", "operator"),
         )
         return jsonify(admin), 201
-    except (KeyError, Exception) as e:
-        logging.exception("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+    except KeyError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
+    except UserError as e:
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": str(e)}), 400
+    except Exception:
+        logging.exception("add_admin failed")
+        return jsonify({"error": "Internal server error"}), 400
 
 
 @app.route("/api/admins/<username>", methods=["PUT"])
@@ -887,7 +910,7 @@ def update_admin(username):
     try:
         result = actions.update_admin(username, email, role, g.admin_id)
         return jsonify({"message": "Admin updated"})
-    except ValueError as e:
+    except UserError as e:
         err_msg = str(e)
         logging.warning("%s", err_msg.replace("\n", "\\n").replace("\r", "\\r"))
         if "own role" in err_msg:
@@ -907,7 +930,7 @@ def change_admin_password(username):
     try:
         actions.change_password(username, password)
         return jsonify({"status": "updated"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -927,7 +950,7 @@ def disable_admin(username):
     try:
         actions.disable_admin(username, g.admin_id)
         return jsonify({"status": "disabled"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -941,7 +964,7 @@ def enable_admin(username):
     try:
         actions.enable_admin(username, g.admin_id)
         return jsonify({"status": "enabled"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 404
 
@@ -955,7 +978,7 @@ def delete_admin(username):
     try:
         actions.delete_admin(username, g.admin_id)
         return jsonify({"status": "deleted"})
-    except ValueError as e:
+    except UserError as e:
         logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
         return jsonify({"error": str(e)}), 400
 
@@ -971,7 +994,7 @@ def toggle_admin_alerts(username):
     try:
         result = actions.toggle_alerts(username, receive_alerts)
         return jsonify(result)
-    except ValueError as e:
+    except UserError as e:
         return jsonify({"error": str(e)}), 404
 
 
@@ -1174,7 +1197,8 @@ def test_smtp():
     except FileNotFoundError:
         return jsonify({"error": "msmtp not found on this system"}), 500
     except RuntimeError as e:
-        return jsonify({"error": str(e)}), 502
+        logging.warning("%s", str(e).replace("\n", "\\n").replace("\r", "\\r"))
+        return jsonify({"error": "SMTP test failed"}), 502
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #313

## Summary

- Adds `UserError(Exception)` in `actions.py` to mark user-facing messages as safe to include in HTTP responses
- Replaces all `raise ValueError/KeyError(...)` user-facing raises in `actions.py` with `raise UserError(...)`
- Updates `web.py` to catch `UserError` instead of `ValueError/KeyError` — `str(e)` is now safe from CodeQL's taint perspective
- Broad `except Exception as e` catches now return `"Internal server error"` and log the details server-side
- `except RuntimeError as e` SSH errors return `{"error": "SSH operation failed", "error_code": ...}` — raw message not leaked, `error_code` preserved for frontend
- Validates IP address in `add_to_known_hosts` (defense-in-depth, breaks taint chain)
- Updates test fixtures: `pytest.raises(ValueError)` → `pytest.raises(UserError)`, mock `side_effect` updated

## Test plan

- [ ] 472 Python tests pass
- [ ] CodeQL `py/stack-trace-exposure` alerts resolved (22 open alerts)
- [ ] API error responses unchanged for validated inputs (e.g. "Invalid IP address", "Server not found")
- [ ] SSH errors return `{"error": "SSH operation failed", "error_code": "..."}` — no raw exception message

🤖 Generated with [Claude Code](https://claude.com/claude-code)