### PR TITLE
fix: replace who+last with utmpdump for locale-independent session pa…

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -170,39 +170,74 @@ SAM_SESSIONS_PATH = "/usr/local/bin/sam-sessions"
 SAM_SESSIONS = b"""#!/bin/sh
 # sam-sessions - collect SSH session data
 # Outputs tab-separated lines:
-#   A\\tuser\\ttty\\tip\\tlogin_str   (active, from 'who')
-#   H\\tuser\\ttty\\tip\\trest        (history, from 'last')
-set -e
+#   A\\tuser\\ttty\\tip\\t<ISO8601>            (active, utmpdump /var/run/utmp)
+#   H\\tuser\\ttty\\tip\\t<ISO8601> - <ISO8601> (history, utmpdump /var/log/wtmp)
+# Falls back to who + LANG=C last -F when utmpdump is unavailable (busybox/Alpine).
+#
+# utmpdump output format (8 bracket-delimited fields per line):
+#   [type] [pid] [id] [user] [line] [host] [addr] [time]
+# type 7=USER_PROCESS (login), type 8=DEAD_PROCESS (logout)
+# Parsing: replace all [ and ] with tab, then split on tab.
 
-# Active sessions from 'who'
-# GNU who: alice pts/0 2024-03-01 10:00 (192.168.1.10)
-# busybox who: alice pts/0 Mar  1 10:00
-who 2>/dev/null | awk '{
-    user=$1; tty=$2;
-    if($3 ~ /^[0-9]{4}-/) {
-        login=$3" "$4;
-        ip=$5; gsub(/[()]/,"",ip);
-    } else {
-        login=$3" "$4" "$5;
-        ip="";
-    }
-    if(ip=="" || ip==user) ip="local";
-    print "A\\t"user"\\t"tty"\\t"ip"\\t"login;
-}'
-
-# Session history from 'last -F' (full timestamps including year).
-# Falls back to 'last' if -F is unsupported (busybox targets).
-# Local TTY: 'root tty1   Mon Apr 27 18:38:00 2026 ...'
-# SSH:       'alice pts/0 192.168.1.10 Mon Apr 27 18:38:00 2026 ...'
-# Detect IP by presence of '.' (IPv4) or ':' (IPv6) in field 3.
-{ last -F -n 100 2>/dev/null || last -n 100 2>/dev/null; } | grep -v "^$\\|^reboot\\|^wtmp\\|^btmp" | awk '{
-    if(NF<3) next;
-    user=$1; tty=$2;
-    if($3 ~ /[.:]/) { ip=$3; start=4; } else { ip=""; start=3; }
-    rest="";
-    for(i=start;i<=NF;i++) rest=rest$i(i<NF?" ":"");
-    print "H\\t"user"\\t"tty"\\t"ip"\\t"rest;
-}'
+if command -v utmpdump >/dev/null 2>&1 && [ -r /var/run/utmp ]; then
+    utmpdump /var/run/utmp 2>/dev/null | awk '{
+        s=$0; gsub(/\\[|\\]/, "\\t", s); split(s, f, "\\t");
+        type=f[2]+0;
+        user=f[8];  gsub(/^ +| +$/, "", user);
+        line=f[10]; gsub(/^ +| +$/, "", line);
+        host=f[12]; gsub(/^ +| +$/, "", host);
+        time=f[16]; gsub(/^ +| +$/, "", time);
+        if(type!=7 || user=="") next;
+        ip=host; if(ip=="" || ip=="0.0.0.0") ip="local";
+        print "A\\t"user"\\t"line"\\t"ip"\\t"time;
+    }'
+    if [ -r /var/log/wtmp ]; then
+        utmpdump /var/log/wtmp 2>/dev/null | tail -n 300 | awk '{
+            s=$0; gsub(/\\[|\\]/, "\\t", s); split(s, f, "\\t");
+            type=f[2]+0;
+            pid=f[4];   gsub(/^ +| +$/, "", pid);
+            user=f[8];  gsub(/^ +| +$/, "", user);
+            line=f[10]; gsub(/^ +| +$/, "", line);
+            host=f[12]; gsub(/^ +| +$/, "", host);
+            time=f[16]; gsub(/^ +| +$/, "", time);
+            if(line=="") next;
+            if(type==7 && user!="") {
+                key=line":"pid;
+                ltime[key]=time; luser[key]=user; lhost[key]=host;
+            } else if(type==8) {
+                key=line":"pid;
+                if(key in ltime) {
+                    ip=lhost[key]; if(ip=="" || ip=="0.0.0.0") ip="local";
+                    print "H\\t"luser[key]"\\t"line"\\t"ip"\\t"ltime[key]" - "time;
+                    delete ltime[key]; delete luser[key]; delete lhost[key];
+                }
+            }
+        }'
+    fi
+else
+    # Fallback: who (active) + LANG=C last -F (history, English forced, year included)
+    who 2>/dev/null | awk '{
+        user=$1; tty=$2;
+        if($3 ~ /^[0-9]{4}-/) {
+            login=$3" "$4;
+            ip=$5; gsub(/[()]/,"",ip);
+        } else {
+            login=$3" "$4" "$5;
+            ip="";
+        }
+        if(ip=="" || ip==user) ip="local";
+        print "A\\t"user"\\t"tty"\\t"ip"\\t"login;
+    }'
+    { LANG=C last -F -n 100 2>/dev/null || LANG=C last -n 100 2>/dev/null; } | \\
+        grep -v "^$\\|^reboot\\|^wtmp\\|^btmp" | awk '{
+        if(NF<3) next;
+        user=$1; tty=$2;
+        if($3 ~ /[.:]/) { ip=$3; start=4; } else { ip=""; start=3; }
+        rest="";
+        for(i=start;i<=NF;i++) rest=rest$i(i<NF?" ":"");
+        print "H\\t"user"\\t"tty"\\t"ip"\\t"rest;
+    }'
+fi
 """
 
 
@@ -360,33 +395,46 @@ def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22
 
 
 def _parse_session_datetime(s: str, now) -> "datetime | None":
-    """Parse various date formats from who/last output. Returns UTC datetime or None."""
+    """Parse date strings from sam-sessions output. Returns UTC datetime or None.
+
+    Handles three sources:
+    - utmpdump ISO 8601:  2026-05-01T07:35:23,000000+0000  (primary path)
+    - who ISO date:       2026-05-01 07:35                  (fallback active)
+    - last -F / last:     Mon Apr 27 08:00:01 2026          (fallback history)
+    """
     import re
     from datetime import datetime, timezone
     s = s.strip()
     if not s:
         return None
-    formats = [
-        "%a %b %d %H:%M:%S %Y",
-        "%a %b  %d %H:%M:%S %Y",
-        "%a %b %d %H:%M %Y",
-        "%a %b  %d %H:%M %Y",
-        "%a %b %d %H:%M",
-        "%a %b  %d %H:%M",
-        "%Y-%m-%d %H:%M",
-        "%b %d %H:%M",
-        "%b  %d %H:%M",
-    ]
-    for fmt in formats:
+    # ISO 8601 from utmpdump (contains 'T' and timezone offset)
+    if 'T' in s:
         try:
-            dt = datetime.strptime(s, fmt)
-            if dt.year == 1900:
-                dt = dt.replace(year=now.year)
-                if dt.date() > now.date():
-                    dt = dt.replace(year=now.year - 1)
+            return datetime.fromisoformat(s.replace(',', '.')).astimezone(timezone.utc)
+        except ValueError:
+            pass
+    # ISO date from who: 2026-05-01 07:35 (no timezone — treat as UTC)
+    if re.match(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}', s):
+        try:
+            dt = datetime.strptime(s[:16], "%Y-%m-%d %H:%M")
+            return dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    # last / last -F fallback: strip leading weekday abbreviation (Mon, Fri, …)
+    # then inject current year when absent — avoids DeprecationWarning in Python
+    # 3.12 and the upcoming ValueError in Python 3.15 for year-less formats.
+    s = re.sub(r'^[A-Z][a-z]{2}\s+', '', s)
+    has_year = bool(re.search(r'\b\d{4}\b', s))
+    s_parse = f"{s} {now.year}" if not has_year else s
+    for fmt in ("%b %d %H:%M:%S %Y", "%b  %d %H:%M:%S %Y", "%b %d %H:%M %Y", "%b  %d %H:%M %Y"):
+        try:
+            dt = datetime.strptime(s_parse, fmt)
+            if not has_year and dt.date() > now.date():
+                dt = dt.replace(year=now.year - 1)
             return dt.replace(tzinfo=timezone.utc)
         except ValueError:
             continue
+    # Pure HH:MM logout time from legacy last output (no date context available)
     if re.match(r'^\d{1,2}:\d{2}$', s):
         try:
             t = datetime.strptime(s, "%H:%M")

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -520,6 +520,10 @@ def test_ssh_unlock_user_on_server_calls_sam_unlock_user(sample_server):
 
 def test_ssh_sam_sessions_is_bytes():
     assert isinstance(ssh.SAM_SESSIONS, bytes)
+    assert b"utmpdump" in ssh.SAM_SESSIONS
+    assert b"/var/run/utmp" in ssh.SAM_SESSIONS
+    assert b"/var/log/wtmp" in ssh.SAM_SESSIONS
+    assert b"#!/bin/sh" in ssh.SAM_SESSIONS
 
 
 def test_ssh_parse_session_datetime_iso():
@@ -531,7 +535,22 @@ def test_ssh_parse_session_datetime_iso():
     assert dt.hour == 10
 
 
+def test_ssh_parse_session_datetime_utmpdump_iso():
+    """Primary path: utmpdump ISO 8601 with timezone (2026-05-01T07:35:23,000000+0000)."""
+    from datetime import datetime, timezone
+    now = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+    dt = ssh._parse_session_datetime("2026-05-01T07:35:23,000000+0000", now)
+    assert dt is not None
+    assert dt.year == 2026
+    assert dt.month == 5
+    assert dt.day == 1
+    assert dt.hour == 7
+    assert dt.minute == 35
+    assert dt.tzinfo is not None
+
+
 def test_ssh_parse_session_datetime_last_f():
+    """Fallback last -F: weekday stripped, year present — must parse correctly."""
     from datetime import datetime, timezone
     now = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc)
     dt = ssh._parse_session_datetime("Mon Apr 27 08:00:01 2026", now)
@@ -548,7 +567,7 @@ def test_ssh_parse_session_datetime_hhmm():
 
 
 def test_ssh_parse_session_datetime_last_no_year():
-    """last without -F gives 'Mon Apr 28 13:21' (no year) — must parse correctly."""
+    """Fallback last (no -F): 'Mon Apr 28 13:21' — weekday stripped, year injected."""
     from datetime import datetime, timezone
     now = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc)
     dt = ssh._parse_session_datetime("Mon Apr 28 13:21", now)
@@ -559,7 +578,7 @@ def test_ssh_parse_session_datetime_last_no_year():
 
 
 def test_ssh_parse_session_datetime_last_no_year_single_digit_day():
-    """last without -F with day < 10 uses double-space padding: 'Mon Apr  7 08:00'."""
+    """Fallback last (no -F): single-digit day with double-space: 'Mon Apr  7 08:00'."""
     from datetime import datetime, timezone
     now = datetime(2026, 4, 28, 12, 0, 0, tzinfo=timezone.utc)
     dt = ssh._parse_session_datetime("Mon Apr  7 08:00", now)
@@ -608,11 +627,13 @@ def test_ssh_is_valid_ip_invalid():
 
 
 def test_ssh_collect_sessions_calls_sam_sessions(mock_ssh_client):
-    """collect_sessions_on_server runs sam-sessions and upserts results."""
+    """collect_sessions_on_server runs sam-sessions and upserts results (utmpdump ISO format)."""
     from unittest.mock import MagicMock, patch
     mock_client = MagicMock()
     mock_stdout = MagicMock()
-    mock_stdout.read.return_value = b"A\talice\tpts/0\t192.168.1.50\t2026-04-28 10:00\n"
+    mock_stdout.read.return_value = (
+        b"A\talice\tpts/0\t192.168.1.50\t2026-04-28T10:00:00,000000+0000\n"
+    )
     mock_stdout.channel.recv_exit_status.return_value = 0
     mock_stderr = MagicMock()
     mock_stderr.read.return_value = b""
@@ -629,7 +650,9 @@ def test_ssh_collect_sessions_marks_inactive_before_reinserting(mock_ssh_client)
     from unittest.mock import MagicMock, patch
     mock_client = MagicMock()
     mock_stdout = MagicMock()
-    mock_stdout.read.return_value = b"A\talice\tpts/0\t192.168.1.50\t2026-04-28 10:00\n"
+    mock_stdout.read.return_value = (
+        b"A\talice\tpts/0\t192.168.1.50\t2026-04-28T10:00:00,000000+0000\n"
+    )
     mock_stdout.channel.recv_exit_status.return_value = 0
     mock_stderr = MagicMock()
     mock_stderr.read.return_value = b""
@@ -646,12 +669,61 @@ def test_ssh_collect_sessions_marks_inactive_before_reinserting(mock_ssh_client)
         assert first_call[0][1] == ("server-uuid-1",)
 
 
-def test_ssh_collect_sessions_local_tty_no_ip(mock_ssh_client):
-    """Local TTY sessions (no IP in last output) must not fail INET insertion."""
+def test_ssh_collect_sessions_utmpdump_history(mock_ssh_client):
+    """H-type lines from utmpdump (ISO login - ISO logout) are parsed and inserted."""
     from unittest.mock import MagicMock, patch
     mock_client = MagicMock()
     mock_stdout = MagicMock()
-    # 'root' on tty1 with no IP (Mon is a day abbreviation, not an IP)
+    mock_stdout.read.return_value = (
+        b"H\troot\tpts/0\t192.168.1.50\t"
+        b"2026-04-27T16:37:00,000000+0000 - 2026-04-27T16:45:00,000000+0000\n"
+    )
+    mock_stdout.channel.recv_exit_status.return_value = 0
+    mock_stderr = MagicMock()
+    mock_stderr.read.return_value = b""
+    mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
+
+    with patch("ssh._connect", return_value=mock_client), \
+         patch("ssh.db") as mock_db:
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
+        assert insert_calls
+        params = insert_calls[0][0][1]
+        # login_ip must be the real IP
+        assert params[3] == "192.168.1.50"
+        # logout_at must not be None
+        assert params[5] is not None
+
+
+def test_ssh_collect_sessions_local_tty_no_ip(mock_ssh_client):
+    """Local TTY sessions with no IP (utmpdump 'local') must not fail INET insertion."""
+    from unittest.mock import MagicMock, patch
+    mock_client = MagicMock()
+    mock_stdout = MagicMock()
+    # utmpdump format: local TTY login (no real IP → 'local')
+    mock_stdout.read.return_value = (
+        b"A\troot\ttty1\tlocal\t2026-04-27T18:38:00,000000+0000\n"
+    )
+    mock_stdout.channel.recv_exit_status.return_value = 0
+    mock_stderr = MagicMock()
+    mock_stderr.read.return_value = b""
+    mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
+
+    with patch("ssh._connect", return_value=mock_client), \
+         patch("ssh.db") as mock_db:
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
+        if insert_calls:
+            params = insert_calls[0][0][1]
+            # login_ip must be None ('local' is not a valid IP)
+            assert params[3] is None
+
+
+def test_ssh_collect_sessions_fallback_still_logged_in(mock_ssh_client):
+    """Fallback H-type with 'still logged in' (last output) must set is_still_active."""
+    from unittest.mock import MagicMock, patch
+    mock_client = MagicMock()
+    mock_stdout = MagicMock()
     mock_stdout.read.return_value = (
         b"H\troot\ttty1\t\tMon Apr 27 18:38 2026   still logged in\n"
     )
@@ -662,16 +734,12 @@ def test_ssh_collect_sessions_local_tty_no_ip(mock_ssh_client):
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        # Must not raise — "Mon" must not reach the INET column
         ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
-        # call_args_list[0] is the UPDATE (mark inactive), [1] is the H line INSERT
-        insert_calls = [
-            c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]
-        ]
+        insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
         if insert_calls:
             params = insert_calls[0][0][1]
-            # login_ip must be None, not "Mon"
-            assert params[3] is None
+            # is_still_active must be True
+            assert params[6] is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request significantly improves how SSH session data is collected and parsed, with a focus on robust handling of session logs across different Linux environments. The `sam-sessions` shell script now prefers `utmpdump` for accurate ISO 8601 timestamps and falls back to legacy tools when necessary. The Python parser and tests have been updated to fully support these changes, ensuring reliable session tracking and compatibility.

**Session collection and parsing improvements:**

- The `SAM_SESSIONS` shell script now uses `utmpdump` (when available) to extract active and historical session data with precise ISO 8601 timestamps, falling back to `who` and `last -F` only if `utmpdump` is unavailable. The output format and parsing logic have been updated to handle these changes, including better IP address handling and support for local sessions. [[1]](diffhunk://#diff-daeeeced88e71749deeb48558b7c2ea4872c78521471c4caddbf3a548f636e27L173-R218) [[2]](diffhunk://#diff-daeeeced88e71749deeb48558b7c2ea4872c78521471c4caddbf3a548f636e27L192-R240)

**Datetime parsing enhancements:**

- The `_parse_session_datetime` function has been rewritten to robustly parse ISO 8601 timestamps from `utmpdump`, as well as fallback formats from `who` and `last`, including improved handling for missing years and various edge cases.

**Test coverage and reliability:**

- The test suite for SSH session parsing has been expanded to cover all new formats and edge cases, including utmpdump ISO output, fallback scenarios, local TTY sessions, and "still logged in" states. Test descriptions and mocks have been updated for clarity and accuracy. [[1]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dR523-R526) [[2]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dR538-R553) [[3]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dL551-R570) [[4]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dL562-R581) [[5]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dL611-R636) [[6]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dL632-R655) [[7]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dR672-R705) [[8]](diffhunk://#diff-ee62010660435d23a7f57467a6c2082efe2967fa6425305fb6ab38c47ade5e0dL665-R744)

Closes #321