### PR TITLE
fix: scan failures visible on dashboard + disable Validate/Revoke + banner red

### DIFF
--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -299,6 +299,61 @@ def test_web_get_servers_returns_200(auth_client):
 
 
 # ---------------------------------------------------------------------------
+# GET /api/servers/<hostname>
+# ---------------------------------------------------------------------------
+
+def test_web_get_server_last_scan_ok_true(auth_client):
+    """GET /api/servers/<hostname> includes last_scan_ok=True when last audit is SCAN_COMPLETED."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            _admin_row(),
+            {"id": SERVER_ID, "hostname": "srv-01", "ip_address": "10.0.0.1",
+             "ssh_port": 22, "is_active": True, "environment": "lab",
+             "os_family": None, "os_version": None, "added_at": None},
+            {"action": "SCAN_COMPLETED", "scan_error": None},
+        ]
+        resp = auth_client.get("/api/servers/srv-01")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_scan_ok"] is True
+        assert data["last_scan_error"] is None
+
+
+def test_web_get_server_last_scan_ok_false(auth_client):
+    """GET /api/servers/<hostname> includes last_scan_ok=False and error when last audit is SCAN_FAILED."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            _admin_row(),
+            {"id": SERVER_ID, "hostname": "srv-01", "ip_address": "10.0.0.1",
+             "ssh_port": 22, "is_active": True, "environment": "lab",
+             "os_family": None, "os_version": None, "added_at": None},
+            {"action": "SCAN_FAILED", "scan_error": "Connection timed out"},
+        ]
+        resp = auth_client.get("/api/servers/srv-01")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_scan_ok"] is False
+        assert data["last_scan_error"] == "Connection timed out"
+
+
+def test_web_get_server_no_scan_yet(auth_client):
+    """GET /api/servers/<hostname> includes last_scan_ok=None when no scan has run yet."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            _admin_row(),
+            {"id": SERVER_ID, "hostname": "srv-01", "ip_address": "10.0.0.1",
+             "ssh_port": 22, "is_active": True, "environment": "lab",
+             "os_family": None, "os_version": None, "added_at": None},
+            None,
+        ]
+        resp = auth_client.get("/api/servers/srv-01")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["last_scan_ok"] is None
+        assert data["last_scan_error"] is None
+
+
+# ---------------------------------------------------------------------------
 # POST /api/servers
 # ---------------------------------------------------------------------------
 

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -293,9 +293,34 @@ def test_web_set_expiry_rejects_no_date_or_hours(auth_client):
 def test_web_get_servers_returns_200(auth_client):
     with patch("web.db") as mock_db:
         mock_db.query_one.return_value = _admin_row()
-        mock_db.query.return_value = [{"hostname": "srv-01"}]
+        mock_db.query.return_value = [{"hostname": "srv-01", "last_scan_action": "SCAN_COMPLETED"}]
         resp = auth_client.get("/api/servers")
         assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["last_scan_ok"] is True
+        assert "last_scan_action" not in data[0]
+
+
+def test_web_get_servers_last_scan_ok_false(auth_client):
+    """GET /api/servers includes last_scan_ok=False when last_scan_action is SCAN_FAILED."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = [{"hostname": "srv-01", "last_scan_action": "SCAN_FAILED"}]
+        resp = auth_client.get("/api/servers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["last_scan_ok"] is False
+
+
+def test_web_get_servers_last_scan_ok_none(auth_client):
+    """GET /api/servers includes last_scan_ok=None when no scan has run (last_scan_action absent)."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = [{"hostname": "srv-01", "last_scan_action": None}]
+        resp = auth_client.get("/api/servers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["last_scan_ok"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -258,8 +258,26 @@ def _ssh_error_code(msg: str) -> str:
 @app.route("/api/servers", methods=["GET"])
 @require_auth
 def list_servers():
-    rows = db.query("SELECT * FROM servers ORDER BY hostname")
-    return jsonify(rows)
+    rows = db.query(
+        """
+        SELECT s.*, ls.action AS last_scan_action
+        FROM servers s
+        LEFT JOIN LATERAL (
+            SELECT action FROM audit_log
+            WHERE target_server = s.id AND action IN ('SCAN_COMPLETED', 'SCAN_FAILED')
+            ORDER BY performed_at DESC LIMIT 1
+        ) ls ON true
+        ORDER BY s.hostname
+        """
+    )
+    result = []
+    for row in rows:
+        d = dict(row)
+        last_action = d.pop('last_scan_action', None)
+        d['last_scan_ok'] = (True if last_action == 'SCAN_COMPLETED' else
+                             False if last_action == 'SCAN_FAILED' else None)
+        result.append(d)
+    return jsonify(result)
 
 
 @app.route("/api/servers/<hostname>", methods=["GET"])

--- a/app/web.py
+++ b/app/web.py
@@ -268,7 +268,26 @@ def get_server(hostname):
     row = db.query_one("SELECT * FROM servers WHERE hostname = %s", (hostname,))
     if not row:
         return jsonify({"error": "Not found"}), 404
-    return jsonify(row)
+    server = dict(row)
+    last_scan = db.query_one(
+        """
+        SELECT action, details->>'error' AS scan_error
+        FROM audit_log
+        WHERE target_server = %s AND action IN ('SCAN_COMPLETED', 'SCAN_FAILED')
+        ORDER BY performed_at DESC LIMIT 1
+        """,
+        (server["id"],),
+    )
+    if last_scan is None:
+        server["last_scan_ok"] = None
+        server["last_scan_error"] = None
+    elif last_scan["action"] == "SCAN_COMPLETED":
+        server["last_scan_ok"] = True
+        server["last_scan_error"] = None
+    else:
+        server["last_scan_ok"] = False
+        server["last_scan_error"] = last_scan["scan_error"]
+    return jsonify(server)
 
 
 @app.route("/api/servers", methods=["POST"])

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -128,6 +128,8 @@
                   props.currentRole !== 'viewer'
                 "
                 class="btn-danger"
+                :disabled="props.scanOk === false"
+                :title="props.scanOk === false ? $t('key_table.revoke_unavailable') : undefined"
                 @click="$emit('revoke', k)"
               >
                 {{ $t('key_table.btn_revoke') }}
@@ -186,6 +188,7 @@ const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 const props = defineProps({
   keys: { type: Array, default: () => [] },
   currentRole: { type: String, default: 'viewer' },
+  scanOk: { type: Boolean, default: null },
 })
 defineEmits(['validate', 'revoke', 'set-expiry', 'remove-expiry', 'assign'])
 

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -118,6 +118,8 @@
               <button
                 v-if="k.status === 'PENDING_REVIEW' && props.currentRole !== 'viewer'"
                 class="btn-success"
+                :disabled="props.scanOk === false"
+                :title="props.scanOk === false ? $t('key_table.validate_unavailable') : undefined"
                 @click="$emit('validate', k)"
               >
                 {{ $t('key_table.btn_validate') }}

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -68,7 +68,9 @@
           <td colspan="7" class="empty">{{ $t('server_table.empty') }}</td>
         </tr>
         <tr v-for="s in paginatedItems" :key="s.id" :class="rowClass(s)">
-          <td>{{ statusIcon(s) }}</td>
+          <td :title="s.last_scan_ok === false ? $t('server_table.status_scan_failed') : undefined">
+            {{ statusIcon(s) }}
+          </td>
           <td>
             <router-link
               :to="`/servers/${s.hostname}`"
@@ -158,12 +160,14 @@ const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSi
 
 function statusIcon(s) {
   if (!s.is_active) return '🔴'
+  if (s.last_scan_ok === false) return '🟠'
   if (s.has_anomalies) return '🟡'
   return '✅'
 }
 
 function rowClass(s) {
   if (!s.is_active) return 'row-danger'
+  if (s.last_scan_ok === false) return 'row-scan-fail'
   if (s.has_anomalies) return 'row-warning'
   return ''
 }
@@ -216,6 +220,9 @@ function envBadge(env) {
 }
 .row-danger td {
   color: #6c6c6c;
+}
+.row-scan-fail {
+  background: #fff4e5;
 }
 .row-warning {
   background: #fffbf0;

--- a/ui/src/components/SessionsCard.vue
+++ b/ui/src/components/SessionsCard.vue
@@ -10,7 +10,8 @@
       <div class="header-actions">
         <button
           class="btn-sm btn-secondary"
-          :disabled="refreshing"
+          :disabled="refreshing || props.scanOk === false"
+          :title="props.scanOk === false ? $t('sessions.scan_required') : undefined"
           @click="refreshSessions"
           data-testid="sessions-refresh"
         >
@@ -184,6 +185,10 @@ const props = defineProps({
   currentRole: {
     type: String,
     default: 'viewer',
+  },
+  scanOk: {
+    type: Boolean,
+    default: null,
   },
 })
 

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -30,6 +30,7 @@
     "scanning": "Scannen…",
     "status_ok": "✅ OK",
     "status_alert": "🟡 Warnung",
+    "status_scan_failed": "🟠 Scan fehlgeschlagen",
     "status_inactive": "🔴 Inaktiv",
     "status_total": "Gesamt",
     "collector_key": "Öffentlicher Collector-Schlüssel",
@@ -96,6 +97,7 @@
     "col_actions": "Aktionen",
     "empty": "Kein Server gefunden.",
     "disabled_badge": "DEAKTIVIERT",
+    "status_scan_failed": "Letzter Scan fehlgeschlagen",
     "scan": "Scannen",
     "edit": "Bearbeiten"
   },
@@ -179,7 +181,8 @@
     "filter_placeholder": "Fingerprint, Benutzer, Owner suchen…",
     "filter_all_statuses": "Alle Status",
     "no_results": "Keine passenden Schlüssel.",
-    "revoke_unavailable": "Widerrufen nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)"
+    "revoke_unavailable": "Widerrufen nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)",
+    "validate_unavailable": "Validieren nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)"
   },
   "access": {
     "title": "Temporärer Zugriff",

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -120,6 +120,7 @@
     "load_error": "Server nicht gefunden (HTTP {status})",
     "scan_success": "Scan erfolgreich gestartet.",
     "scan_error": "Scan-Fehler: {error}",
+    "last_scan_failed": "Letzter Scan fehlgeschlagen: {error}",
     "disable_success": "Server deaktiviert.",
     "reactivate_success": "Server reaktiviert.",
     "delete_modal_title": "Server löschen",
@@ -177,7 +178,8 @@
     "btn_unlimited": "Unbegrenzt",
     "filter_placeholder": "Fingerprint, Benutzer, Owner suchen…",
     "filter_all_statuses": "Alle Status",
-    "no_results": "Keine passenden Schlüssel."
+    "no_results": "Keine passenden Schlüssel.",
+    "revoke_unavailable": "Widerrufen nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)"
   },
   "access": {
     "title": "Temporärer Zugriff",
@@ -434,7 +436,8 @@
     "filter_apply": "Anwenden",
     "export_csv": "CSV exportieren",
     "refresh_error": "Aktualisierung fehlgeschlagen: {error}",
-    "load_error": "Sitzungen konnten nicht geladen werden: {error}"
+    "load_error": "Sitzungen konnten nicht geladen werden: {error}",
+    "scan_required": "Zuerst den Server scannen, um Sitzungen zu aktualisieren"
   },
   "password_banner": {
     "message": "Ihr Passwort wurde noch nie geändert. Bitte aktualisieren Sie es aus Sicherheitsgründen.",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -30,6 +30,7 @@
     "scanning": "Scanning…",
     "status_ok": "✅ OK",
     "status_alert": "🟡 Alert",
+    "status_scan_failed": "🟠 Scan Failed",
     "status_inactive": "🔴 Inactive",
     "status_total": "Total",
     "collector_key": "Collector public key",
@@ -96,6 +97,7 @@
     "col_actions": "Actions",
     "empty": "No server found.",
     "disabled_badge": "DISABLED",
+    "status_scan_failed": "Last scan failed",
     "scan": "Scan",
     "edit": "Edit"
   },
@@ -179,7 +181,8 @@
     "filter_placeholder": "Search fingerprint, user, owner…",
     "filter_all_statuses": "All statuses",
     "no_results": "No matching keys.",
-    "revoke_unavailable": "Cannot revoke: last scan failed (server unreachable)"
+    "revoke_unavailable": "Cannot revoke: last scan failed (server unreachable)",
+    "validate_unavailable": "Cannot validate: last scan failed (server unreachable)"
   },
   "access": {
     "title": "Temporary Access",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -120,6 +120,7 @@
     "load_error": "Server not found (HTTP {status})",
     "scan_success": "Scan launched successfully.",
     "scan_error": "Scan error: {error}",
+    "last_scan_failed": "Last scan failed: {error}",
     "disable_success": "Server disabled.",
     "reactivate_success": "Server reactivated.",
     "delete_modal_title": "Delete server",
@@ -177,7 +178,8 @@
     "btn_unlimited": "Unlimited",
     "filter_placeholder": "Search fingerprint, user, owner…",
     "filter_all_statuses": "All statuses",
-    "no_results": "No matching keys."
+    "no_results": "No matching keys.",
+    "revoke_unavailable": "Cannot revoke: last scan failed (server unreachable)"
   },
   "access": {
     "title": "Temporary Access",
@@ -434,7 +436,8 @@
     "filter_apply": "Apply",
     "export_csv": "Export CSV",
     "refresh_error": "Refresh failed: {error}",
-    "load_error": "Failed to load sessions: {error}"
+    "load_error": "Failed to load sessions: {error}",
+    "scan_required": "Scan the server first to refresh sessions"
   },
   "password_banner": {
     "message": "Your password has never been changed. Please update it for security.",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -120,6 +120,7 @@
     "load_error": "Servidor no encontrado (HTTP {status})",
     "scan_success": "Escaneo iniciado con éxito.",
     "scan_error": "Error de escaneo: {error}",
+    "last_scan_failed": "Último escaneo fallido: {error}",
     "disable_success": "Servidor desactivado.",
     "reactivate_success": "Servidor reactivado.",
     "delete_modal_title": "Eliminar servidor",
@@ -177,7 +178,8 @@
     "btn_unlimited": "Ilimitado",
     "filter_placeholder": "Buscar fingerprint, usuario, owner…",
     "filter_all_statuses": "Todos los estados",
-    "no_results": "No se encontraron claves."
+    "no_results": "No se encontraron claves.",
+    "revoke_unavailable": "No se puede revocar: último escaneo fallido (servidor inaccesible)"
   },
   "access": {
     "title": "Acceso temporal",
@@ -434,7 +436,8 @@
     "filter_apply": "Aplicar",
     "export_csv": "Exportar CSV",
     "refresh_error": "Error al actualizar: {error}",
-    "load_error": "Error al cargar sesiones: {error}"
+    "load_error": "Error al cargar sesiones: {error}",
+    "scan_required": "Escanee el servidor primero para actualizar las sesiones"
   },
   "password_banner": {
     "message": "Su contraseña nunca ha sido cambiada. Por favor, actualícela por seguridad.",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -30,6 +30,7 @@
     "scanning": "Escaneando…",
     "status_ok": "✅ OK",
     "status_alert": "🟡 Alerta",
+    "status_scan_failed": "🟠 Escaneo fallido",
     "status_inactive": "🔴 Inactivo",
     "status_total": "Total",
     "collector_key": "Clave pública del colector",
@@ -96,6 +97,7 @@
     "col_actions": "Acciones",
     "empty": "No se encontraron servidores.",
     "disabled_badge": "DESACTIVADO",
+    "status_scan_failed": "Último escaneo fallido",
     "scan": "Escanear",
     "edit": "Editar"
   },
@@ -179,7 +181,8 @@
     "filter_placeholder": "Buscar fingerprint, usuario, owner…",
     "filter_all_statuses": "Todos los estados",
     "no_results": "No se encontraron claves.",
-    "revoke_unavailable": "No se puede revocar: último escaneo fallido (servidor inaccesible)"
+    "revoke_unavailable": "No se puede revocar: último escaneo fallido (servidor inaccesible)",
+    "validate_unavailable": "No se puede validar: último escaneo fallido (servidor inaccesible)"
   },
   "access": {
     "title": "Acceso temporal",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -120,6 +120,7 @@
     "load_error": "Serveur introuvable (HTTP {status})",
     "scan_success": "Scan lancé avec succès.",
     "scan_error": "Erreur scan : {error}",
+    "last_scan_failed": "Dernier scan échoué : {error}",
     "disable_success": "Serveur désactivé.",
     "reactivate_success": "Serveur réactivé.",
     "delete_modal_title": "Supprimer le serveur",
@@ -177,7 +178,8 @@
     "btn_unlimited": "Illimité",
     "filter_placeholder": "Rechercher fingerprint, utilisateur, owner…",
     "filter_all_statuses": "Tous les statuts",
-    "no_results": "Aucune clé correspondante."
+    "no_results": "Aucune clé correspondante.",
+    "revoke_unavailable": "Révocation impossible : dernier scan échoué (serveur injoignable)"
   },
   "access": {
     "title": "Accès temporaires",
@@ -434,7 +436,8 @@
     "filter_apply": "Appliquer",
     "export_csv": "Exporter CSV",
     "refresh_error": "Actualisation échouée : {error}",
-    "load_error": "Impossible de charger les sessions : {error}"
+    "load_error": "Impossible de charger les sessions : {error}",
+    "scan_required": "Scannez le serveur pour actualiser les sessions"
   },
   "password_banner": {
     "message": "Votre mot de passe n'a jamais été changé. Veuillez le mettre à jour pour votre sécurité.",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -30,6 +30,7 @@
     "scanning": "Scan en cours…",
     "status_ok": "✅ OK",
     "status_alert": "🟡 Alerte",
+    "status_scan_failed": "🟠 Scan échoué",
     "status_inactive": "🔴 Inactif",
     "status_total": "Total",
     "collector_key": "Clé publique collecteur",
@@ -96,6 +97,7 @@
     "col_actions": "Actions",
     "empty": "Aucun serveur trouvé.",
     "disabled_badge": "DÉSACTIVÉ",
+    "status_scan_failed": "Dernier scan échoué",
     "scan": "Scanner",
     "edit": "Éditer"
   },
@@ -179,7 +181,8 @@
     "filter_placeholder": "Rechercher fingerprint, utilisateur, owner…",
     "filter_all_statuses": "Tous les statuts",
     "no_results": "Aucune clé correspondante.",
-    "revoke_unavailable": "Révocation impossible : dernier scan échoué (serveur injoignable)"
+    "revoke_unavailable": "Révocation impossible : dernier scan échoué (serveur injoignable)",
+    "validate_unavailable": "Validation impossible : dernier scan échoué (serveur injoignable)"
   },
   "access": {
     "title": "Accès temporaires",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -30,6 +30,7 @@
     "scanning": "Scansione…",
     "status_ok": "✅ OK",
     "status_alert": "🟡 Allerta",
+    "status_scan_failed": "🟠 Scansione fallita",
     "status_inactive": "🔴 Inattivo",
     "status_total": "Totale",
     "collector_key": "Chiave pubblica collector",
@@ -96,6 +97,7 @@
     "col_actions": "Azioni",
     "empty": "Nessun server trovato.",
     "disabled_badge": "DISABILITATO",
+    "status_scan_failed": "Ultima scansione fallita",
     "scan": "Scansiona",
     "edit": "Modifica"
   },
@@ -179,7 +181,8 @@
     "filter_placeholder": "Cerca fingerprint, utente, owner…",
     "filter_all_statuses": "Tutti gli stati",
     "no_results": "Nessuna chiave corrispondente.",
-    "revoke_unavailable": "Impossibile revocare: ultima scansione fallita (server non raggiungibile)"
+    "revoke_unavailable": "Impossibile revocare: ultima scansione fallita (server non raggiungibile)",
+    "validate_unavailable": "Impossibile validare: ultima scansione fallita (server non raggiungibile)"
   },
   "access": {
     "title": "Accesso temporaneo",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -120,6 +120,7 @@
     "load_error": "Server non trovato (HTTP {status})",
     "scan_success": "Scansione avviata con successo.",
     "scan_error": "Errore scansione: {error}",
+    "last_scan_failed": "Ultima scansione fallita: {error}",
     "disable_success": "Server disabilitato.",
     "reactivate_success": "Server riattivato.",
     "delete_modal_title": "Elimina server",
@@ -177,7 +178,8 @@
     "btn_unlimited": "Illimitato",
     "filter_placeholder": "Cerca fingerprint, utente, owner…",
     "filter_all_statuses": "Tutti gli stati",
-    "no_results": "Nessuna chiave corrispondente."
+    "no_results": "Nessuna chiave corrispondente.",
+    "revoke_unavailable": "Impossibile revocare: ultima scansione fallita (server non raggiungibile)"
   },
   "access": {
     "title": "Accesso temporaneo",
@@ -434,7 +436,8 @@
     "filter_apply": "Applica",
     "export_csv": "Esporta CSV",
     "refresh_error": "Aggiornamento fallito: {error}",
-    "load_error": "Impossibile caricare le sessioni: {error}"
+    "load_error": "Impossibile caricare le sessioni: {error}",
+    "scan_required": "Scansionare prima il server per aggiornare le sessioni"
   },
   "password_banner": {
     "message": "La password non è mai stata cambiata. Aggiornala per motivi di sicurezza.",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -29,6 +29,10 @@
         <span class="counter-value">{{ counts.warn }}</span>
         <span class="counter-label">{{ $t('dashboard.status_alert') }}</span>
       </div>
+      <div class="counter counter-scan-fail">
+        <span class="counter-value">{{ counts.scanFailed }}</span>
+        <span class="counter-label">{{ $t('dashboard.status_scan_failed') }}</span>
+      </div>
       <div class="counter counter-danger">
         <span class="counter-value">{{ counts.danger }}</span>
         <span class="counter-label">{{ $t('dashboard.status_inactive') }}</span>
@@ -312,8 +316,11 @@ const editError = ref('')
 const editForm = ref({ hostname: '', ip: '', environment: '', os_family: '', ssh_port: 22 })
 
 const counts = computed(() => ({
-  ok: servers.value.filter((s) => s.is_active && !s.has_anomalies).length,
-  warn: servers.value.filter((s) => s.is_active && s.has_anomalies).length,
+  ok: servers.value.filter((s) => s.is_active && !s.has_anomalies && s.last_scan_ok !== false)
+    .length,
+  warn: servers.value.filter((s) => s.is_active && s.last_scan_ok !== false && s.has_anomalies)
+    .length,
+  scanFailed: servers.value.filter((s) => s.is_active && s.last_scan_ok === false).length,
   danger: servers.value.filter((s) => !s.is_active).length,
 }))
 
@@ -583,6 +590,9 @@ h1 {
 }
 .counter-warn {
   border-left: 4px solid #ffc107;
+}
+.counter-scan-fail {
+  border-left: 4px solid #fd7e14;
 }
 .counter-danger {
   border-left: 4px solid #dc3545;

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -53,6 +53,9 @@
 
     <div v-if="error" class="alert-error">{{ error }}</div>
     <div v-if="message" class="alert-info">{{ message }}</div>
+    <div v-if="!loading && server.last_scan_ok === false" class="alert-warning">
+      {{ $t('server_detail.last_scan_failed', { error: server.last_scan_error }) }}
+    </div>
 
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
 
@@ -85,7 +88,7 @@
       </section>
 
       <!-- SSH Sessions -->
-      <SessionsCard :hostname="hostname" :current-role="currentRole" />
+      <SessionsCard :hostname="hostname" :current-role="currentRole" :scan-ok="scanOk" />
 
       <!-- SSH Keys -->
       <section class="card">
@@ -93,6 +96,7 @@
         <KeyTable
           :keys="keys"
           :current-role="currentRole"
+          :scan-ok="scanOk"
           @validate="validateKey"
           @revoke="openRevoke"
           @set-expiry="openExpiry"
@@ -420,7 +424,12 @@ async function scanServer() {
   try {
     const res = await apiFetch(`/api/servers/${hostname}/scan`, { method: 'POST' })
     if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    message.value = t('server_detail.scan_success')
+    const data = await res.json()
+    if (data.error) {
+      error.value = t('server_detail.scan_error', { error: data.error })
+    } else {
+      message.value = t('server_detail.scan_success')
+    }
     await load()
   } catch (e) {
     error.value = t('server_detail.scan_error', { error: e.message })
@@ -428,6 +437,8 @@ async function scanServer() {
     scanning.value = false
   }
 }
+
+const scanOk = computed(() => server.value?.last_scan_ok ?? null)
 
 const efp = (fp) => encodeURIComponent(fp)
 
@@ -668,6 +679,15 @@ dd {
   background: #f8d7da;
   color: #721c24;
   border: 1px solid #f5c6cb;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+.alert-warning {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeeba;
   padding: 0.75rem 1rem;
   border-radius: 4px;
   margin-bottom: 1rem;

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -53,7 +53,7 @@
 
     <div v-if="error" class="alert-error">{{ error }}</div>
     <div v-if="message" class="alert-info">{{ message }}</div>
-    <div v-if="!loading && server.last_scan_ok === false" class="alert-warning">
+    <div v-if="!loading && server.last_scan_ok === false" class="alert-error">
       {{ $t('server_detail.last_scan_failed', { error: server.last_scan_error }) }}
     </div>
 
@@ -684,16 +684,6 @@ dd {
   margin-bottom: 1rem;
   font-size: 0.95rem;
 }
-.alert-warning {
-  background: #fff3cd;
-  color: #856404;
-  border: 1px solid #ffeeba;
-  padding: 0.75rem 1rem;
-  border-radius: 4px;
-  margin-bottom: 1rem;
-  font-size: 0.95rem;
-}
-
 .modal-overlay {
   position: fixed;
   inset: 0;

--- a/ui/tests/Dashboard.spec.js
+++ b/ui/tests/Dashboard.spec.js
@@ -305,6 +305,33 @@ describe('Dashboard - Add Server Modal', () => {
     expect(w.find('.field-error').exists()).toBe(true)
   })
 
+  it('counts scanFailed servers in the dedicated counter', async () => {
+    const router = createMockRouter()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url) => {
+        if (url === '/api/servers') {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve([
+                { hostname: 's1', is_active: true, has_anomalies: false, last_scan_ok: true },
+                { hostname: 's2', is_active: true, has_anomalies: false, last_scan_ok: false },
+                { hostname: 's3', is_active: true, has_anomalies: false, last_scan_ok: false },
+                { hostname: 's4', is_active: false, has_anomalies: false, last_scan_ok: null },
+              ]),
+          })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(null) })
+      }),
+    )
+    const w = mount(Dashboard, { global: { plugins: [i18n, router] } })
+    await flushPromises()
+    expect(w.vm.counts.ok).toBe(1)
+    expect(w.vm.counts.scanFailed).toBe(2)
+    expect(w.vm.counts.danger).toBe(1)
+  })
+
   it('accepts valid hostnames — simple label and FQDN', async () => {
     const router = createMockRouter()
     const w = mount(Dashboard, { global: { plugins: [i18n, router] } })

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -231,4 +231,49 @@ describe('KeyTable', () => {
     const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
     expect(rows.length).toBe(2)
   })
+
+  it('disables revoke button when scanOk is false', () => {
+    const w = mount(KeyTable, {
+      props: { keys: [makeKey({ status: 'ACTIVE' })], currentRole: 'sysadmin', scanOk: false },
+      global: { plugins: [i18n] },
+    })
+    const revokeBtn = w.findAll('button').find((b) => b.text() === 'Revoke')
+    expect(revokeBtn).toBeDefined()
+    expect(revokeBtn.attributes('disabled')).toBeDefined()
+    expect(revokeBtn.attributes('title')).toContain('Cannot revoke')
+  })
+
+  it('keeps revoke button enabled when scanOk is true', () => {
+    const w = mount(KeyTable, {
+      props: { keys: [makeKey({ status: 'ACTIVE' })], currentRole: 'sysadmin', scanOk: true },
+      global: { plugins: [i18n] },
+    })
+    const revokeBtn = w.findAll('button').find((b) => b.text() === 'Revoke')
+    expect(revokeBtn).toBeDefined()
+    expect(revokeBtn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('keeps revoke button enabled when scanOk is null (no scan yet)', () => {
+    const w = mount(KeyTable, {
+      props: { keys: [makeKey({ status: 'ACTIVE' })], currentRole: 'sysadmin', scanOk: null },
+      global: { plugins: [i18n] },
+    })
+    const revokeBtn = w.findAll('button').find((b) => b.text() === 'Revoke')
+    expect(revokeBtn).toBeDefined()
+    expect(revokeBtn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('validate button stays enabled even when scanOk is false', () => {
+    const w = mount(KeyTable, {
+      props: {
+        keys: [makeKey({ status: 'PENDING_REVIEW' })],
+        currentRole: 'sysadmin',
+        scanOk: false,
+      },
+      global: { plugins: [i18n] },
+    })
+    const validateBtn = w.findAll('button').find((b) => b.text() === 'Validate')
+    expect(validateBtn).toBeDefined()
+    expect(validateBtn.attributes('disabled')).toBeUndefined()
+  })
 })

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -263,12 +263,27 @@ describe('KeyTable', () => {
     expect(revokeBtn.attributes('disabled')).toBeUndefined()
   })
 
-  it('validate button stays enabled even when scanOk is false', () => {
+  it('validate button is disabled when scanOk is false', () => {
     const w = mount(KeyTable, {
       props: {
         keys: [makeKey({ status: 'PENDING_REVIEW' })],
         currentRole: 'sysadmin',
         scanOk: false,
+      },
+      global: { plugins: [i18n] },
+    })
+    const validateBtn = w.findAll('button').find((b) => b.text() === 'Validate')
+    expect(validateBtn).toBeDefined()
+    expect(validateBtn.attributes('disabled')).toBeDefined()
+    expect(validateBtn.attributes('title')).toContain('Cannot validate')
+  })
+
+  it('validate button is enabled when scanOk is true', () => {
+    const w = mount(KeyTable, {
+      props: {
+        keys: [makeKey({ status: 'PENDING_REVIEW' })],
+        currentRole: 'sysadmin',
+        scanOk: true,
       },
       global: { plugins: [i18n] },
     })

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -217,4 +217,36 @@ describe('ServerTable', () => {
     const hostnameHeader = w.findAll('th.th-sortable').find((th) => th.text().includes('Hostname'))
     expect(hostnameHeader.text()).toContain('↕')
   })
+
+  it('affiche 🟠 pour un serveur actif dont le dernier scan a échoué', () => {
+    const server = {
+      id: '4', hostname: 'fail-01', ip_address: '10.0.0.4',
+      environment: 'lab', os_family: null, added_at: null,
+      is_active: true, has_anomalies: false, last_scan_ok: false,
+    }
+    const w = mountTable([server])
+    expect(w.text()).toContain('🟠')
+  })
+
+  it('applique la classe row-scan-fail quand last_scan_ok est false', () => {
+    const server = {
+      id: '4', hostname: 'fail-01', ip_address: '10.0.0.4',
+      environment: 'lab', os_family: null, added_at: null,
+      is_active: true, has_anomalies: false, last_scan_ok: false,
+    }
+    const w = mountTable([server])
+    const row = w.find('tbody tr')
+    expect(row.classes()).toContain('row-scan-fail')
+  })
+
+  it('🟠 a priorité sur 🟡 (scan failed + anomalies)', () => {
+    const server = {
+      id: '5', hostname: 'fail-anomaly', ip_address: '10.0.0.5',
+      environment: 'lab', os_family: null, added_at: null,
+      is_active: true, has_anomalies: true, last_scan_ok: false,
+    }
+    const w = mountTable([server])
+    expect(w.text()).toContain('🟠')
+    expect(w.text()).not.toContain('🟡')
+  })
 })

--- a/ui/tests/SessionsCard.spec.js
+++ b/ui/tests/SessionsCard.spec.js
@@ -482,4 +482,56 @@ describe('SessionsCard.vue', () => {
     expect(wrapper.find('.alert-error').exists()).toBe(true)
     expect(wrapper.find('.alert-error').text()).toContain('Failed to load sessions')
   })
+
+  it('disables refresh button when scanOk is false', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ active: [], recent: [] }),
+    })
+
+    const wrapper = mount(SessionsCard, {
+      props: { hostname: 'server13', currentRole: 'sysadmin', scanOk: false },
+      global: { plugins: [i18n] },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    const refreshBtn = wrapper.find('[data-testid="sessions-refresh"]')
+    expect(refreshBtn.attributes('disabled')).toBeDefined()
+    expect(refreshBtn.attributes('title')).toContain('Scan the server first')
+  })
+
+  it('keeps refresh button enabled when scanOk is null (no scan yet)', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ active: [], recent: [] }),
+    })
+
+    const wrapper = mount(SessionsCard, {
+      props: { hostname: 'server14', currentRole: 'sysadmin', scanOk: null },
+      global: { plugins: [i18n] },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    const refreshBtn = wrapper.find('[data-testid="sessions-refresh"]')
+    expect(refreshBtn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('keeps history button accessible even when scanOk is false', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ active: [], recent: [] }),
+    })
+
+    const wrapper = mount(SessionsCard, {
+      props: { hostname: 'server15', currentRole: 'sysadmin', scanOk: false },
+      global: { plugins: [i18n] },
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    const historyBtn = wrapper.find('[data-testid="sessions-history-btn"]')
+    expect(historyBtn.attributes('disabled')).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

- **Faux positif bannière verte corrigé** : `scanServer()` lisait uniquement le code HTTP (toujours 200) — désormais le champ `error` du JSON est inspecté → bannière rouge si scan SSH échoué.
- **État scan persisté** : `GET /api/servers/<hostname>` inclut `last_scan_ok` / `last_scan_error` depuis `audit_log` — état correct dès le chargement de la page.
- **Refresh sessions grisé** si `scanOk === false` (historique toujours accessible).
- **Revoke et Validate grisés** si `scanOk === false` (Assign/Expiry restent actifs — DB-only).
- **Bannière rouge** (`.alert-error`) pour l'état scan échoué — CSS jaune inutilisé supprimé.
- **Dashboard enrichi** : `GET /api/servers` inclut `last_scan_ok` via `LATERAL JOIN` sur `audit_log`.
- **5e compteur** "🟠 Scan Failed" (orange) sur le dashboard — compteurs mutuellement exclusifs.
- **ServerTable** : 4e état 🟠 + classe `row-scan-fail` (fond orange clair), prioritaire sur les anomalies.
- **6 nouvelles clés i18n** dans les 5 locales (EN/FR/ES/IT/DE).

## Test plan

- [ ] 489 pytest verts (`python -m pytest app/tests/`)
- [ ] 301 vitest verts (`npx vitest run`)
- [ ] Prettier OK (`npm run format:check`)
- [ ] Scanner un serveur injoignable → bannière rouge, Refresh grisé, Revoke grisé, Validate grisé
- [ ] Dashboard : serveur avec scan échoué → compteur orange incrémenté, badge 🟠, fond orange dans la liste
- [ ] Recharger la page après scan échoué → état grisé persisté (via audit_log)
- [ ] Scanner un serveur joignable → bannière verte, tous boutons actifs, compteur OK incrémenté

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)