### PR TITLE
fix: make msmtp auth conditional on SMTP_USERNAME

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,9 +53,17 @@ tls_certcheck  ${_certcheck}"
             ;;
     esac
 
+    if [ -n "${SMTP_USERNAME}" ]; then
+        _auth_block="auth           on
+user           ${SMTP_USERNAME}
+password       ${SMTP_PASSWORD}"
+    else
+        _auth_block="auth           off"
+    fi
+
     cat > /etc/msmtprc << EOF
 defaults
-auth           on
+${_auth_block}
 ${_tls_block}
 logfile        /dev/stderr
 
@@ -63,8 +71,6 @@ account        default
 host           ${SMTP_HOST:-mail.example.com}
 port           ${SMTP_PORT:-587}
 from           ${SMTP_FROM:-ssh-manager@example.com}
-user           ${SMTP_USERNAME:-alerts@example.com}
-password       ${SMTP_PASSWORD:-changeme}
 EOF
     chmod 640 /etc/msmtprc
     chown root:nobody /etc/msmtprc


### PR DESCRIPTION
## Summary

- `generate_msmtprc()` always wrote `auth on` with hardcoded fallbacks — local relays without auth (Postfix port 25) rejected this
- If `SMTP_USERNAME` is empty → `auth off` (unauthenticated relay)
- If `SMTP_USERNAME` is set → `auth on` with user/password (unchanged behavior)
- `user` and `password` lines are now only written when credentials are provided

Closes #329

## Test plan

- [ ] `SMTP_USERNAME=` (empty) → `cat /etc/msmtprc` shows `auth off`, no `user`/`password` lines
- [ ] `SMTP_USERNAME=user@example.com` → `auth on` with user/password present
- [ ] SMTP test from Settings UI passes against a local unauthenticated relay

🤖 Generated with [Claude Code](https://claude.com/claude-code)