### PR TITLE
feat: add Edit button to ServerDetail page

### DIFF
--- a/ui/src/components/EditServerModal.vue
+++ b/ui/src/components/EditServerModal.vue
@@ -162,3 +162,89 @@ async function confirm() {
   }
 }
 </script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  width: 480px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.required {
+  color: #dc3545;
+}
+
+.modal input[type='text'],
+.modal input[type='number'],
+.modal select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+}
+
+.input-readonly {
+  background: #f5f5f5;
+  color: #666;
+  cursor: not-allowed;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form-field label {
+  margin-bottom: 0;
+}
+
+.alert-error {
+  background: #f8d7da;
+  color: #721c24;
+  padding: 0.6rem 1rem;
+  border-radius: 4px;
+}
+
+.field-error {
+  font-size: 0.8rem;
+  color: #c00;
+  margin-top: 0.2rem;
+  display: block;
+}
+</style>

--- a/ui/src/components/EditServerModal.vue
+++ b/ui/src/components/EditServerModal.vue
@@ -1,0 +1,164 @@
+<template>
+  <div v-if="modelValue" class="modal-overlay" @click.self="close">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>{{ $t('edit_server.title') }}</h3>
+        <button class="modal-close" @click="close" aria-label="Close">&#x2715;</button>
+      </div>
+      <div v-if="editError" class="alert-error">{{ editError }}</div>
+
+      <div class="form-grid">
+        <!-- Hostname (readonly) + IP -->
+        <div class="form-field">
+          <label>{{ $t('edit_server.hostname') }}</label>
+          <input :value="props.server?.hostname" type="text" disabled class="input-readonly" />
+        </div>
+        <div class="form-field">
+          <label
+            >{{ $t('edit_server.ip') }}
+            <span class="required">{{ $t('common.required') }}</span></label
+          >
+          <input
+            v-model="editForm.ip"
+            type="text"
+            :placeholder="$t('edit_server.ip_placeholder')"
+          />
+          <span v-if="editIpError" class="field-error">{{ editIpError }}</span>
+        </div>
+
+        <!-- Environment + OS Family -->
+        <div class="form-field">
+          <label>{{ $t('edit_server.environment') }}</label>
+          <select v-model="editForm.environment">
+            <option value="">{{ $t('edit_server.env_placeholder') }}</option>
+            <option value="production">production</option>
+            <option value="staging">staging</option>
+            <option value="lab">lab</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label>{{ $t('edit_server.os_family') }}</label>
+          <input
+            v-model="editForm.os_family"
+            type="text"
+            :placeholder="$t('edit_server.os_placeholder')"
+          />
+        </div>
+
+        <!-- Port SSH (half width) -->
+        <div class="form-field">
+          <label>{{ $t('edit_server.ssh_port_label') }}</label>
+          <input
+            v-model.number="editForm.ssh_port"
+            type="number"
+            min="1"
+            max="65535"
+            placeholder="22"
+          />
+        </div>
+      </div>
+
+      <div class="modal-actions">
+        <button class="btn-secondary" @click="close">{{ $t('common.cancel') }}</button>
+        <button class="btn-primary" :disabled="!editFormValid || editing" @click="confirm">
+          <Spinner v-if="editing" />
+          {{ editing ? $t('edit_server.submitting') : $t('edit_server.submit') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { apiFetch } from '../composables/useAuth.js'
+import Spinner from './Spinner.vue'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  server: { type: Object, default: null },
+  allServers: { type: Array, default: () => [] },
+})
+
+const emit = defineEmits(['update:modelValue', 'saved'])
+
+const { t } = useI18n()
+
+const editForm = ref({ ip: '', environment: '', os_family: '', ssh_port: 22 })
+const editing = ref(false)
+const editError = ref('')
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open && props.server) {
+      editForm.value = {
+        ip: props.server.ip_address || '',
+        environment: props.server.environment || '',
+        os_family: props.server.os_family || '',
+        ssh_port: props.server.ssh_port || 22,
+      }
+      editError.value = ''
+    }
+  }
+)
+
+function isValidIp(ip) {
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+  const m = v4.exec(ip.trim())
+  if (m) return m.slice(1).every((n) => +n <= 255)
+  const v6 = /^[0-9a-fA-F:]+$/
+  return v6.test(ip.trim()) && ip.includes(':')
+}
+
+function isIpDuplicate(ip) {
+  if (!props.allServers.length) return false
+  const normalized = ip.trim()
+  return props.allServers.some(
+    (s) => s.ip_address === normalized && s.hostname !== props.server?.hostname
+  )
+}
+
+const editIpError = computed(() => {
+  const ip = editForm.value.ip.trim()
+  if (!ip) return ''
+  if (!isValidIp(ip)) return t('add_server.error_invalid_ip')
+  if (isIpDuplicate(ip)) return t('add_server.error_duplicate_ip')
+  return ''
+})
+
+const editFormValid = computed(
+  () =>
+    editForm.value.ip.trim() && isValidIp(editForm.value.ip) && !isIpDuplicate(editForm.value.ip)
+)
+
+function close() {
+  emit('update:modelValue', false)
+}
+
+async function confirm() {
+  editing.value = true
+  editError.value = ''
+  try {
+    const res = await apiFetch(`/api/servers/${props.server.hostname}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ip: editForm.value.ip.trim(),
+        environment: editForm.value.environment,
+        os_family: editForm.value.os_family.trim() || null,
+        ssh_port: editForm.value.ssh_port || 22,
+      }),
+    })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
+    close()
+    emit('saved')
+  } catch (e) {
+    editError.value = e.message
+  } finally {
+    editing.value = false
+  }
+}
+</script>

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -105,6 +105,7 @@
   "server_detail": {
     "scan": "Scannen",
     "scanning": "Scannen",
+    "edit": "Bearbeiten",
     "disable": "Deaktivieren",
     "reactivate": "Reaktivieren",
     "delete": "Löschen",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -105,6 +105,7 @@
   "server_detail": {
     "scan": "Scan",
     "scanning": "Scanning",
+    "edit": "Edit",
     "disable": "Disable",
     "reactivate": "Reactivate",
     "delete": "Delete",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -105,6 +105,7 @@
   "server_detail": {
     "scan": "Escanear",
     "scanning": "Escaneando",
+    "edit": "Editar",
     "disable": "Desactivar",
     "reactivate": "Reactivar",
     "delete": "Eliminar",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -105,6 +105,7 @@
   "server_detail": {
     "scan": "Scanner",
     "scanning": "Scan en cours",
+    "edit": "Modifier",
     "disable": "Désactiver",
     "reactivate": "Réactiver",
     "delete": "Supprimer",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -105,6 +105,7 @@
   "server_detail": {
     "scan": "Scansiona",
     "scanning": "Scansione",
+    "edit": "Modifica",
     "disable": "Disabilita",
     "reactivate": "Riattiva",
     "delete": "Elimina",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -204,79 +204,12 @@
       </div>
     </div>
 
-    <!-- Edit server modal -->
-    <div v-if="showEditServer" class="modal-overlay" @click.self="closeEditServer">
-      <div class="modal">
-        <div class="modal-header">
-          <h3>{{ $t('edit_server.title') }}</h3>
-          <button class="modal-close" @click="closeEditServer" aria-label="Close">&#x2715;</button>
-        </div>
-        <div v-if="editError" class="alert-error">{{ editError }}</div>
-
-        <div class="form-grid">
-          <!-- Hostname (readonly) + IP -->
-          <div class="form-field">
-            <label>{{ $t('edit_server.hostname') }}</label>
-            <input v-model="editForm.hostname" type="text" disabled class="input-readonly" />
-          </div>
-          <div class="form-field">
-            <label
-              >{{ $t('edit_server.ip') }}
-              <span class="required">{{ $t('common.required') }}</span></label
-            >
-            <input
-              v-model="editForm.ip"
-              type="text"
-              :placeholder="$t('edit_server.ip_placeholder')"
-            />
-            <span v-if="editIpError" class="field-error">{{ editIpError }}</span>
-          </div>
-
-          <!-- Environment + OS Family -->
-          <div class="form-field">
-            <label>{{ $t('edit_server.environment') }}</label>
-            <select v-model="editForm.environment">
-              <option value="">{{ $t('edit_server.env_placeholder') }}</option>
-              <option value="production">production</option>
-              <option value="staging">staging</option>
-              <option value="lab">lab</option>
-            </select>
-          </div>
-          <div class="form-field">
-            <label>{{ $t('edit_server.os_family') }}</label>
-            <input
-              v-model="editForm.os_family"
-              type="text"
-              :placeholder="$t('edit_server.os_placeholder')"
-            />
-          </div>
-
-          <!-- Port SSH (half width) -->
-          <div class="form-field">
-            <label>{{ $t('edit_server.ssh_port_label') }}</label>
-            <input
-              v-model.number="editForm.ssh_port"
-              type="number"
-              min="1"
-              max="65535"
-              placeholder="22"
-            />
-          </div>
-        </div>
-
-        <div class="modal-actions">
-          <button class="btn-secondary" @click="closeEditServer">{{ $t('common.cancel') }}</button>
-          <button
-            class="btn-primary"
-            :disabled="!editFormValid || editing"
-            @click="confirmEditServer"
-          >
-            <Spinner v-if="editing" />
-            {{ editing ? $t('edit_server.submitting') : $t('edit_server.submit') }}
-          </button>
-        </div>
-      </div>
-    </div>
+    <EditServerModal
+      v-model="showEditServer"
+      :server="editingServer"
+      :all-servers="servers"
+      @saved="loadServers"
+    />
   </div>
 </template>
 
@@ -286,6 +219,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuth, apiFetch } from '../composables/useAuth.js'
 import ServerTable from '../components/ServerTable.vue'
 import Spinner from '../components/Spinner.vue'
+import EditServerModal from '../components/EditServerModal.vue'
 
 const { t, te } = useI18n()
 const { admin } = useAuth()
@@ -316,9 +250,7 @@ const addForm = ref({
 })
 
 const showEditServer = ref(false)
-const editing = ref(false)
-const editError = ref('')
-const editForm = ref({ hostname: '', ip: '', environment: '', os_family: '', ssh_port: 22 })
+const editingServer = ref(null)
 
 const counts = computed(() => ({
   ok: servers.value.filter((s) => s.is_active && !s.has_anomalies && s.last_scan_ok !== false)
@@ -362,14 +294,6 @@ const addIpError = computed(() => {
   return ''
 })
 
-const editIpError = computed(() => {
-  const ip = editForm.value.ip.trim()
-  if (!ip) return ''
-  if (!isValidIp(ip)) return t('add_server.error_invalid_ip')
-  if (isIpDuplicate(ip, editForm.value.hostname)) return t('add_server.error_duplicate_ip')
-  return ''
-})
-
 const addFormValid = computed(
   () =>
     addForm.value.hostname.trim() &&
@@ -378,13 +302,6 @@ const addFormValid = computed(
     isValidIp(addForm.value.ip) &&
     !isIpDuplicate(addForm.value.ip.trim()) &&
     addForm.value.sshUser.trim()
-)
-
-const editFormValid = computed(
-  () =>
-    editForm.value.ip.trim() &&
-    isValidIp(editForm.value.ip) &&
-    !isIpDuplicate(editForm.value.ip.trim(), editForm.value.hostname)
 )
 
 async function loadCollectorKey() {
@@ -505,44 +422,8 @@ async function triggerScan(url, hostname) {
 }
 
 function openEditServer(server) {
-  editForm.value = {
-    hostname: server.hostname,
-    ip: server.ip_address,
-    environment: server.environment,
-    os_family: server.os_family || '',
-    ssh_port: server.ssh_port || 22,
-  }
-  editError.value = ''
+  editingServer.value = server
   showEditServer.value = true
-}
-
-function closeEditServer() {
-  showEditServer.value = false
-}
-
-async function confirmEditServer() {
-  editing.value = true
-  editError.value = ''
-  try {
-    const res = await apiFetch(`/api/servers/${editForm.value.hostname}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ip: editForm.value.ip.trim(),
-        environment: editForm.value.environment,
-        os_family: editForm.value.os_family.trim() || null,
-        ssh_port: editForm.value.ssh_port || 22,
-      }),
-    })
-    const data = await res.json().catch(() => ({}))
-    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
-    closeEditServer()
-    await loadServers()
-  } catch (e) {
-    editError.value = e.message
-  } finally {
-    editing.value = false
-  }
 }
 
 onMounted(() => {

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -15,6 +15,9 @@
           <Spinner v-if="scanning" />
           {{ scanning ? $t('server_detail.scanning') : $t('server_detail.scan') }}
         </button>
+        <button v-if="currentRole === 'sysadmin'" class="btn-secondary" @click="openEdit">
+          {{ $t('server_detail.edit') }}
+        </button>
         <button
           v-if="server.is_active && currentRole === 'sysadmin'"
           class="btn-warning"
@@ -237,6 +240,73 @@
       </div>
     </div>
 
+    <!-- Edit server modal -->
+    <div v-if="showEditModal" class="modal-overlay" @click.self="closeEdit">
+      <div class="modal">
+        <div class="modal-header">
+          <h3>{{ $t('edit_server.title') }}</h3>
+          <button class="modal-close" @click="closeEdit" aria-label="Close">&#x2715;</button>
+        </div>
+        <div v-if="editError" class="alert-error">{{ editError }}</div>
+
+        <div class="form-grid">
+          <div class="form-field">
+            <label>{{ $t('edit_server.hostname') }}</label>
+            <input :value="hostname" type="text" disabled class="input-readonly" />
+          </div>
+          <div class="form-field">
+            <label
+              >{{ $t('edit_server.ip') }}
+              <span class="required">{{ $t('common.required') }}</span></label
+            >
+            <input
+              v-model="editForm.ip"
+              type="text"
+              :placeholder="$t('edit_server.ip_placeholder')"
+            />
+            <span v-if="editForm.ip && !isValidIp(editForm.ip)" class="field-error">{{
+              $t('add_server.error_invalid_ip')
+            }}</span>
+          </div>
+          <div class="form-field">
+            <label>{{ $t('edit_server.environment') }}</label>
+            <select v-model="editForm.environment">
+              <option value="">{{ $t('edit_server.env_placeholder') }}</option>
+              <option value="production">production</option>
+              <option value="staging">staging</option>
+              <option value="lab">lab</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label>{{ $t('edit_server.os_family') }}</label>
+            <input
+              v-model="editForm.os_family"
+              type="text"
+              :placeholder="$t('edit_server.os_placeholder')"
+            />
+          </div>
+          <div class="form-field">
+            <label>{{ $t('edit_server.ssh_port_label') }}</label>
+            <input
+              v-model.number="editForm.ssh_port"
+              type="number"
+              min="1"
+              max="65535"
+              placeholder="22"
+            />
+          </div>
+        </div>
+
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="closeEdit">{{ $t('common.cancel') }}</button>
+          <button class="btn-primary" :disabled="!editFormValid || editing" @click="confirmEdit">
+            <Spinner v-if="editing" />
+            {{ editing ? $t('edit_server.submitting') : $t('edit_server.submit') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
     <!-- Re-provision modal -->
     <div
       v-if="showReprovisionModal"
@@ -346,6 +416,11 @@ const scanning = ref(false)
 const error = ref('')
 const message = ref('')
 
+const showEditModal = ref(false)
+const editing = ref(false)
+const editError = ref('')
+const editForm = ref({ ip: '', environment: '', os_family: '', ssh_port: 22 })
+
 const showDeleteModal = ref(false)
 const showReprovisionModal = ref(false)
 const reprovisioning = ref(false)
@@ -366,6 +441,58 @@ const expiryValid = computed(() => {
   if (expiryMode.value === 'hours') return expiryHours.value > 0
   return !!expiryDate.value
 })
+
+function isValidIp(ip) {
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+  const m = v4.exec(ip.trim())
+  if (m) return m.slice(1).every((n) => +n <= 255)
+  const v6 = /^[0-9a-fA-F:]+$/
+  return v6.test(ip.trim()) && ip.includes(':')
+}
+
+const editFormValid = computed(() => editForm.value.ip.trim() && isValidIp(editForm.value.ip))
+
+function openEdit() {
+  editForm.value = {
+    ip: server.value.ip || '',
+    environment: server.value.environment || '',
+    os_family: server.value.os_family || '',
+    ssh_port: server.value.ssh_port || 22,
+  }
+  editError.value = ''
+  showEditModal.value = true
+}
+
+function closeEdit() {
+  showEditModal.value = false
+}
+
+async function confirmEdit() {
+  editing.value = true
+  editError.value = ''
+  try {
+    const res = await apiFetch(`/api/servers/${hostname}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ip: editForm.value.ip.trim(),
+        environment: editForm.value.environment,
+        os_family: editForm.value.os_family.trim() || null,
+        ssh_port: editForm.value.ssh_port || 22,
+      }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    closeEdit()
+    await load()
+  } catch (e) {
+    editError.value = e.message
+  } finally {
+    editing.value = false
+  }
+}
 
 async function load() {
   loading.value = true

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -240,72 +240,7 @@
       </div>
     </div>
 
-    <!-- Edit server modal -->
-    <div v-if="showEditModal" class="modal-overlay" @click.self="closeEdit">
-      <div class="modal">
-        <div class="modal-header">
-          <h3>{{ $t('edit_server.title') }}</h3>
-          <button class="modal-close" @click="closeEdit" aria-label="Close">&#x2715;</button>
-        </div>
-        <div v-if="editError" class="alert-error">{{ editError }}</div>
-
-        <div class="form-grid">
-          <div class="form-field">
-            <label>{{ $t('edit_server.hostname') }}</label>
-            <input :value="hostname" type="text" disabled class="input-readonly" />
-          </div>
-          <div class="form-field">
-            <label
-              >{{ $t('edit_server.ip') }}
-              <span class="required">{{ $t('common.required') }}</span></label
-            >
-            <input
-              v-model="editForm.ip"
-              type="text"
-              :placeholder="$t('edit_server.ip_placeholder')"
-            />
-            <span v-if="editForm.ip && !isValidIp(editForm.ip)" class="field-error">{{
-              $t('add_server.error_invalid_ip')
-            }}</span>
-          </div>
-          <div class="form-field">
-            <label>{{ $t('edit_server.environment') }}</label>
-            <select v-model="editForm.environment">
-              <option value="">{{ $t('edit_server.env_placeholder') }}</option>
-              <option value="production">production</option>
-              <option value="staging">staging</option>
-              <option value="lab">lab</option>
-            </select>
-          </div>
-          <div class="form-field">
-            <label>{{ $t('edit_server.os_family') }}</label>
-            <input
-              v-model="editForm.os_family"
-              type="text"
-              :placeholder="$t('edit_server.os_placeholder')"
-            />
-          </div>
-          <div class="form-field">
-            <label>{{ $t('edit_server.ssh_port_label') }}</label>
-            <input
-              v-model.number="editForm.ssh_port"
-              type="number"
-              min="1"
-              max="65535"
-              placeholder="22"
-            />
-          </div>
-        </div>
-
-        <div class="modal-actions">
-          <button class="btn-secondary" @click="closeEdit">{{ $t('common.cancel') }}</button>
-          <button class="btn-primary" :disabled="!editFormValid || editing" @click="confirmEdit">
-            <Spinner v-if="editing" />
-            {{ editing ? $t('edit_server.submitting') : $t('edit_server.submit') }}
-          </button>
-        </div>
-      </div>
-    </div>
+    <EditServerModal v-model="showEditModal" :server="server" @saved="load" />
 
     <!-- Re-provision modal -->
     <div
@@ -400,6 +335,7 @@ import { useFormatDate } from '../composables/useFormatDate.js'
 import KeyTable from '../components/KeyTable.vue'
 import SessionsCard from '../components/SessionsCard.vue'
 import Spinner from '../components/Spinner.vue'
+import EditServerModal from '../components/EditServerModal.vue'
 
 const { t, te } = useI18n()
 const { admin } = useAuth()
@@ -417,9 +353,6 @@ const error = ref('')
 const message = ref('')
 
 const showEditModal = ref(false)
-const editing = ref(false)
-const editError = ref('')
-const editForm = ref({ ip: '', environment: '', os_family: '', ssh_port: 22 })
 
 const showDeleteModal = ref(false)
 const showReprovisionModal = ref(false)
@@ -442,56 +375,8 @@ const expiryValid = computed(() => {
   return !!expiryDate.value
 })
 
-function isValidIp(ip) {
-  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
-  const m = v4.exec(ip.trim())
-  if (m) return m.slice(1).every((n) => +n <= 255)
-  const v6 = /^[0-9a-fA-F:]+$/
-  return v6.test(ip.trim()) && ip.includes(':')
-}
-
-const editFormValid = computed(() => editForm.value.ip.trim() && isValidIp(editForm.value.ip))
-
 function openEdit() {
-  editForm.value = {
-    ip: server.value.ip || '',
-    environment: server.value.environment || '',
-    os_family: server.value.os_family || '',
-    ssh_port: server.value.ssh_port || 22,
-  }
-  editError.value = ''
   showEditModal.value = true
-}
-
-function closeEdit() {
-  showEditModal.value = false
-}
-
-async function confirmEdit() {
-  editing.value = true
-  editError.value = ''
-  try {
-    const res = await apiFetch(`/api/servers/${hostname}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        ip: editForm.value.ip.trim(),
-        environment: editForm.value.environment,
-        os_family: editForm.value.os_family.trim() || null,
-        ssh_port: editForm.value.ssh_port || 22,
-      }),
-    })
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.error || `HTTP ${res.status}`)
-    }
-    closeEdit()
-    await load()
-  } catch (e) {
-    editError.value = e.message
-  } finally {
-    editing.value = false
-  }
 }
 
 async function load() {


### PR DESCRIPTION
Closes #338

## Summary
- New `btn-secondary` Edit button in the ServerDetail header (sysadmin only), between Scan and Disable
- Modal reuses existing `edit_server.*` i18n keys (already in 5 locales) + one new key `server_detail.edit` per locale
- Pre-fills form with current server values; IP format validated client-side; backend validates duplicates
- Spinner on Save button during submission; page auto-refreshes on success

## Test plan
- [ ] Login as sysadmin → open a server detail → Edit button visible between Scan and Disable
- [ ] Login as operator/viewer → Edit button not visible
- [ ] Click Edit → modal opens pre-filled with current IP, environment, OS, port
- [ ] Clear IP → Save button disabled
- [ ] Enter invalid IP → field error shown, Save disabled
- [ ] Submit valid change → modal closes, page refreshes with new values
- [ ] `npx vitest run` → 302 tests pass
- [ ] `npm run format:check` → OK