### PR TITLE
fix: admin duplicate error, sessions error message, SMTP button, inactive row buttons

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -838,6 +838,8 @@ def add_admin(username: str, email: str, password: str, admin_id: str | None = N
     if role not in VALID_ROLES:
         raise UserError(f"Invalid role: {role}. Must be one of: {', '.join(sorted(VALID_ROLES))}")
     _validate_password_strength(password)
+    if db.query_one("SELECT id FROM administrators WHERE username = %s", (username,)):
+        raise UserError(f"Username '{username}' is already taken")
     password_hash = generate_password_hash(password)
     db.execute(
         "INSERT INTO administrators (username, email, password_hash, role) VALUES (%s, %s, %s, %s)",

--- a/app/collect.py
+++ b/app/collect.py
@@ -5,6 +5,7 @@ Appelee par cron et via manage.py / web.py.
 import base64
 import hashlib
 import json
+import logging
 import os
 import struct
 from datetime import datetime, timezone
@@ -189,8 +190,8 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
     # Collect SSH sessions (non-fatal)
     try:
         ssh.collect_sessions_on_server(hostname, server_id, ip=ip, port=ssh_port)
-    except Exception:
-        pass
+    except Exception as exc:
+        logging.warning("collect_sessions_on_server failed on %s (%s): %s", hostname, ip, exc)
 
     db.execute(
         """

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,6 +1,7 @@
 import hashlib
 import io
 import json
+import logging
 import os
 import shlex
 
@@ -422,14 +423,16 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int
             raise RuntimeError("Server unreachable — check the IP and network connectivity")
         raise RuntimeError(f"Connection failed: {exc}")
     try:
-        out, _, rc = _run(client, f"sudo {SAM_SESSIONS_PATH}")
+        out, err, rc = _run(client, f"sudo {SAM_SESSIONS_PATH}")
         if rc != 0:
+            logging.warning("sam-sessions returned rc=%d on %s: %s", rc, hostname, err.strip())
             return
         now = datetime.now(timezone.utc)
         db.execute(
             "UPDATE ssh_sessions SET is_active = false WHERE server_id = %s AND is_active = true",
             (server_id,),
         )
+        active_count = 0
         for line in out.splitlines():
             parts = line.split('\t')
             if len(parts) < 4:
@@ -445,6 +448,7 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int
                 login_at_str = parts[4].strip() if len(parts) > 4 else ''
                 login_at = _parse_session_datetime(login_at_str, now)
                 if not login_at:
+                    logging.debug("sam-sessions: could not parse login_at %r on %s", login_at_str, hostname)
                     continue
                 db.execute(
                     """
@@ -455,13 +459,18 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int
                     """,
                     (server_id, unix_user, tty, login_ip, login_at),
                 )
+                active_count += 1
             elif session_type == 'H':
                 rest = parts[4].strip() if len(parts) > 4 else ''
                 is_still_active = 'still' in rest.lower()
                 if ' - ' in rest:
                     login_str, logout_str = rest.split(' - ', 1)
+                elif is_still_active:
+                    import re as _re
+                    login_str = _re.split(r'\s{2,}still|\sstill\s', rest, maxsplit=1)[0].strip()
+                    logout_str = ''
                 else:
-                    login_str = rest.split('  still')[0].strip() if is_still_active else rest
+                    login_str = rest
                     logout_str = ''
                 login_at = _parse_session_datetime(login_str.strip(), now)
                 if not login_at:
@@ -482,6 +491,7 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int
                     """,
                     (server_id, unix_user, tty, login_ip, login_at, logout_at, is_still_active),
                 )
+        logging.debug("collect_sessions_on_server: %d active sessions on %s", active_count, hostname)
     finally:
         client.close()
 

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -407,8 +407,20 @@ def _is_valid_ip(s: str) -> bool:
 
 def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int = 22) -> None:
     """Collect SSH sessions via sam-sessions and upsert into ssh_sessions table."""
+    import socket
     from datetime import datetime, timezone
-    client = _connect(ip, port)
+    try:
+        client = _connect(ip, port)
+    except paramiko.AuthenticationException:
+        raise RuntimeError("Authentication failed — check collector key authorization")
+    except paramiko.SSHException as exc:
+        raise RuntimeError(f"SSH error connecting to {hostname}: {exc}")
+    except socket.timeout:
+        raise RuntimeError("Connection timed out — server did not respond within 15 seconds")
+    except OSError as exc:
+        if "Connection refused" in str(exc):
+            raise RuntimeError("Server unreachable — check the IP and network connectivity")
+        raise RuntimeError(f"Connection failed: {exc}")
     try:
         out, _, rc = _run(client, f"sudo {SAM_SESSIONS_PATH}")
         if rc != 0:

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -547,7 +547,7 @@ def test_actions_provision_server_raises_if_not_found():
 
 def test_actions_add_admin_logs_admin_added():
     with patch("actions.db") as mock_db:
-        mock_db.query_one.return_value = {"id": ADMIN_ID}
+        mock_db.query_one.side_effect = [None, {"id": ADMIN_ID}]
         actions.add_admin("newuser", "new@example.com", "Str0ng#Pass!", ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("ADMIN_ADDED" in c for c in calls)

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -587,7 +587,7 @@ def test_web_system_status_returns_200(auth_client):
 
 
 def test_web_system_status_smtp_enabled_default(auth_client):
-    with patch("web.db") as mock_db, patch.dict(os.environ, {}, clear=False):
+    with patch("web.db") as mock_db, patch.dict(os.environ, {"SMTP_HOST": "mail.example.com"}, clear=False):
         if "SMTP_ENABLED" in os.environ:
             del os.environ["SMTP_ENABLED"]
         mock_db.query_one.side_effect = [
@@ -603,7 +603,7 @@ def test_web_system_status_smtp_enabled_default(auth_client):
 
 
 def test_web_system_status_smtp_enabled_set_one(auth_client):
-    with patch("web.db") as mock_db, patch.dict(os.environ, {"SMTP_ENABLED": "1"}):
+    with patch("web.db") as mock_db, patch.dict(os.environ, {"SMTP_ENABLED": "1", "SMTP_HOST": "mail.example.com"}):
         mock_db.query_one.side_effect = [
             _admin_row(),
             {"n": 1},
@@ -614,6 +614,20 @@ def test_web_system_status_smtp_enabled_set_one(auth_client):
         resp = auth_client.get("/api/system/status")
         assert resp.status_code == 200
         assert resp.get_json()["smtp_enabled"] is True
+
+
+def test_web_system_status_smtp_disabled_no_host(auth_client):
+    with patch("web.db") as mock_db, patch.dict(os.environ, {"SMTP_ENABLED": "1", "SMTP_HOST": ""}):
+        mock_db.query_one.side_effect = [
+            _admin_row(),
+            {"n": 1},
+            {"n": 0},
+            {"n": 0},
+            None,
+        ]
+        resp = auth_client.get("/api/system/status")
+        assert resp.status_code == 200
+        assert resp.get_json()["smtp_enabled"] is False
 
 
 def test_web_system_status_smtp_disabled_empty(auth_client):

--- a/app/web.py
+++ b/app/web.py
@@ -424,14 +424,15 @@ def get_server_sessions(hostname):
 @require_role("sysadmin", "operator")
 def refresh_server_sessions(hostname):
     server = db.query_one(
-        "SELECT id, host(ip_address) AS ip_address FROM servers WHERE hostname = %s AND is_active = true",
+        "SELECT id, host(ip_address) AS ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,),
     )
     if not server:
         return jsonify({"error": "Server not found or inactive"}), 404
     ip = str(server["ip_address"])
+    port = server.get("ssh_port") or 22
     try:
-        ssh.collect_sessions_on_server(hostname, server["id"], ip)
+        ssh.collect_sessions_on_server(hostname, server["id"], ip, port=port)
         return jsonify({"status": "refreshed"})
     except RuntimeError as e:
         logging.warning("collect_sessions_on_server failed on %s (%s): %s", hostname, ip, e)
@@ -1086,7 +1087,10 @@ def get_collector_key():
 @require_auth
 def get_config():
     rows = db.query("SELECT key, value FROM settings")
-    return jsonify({r["key"]: r["value"] for r in rows})
+    data = {r["key"]: r["value"] for r in rows}
+    _smtp_env = os.environ.get("SMTP_ENABLED", "1")
+    data["smtp_enabled"] = _smtp_env not in ("", "0")
+    return jsonify(data)
 
 
 @app.route("/api/system/config", methods=["PUT"])

--- a/app/web.py
+++ b/app/web.py
@@ -81,6 +81,15 @@ def _reset_attempts(ip: str) -> None:
         _login_attempts.pop(ip, None)
 
 
+def _is_smtp_enabled() -> bool:
+    """SMTP is considered enabled only when SMTP_ENABLED is truthy AND SMTP_HOST is set."""
+    smtp_env = os.environ.get("SMTP_ENABLED", "1")
+    if smtp_env in ("", "0"):
+        return False
+    smtp_host = os.environ.get("SMTP_HOST", "").strip()
+    return bool(smtp_host)
+
+
 # ---------------------------------------------------------------------------
 # Session timeout — constants (no DB config, no UI)
 # ---------------------------------------------------------------------------
@@ -1052,14 +1061,12 @@ def system_status():
     last_scan = db.query_one(
         "SELECT performed_at FROM audit_log WHERE action = 'SCAN_COMPLETED' ORDER BY performed_at DESC LIMIT 1"
     )
-    _smtp_env = os.environ.get("SMTP_ENABLED", "1")
-    smtp_enabled = _smtp_env not in ("", "0")
     return jsonify({
         "servers_active": servers_total["n"] if servers_total else 0,
         "keys_active": keys_active["n"] if keys_active else 0,
         "keys_pending_review": keys_pending["n"] if keys_pending else 0,
         "last_scan": last_scan["performed_at"].isoformat() if last_scan else None,
-        "smtp_enabled": smtp_enabled,
+        "smtp_enabled": _is_smtp_enabled(),
     })
 
 
@@ -1088,8 +1095,7 @@ def get_collector_key():
 def get_config():
     rows = db.query("SELECT key, value FROM settings")
     data = {r["key"]: r["value"] for r in rows}
-    _smtp_env = os.environ.get("SMTP_ENABLED", "1")
-    data["smtp_enabled"] = _smtp_env not in ("", "0")
+    data["smtp_enabled"] = _is_smtp_enabled()
     return jsonify(data)
 
 

--- a/app/web.py
+++ b/app/web.py
@@ -433,6 +433,9 @@ def refresh_server_sessions(hostname):
     try:
         ssh.collect_sessions_on_server(hostname, server["id"], ip)
         return jsonify({"status": "refreshed"})
+    except RuntimeError as e:
+        logging.warning("collect_sessions_on_server failed on %s (%s): %s", hostname, ip, e)
+        return jsonify({"error": str(e)}), 502
     except Exception:
         logging.exception("collect_sessions_on_server failed on %s (%s)", hostname, ip)
         return jsonify({"error": "Internal server error"}), 502

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -38,7 +38,7 @@
 import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { useAuth } from './composables/useAuth.js'
+import { useAuth, apiFetch } from './composables/useAuth.js'
 
 const router = useRouter()
 const { admin, logout } = useAuth()
@@ -51,7 +51,7 @@ watch(
   async (newAdmin) => {
     if (!newAdmin) return
     try {
-      const res = await fetch('/api/system/status')
+      const res = await apiFetch('/api/system/status')
       if (res.ok) {
         const data = await res.json()
         smtpEnabled.value = data.smtp_enabled !== false

--- a/ui/src/components/AdminsTable.vue
+++ b/ui/src/components/AdminsTable.vue
@@ -216,7 +216,7 @@ const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSi
   width: 240px;
 }
 
-.row-inactive {
+.row-inactive td:not(:last-child) {
   opacity: 0.6;
 }
 

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -144,7 +144,7 @@ const savingSecurity = ref(false)
 const successSecurity = ref(false)
 const errorSecurity = ref('')
 
-const smtpEnabled = ref(false)
+const smtpEnabled = ref(true)
 const smtpTesting = ref(false)
 const smtpSuccess = ref('')
 const smtpError = ref('')

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -112,7 +112,7 @@
     <section class="card">
       <h3>{{ $t('settings.smtp_section') }}</h3>
       <div class="field">
-        <button class="btn-primary" :disabled="smtpTesting" @click="testSmtp">
+        <button class="btn-primary" :disabled="smtpTesting || !smtpEnabled" @click="testSmtp">
           {{ smtpTesting ? $t('settings.smtp_testing') : $t('settings.smtp_test_btn') }}
         </button>
         <p class="hint">{{ $t('settings.smtp_hint') }}</p>
@@ -144,6 +144,7 @@ const savingSecurity = ref(false)
 const successSecurity = ref(false)
 const errorSecurity = ref('')
 
+const smtpEnabled = ref(false)
 const smtpTesting = ref(false)
 const smtpSuccess = ref('')
 const smtpError = ref('')
@@ -158,6 +159,7 @@ onMounted(async () => {
     expireWarnDays2.value = parseInt(data.expire_warn_days_2 || 2)
     loginMaxAttempts.value = parseInt(data.login_max_attempts || 10)
     loginBanSeconds.value = parseInt(data.login_ban_seconds || 300)
+    smtpEnabled.value = data.smtp_enabled || false
   } catch (err) {
     error.value = err.message
   }

--- a/ui/tests/App.spec.js
+++ b/ui/tests/App.spec.js
@@ -131,7 +131,7 @@ describe('App.vue — SMTP banner', () => {
     const wrapper = mount(App, { global: { plugins: [i18n], stubs: ['router-view'] } })
     await flushPromises()
 
-    expect(global.fetch).toHaveBeenCalledWith('/api/system/status')
+    expect(global.fetch).toHaveBeenCalledWith('/api/system/status', expect.any(Object))
     expect(wrapper.find('.smtp-banner').exists()).toBe(true)
   })
 })

--- a/ui/tests/Settings.spec.js
+++ b/ui/tests/Settings.spec.js
@@ -226,6 +226,7 @@ describe('Settings.vue', () => {
           scan_interval_hours: '4',
           expire_warn_days: '7',
           expire_warn_days_2: '2',
+          smtp_enabled: true,
         }),
       })
       .mockResolvedValueOnce({
@@ -251,6 +252,7 @@ describe('Settings.vue', () => {
           scan_interval_hours: '4',
           expire_warn_days: '7',
           expire_warn_days_2: '2',
+          smtp_enabled: true,
         }),
       })
       .mockResolvedValueOnce({
@@ -273,6 +275,7 @@ describe('Settings.vue', () => {
           scan_interval_hours: '4',
           expire_warn_days: '7',
           expire_warn_days_2: '2',
+          smtp_enabled: true,
         }),
       })
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

4 bugs corrigés :

**1. `add_admin` — "Internal server error" sur username dupliqué**
Un username existant lève une `psycopg2.IntegrityError` (contrainte unique) non catchée → tombait dans `except Exception` → "Internal server error". Fix : vérification explicite avant l'INSERT avec `UserError`.

**2. Sessions refresh — "Internal server error" sans détail**
`collect_sessions_on_server` lève des `RuntimeError` pour les erreurs SSH (authentification, timeout, etc.). Ces erreurs sont maintenant catchées séparément et retournées au client. Seules les erreurs inattendues (`Exception`) restent génériques.

**3. Bouton "Test SMTP" non désactivé quand SMTP off**
Le bandeau "Email notifications are disabled" s'affichait mais le bouton restait cliquable. `smtp_enabled` retourné par `/api/system/config` n'était pas lu dans Settings.vue. Fix : `smtpEnabled` ref chargée au mount, `:disabled="smtpTesting || !smtpEnabled"`.

**4. Boutons Enable/Delete délavés sur ligne admin désactivé**
`.row-inactive { opacity: 0.6 }` s'appliquait à toute la ligne y compris les boutons d'action. Fix : `.row-inactive td:not(:last-child)` — seules les cellules d'information sont atténuées, les boutons gardent leurs couleurs vives.

## Test plan

- [ ] Ajouter un admin avec username existant → message "Username 'X' is already taken" (pas "Internal server error")
- [ ] Refresh sessions SSH → message d'erreur SSH précis si échec
- [ ] Settings : bouton "Test SMTP" grisé quand SMTP désactivé, actif quand activé
- [ ] Admins : ligne admin désactivé → cellules atténuées, boutons Enable/Delete couleurs normales
- [ ] 476 tests Python + 289 tests Vitest passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)