### PR TITLE
docs: audit post-features — CLAUDE.md, app, ui, README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Projet "ssh-access-manager" — audit et gestion des accès SSH dans un containe
 VAE RNCP41330 "Expert en développement logiciel" Niveau 7 — C.1.6.
 Développeur : Stéphane de Labrusse.
 
-## État du projet — toutes issues fermées (57/57)
+## État du projet — toutes issues fermées (69/69)
 
-Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303) ✅
+Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303, 312, 314, 320, 322, 324, 326, 328, 330, 332, 335, 337, 339) ✅
 
 ## Stack vérifiée et figée
 
@@ -42,7 +42,7 @@ Nginx : `/api/` → proxy Flask, `/` → /app/static (SPA). Pas de Basic Auth (s
 | Fichier | Rôle |
 |---------|------|
 | db.py | connexion + helpers PostgreSQL |
-| servers.py | parsing servers.yml + sync BDD + ssh-keyscan known_hosts |
+| servers.py | parsing servers.yml + sync BDD + paramiko.Transport known_hosts |
 | ssh.py | connexion paramiko + scripts distants (SAM_*) + revoke/lock/unlock |
 | actions.py | logique métier pure (partagée CLI+API) |
 | collect.py | orchestration scan complet |
@@ -69,6 +69,7 @@ ADMIN_USERNAME=admin  ADMIN_EMAIL  ADMIN_PASSWORD=admin
 Notes : pas de NGINX_USER/NGINX_PASSWORD (#54). Pas de TZ (UTC en base, conversion navigateur — #228).
 Pas de EXPIRE_WARN_DAYS* (configurables en base via settings — #230).
 SMTP_ENCRYPTION : `none` / `starttls` / `tls` — contrôle le mode TLS de msmtp.
+SMTP_USERNAME : si vide → `auth off` dans msmtp (relay sans authentification).
 SMTP_TLSVERIFY : `1` (on) / `` (off) — vérifie les certificats TLS.
 SMTP_ENABLED : `1` / `` (off) — désactive l'envoi d'emails si vide.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Dashboard → bouton **+ Ajouter un serveur** → remplir :
 | Environnement | — | `production` / `staging` / `lab` — modifiable ultérieurement |
 | OS | — | Famille d'OS (`rhel`, `debian`…) — modifiable ultérieurement |
 
-Le serveur n'est enregistré en base **que si la connexion SSH réussit**. En cas d'échec (mauvais mot de passe, port fermé, sudo manquant…), aucune donnée n'est écrite et l'erreur est affichée dans la langue du navigateur. Le script `provision-host.sh` est exécuté à distance : il crée l'utilisateur `audit-collector`, déploie la clé publique collecteur et configure les règles sudoers.
+Le serveur n'est enregistré en base **que si la connexion SSH réussit**. Après la création, un **scan automatique** est lancé immédiatement en arrière-plan (fire-and-forget) afin de collecter les clés existantes sans attendre le prochain cycle cron. En cas d'échec (mauvais mot de passe, port fermé, sudo manquant…), aucune donnée n'est écrite et l'erreur est affichée dans la langue du navigateur. Le script `provision-host.sh` est exécuté à distance : il crée l'utilisateur `audit-collector`, déploie la clé publique collecteur et configure les règles sudoers.
 
 Le script est **idempotent** : il peut être rejoué sans risque (après rebuild, changement de clé ou de règles sudoers). Un bouton **Re-provisionner** est disponible sur la vue détail d'un serveur existant (rôle `sysadmin` uniquement).
 
@@ -195,6 +195,7 @@ Depuis la vue détail d'un serveur (**Dashboard > clic sur hostname**) :
 
 | Action | Effet |
 |---|---|
+| **Modifier** | Modifie l'adresse IP, l'environnement, la famille d'OS ou le port SSH du serveur (rôle `sysadmin`). |
 | **Désactiver** | Le serveur n'est plus scanné automatiquement. Indicateur rouge visible dans le dashboard et la vue détail. |
 | **Réactiver** | Le serveur reprend le cycle de scan automatique. |
 | **Supprimer** | Suppression définitive du serveur et de toutes ses clés, autorisations et logs associés (action irréversible). |
@@ -215,6 +216,12 @@ Lors du premier scan :
 - Les scripts `sam-collect` et `sam-revoke` sont déployés sur chaque hôte (via SFTP, hash SHA256 vérifié)
 - Toutes les clés présentes dans `authorized_keys` sont importées avec le statut `PENDING_REVIEW`
 - Une alerte email CRITIQUE est envoyée pour chaque clé inconnue détectée
+
+Si le scan d'un serveur échoue (SSH injoignable, sudo manquant, timeout…), le serveur passe en statut **Scan Failed** :
+- Indicateur 🟠 visible dans le tableau de bord (badge orange)
+- Bandeau orange en haut de la vue détail du serveur
+- Les boutons **Valider** et **Révoquer** sont désactivés jusqu'au prochain scan réussi
+- Une alerte email CRITIQUE est envoyée
 
 ---
 
@@ -381,7 +388,7 @@ Action recommandée : investiguer l'origine de la suppression (accès root direc
 | `FLASK_SECRET_KEY` | Clé secrète Flask (sessions) — **obligatoire**, le container refuse de démarrer si absente | — |
 | `SMTP_HOST` | Serveur SMTP | — |
 | `SMTP_PORT` | Port SMTP | `587` |
-| `SMTP_USERNAME` | Utilisateur SMTP | — |
+| `SMTP_USERNAME` | Utilisateur SMTP — si vide, `auth off` dans msmtp (relay sans authentification) | — |
 | `SMTP_PASSWORD` | Mot de passe SMTP | — |
 | `SMTP_FROM` | Adresse expéditeur | — |
 | `SMTP_ENCRYPTION` | Mode TLS : `none` / `starttls` / `tls` | `starttls` |

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -71,17 +71,15 @@ Tracées dans audit_log (SCRIPT_DEPLOYED).
 | SAM_ADD | /usr/local/bin/sam-add \<unix_user\> \<pubkey\> | root, 750 | Crée user Unix si absent, ajoute clé idempotent (#164) |
 | SAM_LOCK_USER | /usr/local/bin/sam-lock-user \<unix_user\> | root, 750 | `usermod -L -s /sbin/nologin` — bloque mdp ET shell (#181) |
 | SAM_UNLOCK_USER | /usr/local/bin/sam-unlock-user \<unix_user\> | root, 750 | `usermod -U -s /bin/bash` (#181) |
-| SAM_SESSIONS | /usr/local/bin/sam-sessions | root, 750 | Collecte sessions SSH actives (who) + historique (last) → stdout : `A\|H\tuser\ttty\tip\trest` (#253) |
+| SAM_SESSIONS | /usr/local/bin/sam-sessions | root, 750 | Collecte sessions SSH actives + historique → stdout : `A\|H\tuser\ttty\tip\trest`. Utilise `utmpdump /var/run/utmp` (ISO 8601, locale-safe), fallback `LANG=C last -F` (#253, #322) |
 
 ## Logique métier — known_hosts et connexions SSH
 
 **`paramiko.RejectPolicy()` obligatoire — jamais AutoAddPolicy.**
 
-ssh-keyscan si hôte absent de known_hosts :
-```python
-subprocess.run(['ssh-keyscan', '-H', '-T', '10', ip_address])
-# → append dans /data/keys/known_hosts
-```
+Récupération de clé hôte si absent de known_hosts — `_fetch_host_key(ip, port, known_hosts_path)` via `paramiko.Transport` :
+- 1 handshake TCP (au lieu de 6+ avec ssh-keyscan subprocess) — évite les bans CrowdSec (#320)
+- Écrit la ligne hachée dans `/data/keys/known_hosts`
 
 **Les connexions SSH utilisent ip_address (pas hostname)** — le hostname peut ne pas être résolvable DNS depuis le container (#80, #84). known_hosts est indexé par IP.
 
@@ -151,6 +149,10 @@ Fonctions : `_get_client_ip()`, `_load_login_settings()`, `_check_rate_limit(ip)
 - Format compatible fail2ban/CrowdSec
 
 Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (1–100), login_ban_seconds (30–86400).
+
+## Exceptions métier (actions.py)
+
+- `UserError(message)` — exception user-safe exposée directement dans les réponses HTTP (400/404/409). Ne pas l'attraper dans web.py : le décorateur `@require_auth` la transforme automatiquement en `{"error": message}`. Résout l'exposition de stack-traces Python dans les réponses API (#314).
 
 ## actions.py — fonctions
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -6,7 +6,7 @@
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
 | Dashboard.vue | Tableau serveurs + recherche + compteurs + modal ajout serveur (#71) + clé collecteur (#74). Provisionnement atomique via SSH (#299, #301) : SSH user/password obligatoires, serveur créé uniquement si SSH réussit. Validation hostname RFC 1123 (#303). Layout 2 colonnes. |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Edit** (sysadmin) : ouvre `EditServerModal` pour modifier IP, env, OS, port SSH (#339). Bandeau orange si `last_scan_ok === false` (#324). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + colonne unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
 | Audit.vue | Historique filtrable |
@@ -29,10 +29,12 @@
 | AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) |
 | PaginationBar.vue | Composant pagination réutilisable avec contrôles taille de page |
 | SessionsCard.vue | Sessions SSH actives + modal Full History (filtres user/ip/date, pagination, export CSV) — sysadmin/operator uniquement (#253) |
+| Spinner.vue | Spinner animé universel — utilisé dans tous les boutons en état de chargement (#337) |
+| EditServerModal.vue | Modal édition serveur (IP, env, OS, port SSH) — partagé par Dashboard et ServerDetail. Props : `modelValue` (v-model), `server`, `allServers` (optionnel, pour validation doublon IP). Émet `saved` après PUT /api/servers/{hostname} (#337, #339) |
 
 ## Composables
 
-- `useAuth.js` — authentification session
+- `useAuth.js` — authentification session + détection 401 → redirection automatique vers `/login` via `apiFetch` (session expirée — #312)
 - `useFormatDate.js` — `formatDate()` et `formatDateOnly()` avec locale navigateur (#228, UTC→local)
 - `usePagination.js` — pagination côté client réutilisable (10 lignes par défaut, reset auto au changement de filtre)
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md** : compteur issues 57→69, ajout #312–#339, `servers.py` → paramiko.Transport, note `SMTP_USERNAME` vide = auth off
- **app/CLAUDE.md** : SAM_SESSIONS → utmpdump (#322), known_hosts → `_fetch_host_key()` via paramiko.Transport (#320), ajout section `UserError` (#314)
- **ui/CLAUDE.md** : ServerDetail — bouton Edit + bandeau scan failed (#324, #339) ; composants Spinner.vue + EditServerModal.vue (#337) ; useAuth.js → redirection 401 (#312)
- **README.md** : action Edit dans cycle de vie serveur, auto-scan après ajout (#332), statut Scan Failed 🟠 (#324), `SMTP_USERNAME` vide = auth off (#330)

## Test plan

- [ ] Relire CLAUDE.md — compteur et liste d'issues cohérents
- [ ] Relire app/CLAUDE.md — utmpdump, paramiko.Transport, UserError corrects
- [ ] Relire ui/CLAUDE.md — composants et comportements à jour
- [ ] Relire README.md — workflows et variables d'environnement à jour

Closes #340