### PR TITLE
fix: catch SSHException from paramiko.Transport constructor in _fetch_host_key

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -546,17 +546,24 @@ def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int
 
 def _fetch_host_key(ip: str, port: int, known_hosts_path: str | None = None) -> None:
     """Fetch the server host key via a single Paramiko Transport connection and append to known_hosts."""
-    t = paramiko.Transport((ip, port))
+    t = None
     try:
+        t = paramiko.Transport((ip, port))
         t.start_client(timeout=10)
         key = t.get_remote_server_key()
     except Exception as exc:
+        msg = str(exc)
+        if "Connection refused" in msg or "refused" in msg:
+            raise RuntimeError(
+                f"SSH port {port} refused — check that SSH is running on that port"
+            ) from exc
         raise RuntimeError(
             f"Server unreachable — could not get host key on port {port}. "
             "Check the IP address and that SSH is running."
         ) from exc
     finally:
-        t.close()
+        if t is not None:
+            t.close()
     host = f"[{ip}]:{port}" if port != 22 else ip
     path = known_hosts_path if known_hosts_path is not None else KNOWN_HOSTS
     with open(path, "a") as fh:

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -797,12 +797,12 @@ def test_ssh_fetch_host_key_non_standard_port_brackets():
 
 
 def test_ssh_fetch_host_key_raises_on_unreachable():
-    """_fetch_host_key raises RuntimeError when Transport cannot connect."""
+    """_fetch_host_key raises RuntimeError when Transport cannot connect (generic error)."""
     import tempfile
     from unittest.mock import MagicMock, patch
 
     mock_transport = MagicMock()
-    mock_transport.start_client.side_effect = Exception("Connection refused")
+    mock_transport.start_client.side_effect = Exception("Network timeout")
 
     with tempfile.NamedTemporaryFile("w", suffix="known_hosts", delete=False) as f:
         path = f.name
@@ -811,6 +811,44 @@ def test_ssh_fetch_host_key_raises_on_unreachable():
             with pytest.raises(RuntimeError, match="unreachable"):
                 ssh._fetch_host_key("10.0.0.1", 22, known_hosts_path=path)
         mock_transport.close.assert_called_once()
+    finally:
+        os.unlink(path)
+
+
+def test_ssh_fetch_host_key_connection_refused_raises_runtime_error():
+    """_fetch_host_key raises RuntimeError with 'refused' when Transport constructor gets connection refused."""
+    import tempfile
+    from unittest.mock import patch
+    import paramiko as paramiko_mod
+
+    with tempfile.NamedTemporaryFile("w", suffix="known_hosts", delete=False) as f:
+        path = f.name
+    try:
+        with patch(
+            "ssh.paramiko.Transport",
+            side_effect=paramiko_mod.SSHException("Unable to connect: [Errno 111] Connection refused"),
+        ):
+            with pytest.raises(RuntimeError, match="refused"):
+                ssh._fetch_host_key("10.0.0.1", 22, known_hosts_path=path)
+    finally:
+        os.unlink(path)
+
+
+def test_ssh_fetch_host_key_generic_ssh_exception_raises_runtime_error():
+    """_fetch_host_key raises RuntimeError with 'unreachable' for non-refused SSHException."""
+    import tempfile
+    from unittest.mock import patch
+    import paramiko as paramiko_mod
+
+    with tempfile.NamedTemporaryFile("w", suffix="known_hosts", delete=False) as f:
+        path = f.name
+    try:
+        with patch(
+            "ssh.paramiko.Transport",
+            side_effect=paramiko_mod.SSHException("Network unreachable"),
+        ):
+            with pytest.raises(RuntimeError, match="unreachable"):
+                ssh._fetch_host_key("10.0.0.1", 22, known_hosts_path=path)
     finally:
         os.unlink(path)
 

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -419,6 +419,23 @@ def test_web_add_server_ssh_failure_returns_422(auth_client):
         assert resp.status_code == 422
 
 
+def test_web_add_server_ssh_port_refused_returns_422(auth_client):
+    """POST /api/servers returns 422 with SSH_PORT_REFUSED when port is refused."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.add_server.side_effect = RuntimeError(
+            "SSH port 22 refused — check that SSH is running on that port"
+        )
+        resp = auth_client.post(
+            "/api/servers",
+            json={"hostname": "new-srv", "ip": "10.0.0.1",
+                  "ssh_user": "root", "ssh_password": "pass"},
+        )
+        assert resp.status_code == 422
+        data = resp.get_json()
+        assert data["error_code"] == "SSH_PORT_REFUSED"
+
+
 def test_web_add_server_env_optional(auth_client):
     """environment field is optional — server can be created without it."""
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:


### PR DESCRIPTION
## Summary

- `paramiko.Transport((ip, port))` was outside the `try` block in `_fetch_host_key()` — a `SSHException` on connection refused propagated uncaught → HTTP 500
- Move Transport construction inside the try, with `t = None` before and a conditional `finally`
- Add a "Connection refused" branch that raises `RuntimeError("SSH port X refused …")` so `_ssh_error_code()` maps it to `SSH_PORT_REFUSED` and the Dashboard modal displays the existing localized message instead of "HTTP 500"

Closes #325

## Test plan

- [ ] `python -m pytest app/tests/` → 492 tests green (added 3: 2 in test_ssh.py, 1 in test_web.py)
- [ ] Manually: add a server with a refused SSH port → modal shows "SSH port refused — check that SSH is running on this port." instead of "HTTP 500"

🤖 Generated with [Claude Code](https://claude.com/claude-code)