### PR TITLE
fix: chown audit-collector home directory in provision-host.sh

### DIFF
--- a/provision-host.sh
+++ b/provision-host.sh
@@ -19,6 +19,7 @@ if ! id "${COLLECTOR_USER}" >/dev/null 2>&1; then
 else
     echo "[provision] User ${COLLECTOR_USER} already exists."
 fi
+chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "/home/${COLLECTOR_USER}"
 chmod 700 "/home/${COLLECTOR_USER}"
 
 # 2. Configure SSH directory


### PR DESCRIPTION
## Summary

- `provision-host.sh` called `chmod 700` on the collector home but never `chown` — if a sysadmin accidentally changes ownership, re-provision now silently fixes it
- One-line fix: add `chown "${COLLECTOR_USER}:${COLLECTOR_USER}" "/home/${COLLECTOR_USER}"` before the `chmod`

Closes #327

## Test plan

- [ ] Re-provision a server where `/home/audit-collector` was accidentally set to `root:root`
- [ ] Verify `ls -la /home/` shows `audit-collector:audit-collector 700` after provision
- [ ] Scan succeeds (`SCAN_COMPLETED` in audit log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)