### PR TITLE
feat: bulk validate and bulk revoke SSH keys (#344)

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -95,6 +95,56 @@ def validate_key(
     return key
 
 
+def bulk_validate_keys(fingerprints: list, admin_id: str) -> dict:
+    """Validate multiple keys (PENDING_REVIEW → ACTIVE) in one call.
+
+    Skips fingerprints that have no PENDING_REVIEW authorization (no error).
+    Returns {"validated": N, "skipped": N}.
+    Max 200 fingerprints per call.
+    """
+    if len(fingerprints) > 200:
+        raise UserError("Bulk operation limited to 200 keys at a time")
+    if not fingerprints:
+        raise UserError("At least one fingerprint is required")
+
+    validated = 0
+    skipped = 0
+    for fp in fingerprints:
+        try:
+            _check_fingerprint(fp)
+            validate_key(fp, admin_id)
+            validated += 1
+        except UserError:
+            skipped += 1
+    return {"validated": validated, "skipped": skipped}
+
+
+def bulk_revoke_keys(fingerprints: list, reason: str, admin_id: str) -> dict:
+    """Revoke multiple keys in one call.
+
+    Skips fingerprints that have no ACTIVE/PENDING_REVIEW authorization.
+    Returns {"revoked": N, "skipped": N}.
+    Max 200 fingerprints per call.
+    """
+    if len(fingerprints) > 200:
+        raise UserError("Bulk operation limited to 200 keys at a time")
+    if not fingerprints:
+        raise UserError("At least one fingerprint is required")
+    if not reason or not reason.strip():
+        raise UserError("A revocation reason is required")
+
+    revoked = 0
+    skipped = 0
+    for fp in fingerprints:
+        try:
+            _check_fingerprint(fp)
+            revoke_key(fp, admin_id, reason)
+            revoked += 1
+        except UserError:
+            skipped += 1
+    return {"revoked": revoked, "skipped": skipped}
+
+
 def revoke_key(
     fingerprint: str,
     admin_id: str,

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -1262,3 +1262,80 @@ def test_actions_reset_password_rejects_weak_password():
         mock_db.query_one.return_value = {"id": ADMIN_ID}
         with pytest.raises(UserError):
             actions.reset_password("alice", "weak")
+
+
+# ---------------------------------------------------------------------------
+# bulk_validate_keys
+# ---------------------------------------------------------------------------
+
+def test_actions_bulk_validate_calls_validate_for_each():
+    fp1 = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fp2 = "SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    with patch("actions.validate_key") as mock_validate:
+        mock_validate.return_value = {"id": KEY_ID}
+        result = actions.bulk_validate_keys([fp1, fp2], ADMIN_ID)
+        assert mock_validate.call_count == 2
+        assert result["validated"] == 2
+        assert result["skipped"] == 0
+
+
+def test_actions_bulk_validate_skips_on_user_error():
+    fp1 = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fp2 = "SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    with patch("actions.validate_key") as mock_validate:
+        mock_validate.side_effect = [UserError("no pending"), {"id": KEY_ID}]
+        result = actions.bulk_validate_keys([fp1, fp2], ADMIN_ID)
+        assert result["validated"] == 1
+        assert result["skipped"] == 1
+
+
+def test_actions_bulk_validate_rejects_empty_list():
+    with pytest.raises(UserError, match="At least one"):
+        actions.bulk_validate_keys([], ADMIN_ID)
+
+
+def test_actions_bulk_validate_rejects_over_200():
+    fps = [f"SHA256:{'a' * 43}"] * 201
+    with pytest.raises(UserError, match="200"):
+        actions.bulk_validate_keys(fps, ADMIN_ID)
+
+
+# ---------------------------------------------------------------------------
+# bulk_revoke_keys
+# ---------------------------------------------------------------------------
+
+def test_actions_bulk_revoke_calls_revoke_for_each():
+    fp1 = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fp2 = "SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    with patch("actions.revoke_key") as mock_revoke:
+        result = actions.bulk_revoke_keys([fp1, fp2], "security audit", ADMIN_ID)
+        assert mock_revoke.call_count == 2
+        assert result["revoked"] == 2
+        assert result["skipped"] == 0
+
+
+def test_actions_bulk_revoke_skips_on_user_error():
+    fp1 = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    fp2 = "SHA256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    with patch("actions.revoke_key") as mock_revoke:
+        mock_revoke.side_effect = [UserError("not found"), None]
+        result = actions.bulk_revoke_keys([fp1, fp2], "audit", ADMIN_ID)
+        assert result["revoked"] == 1
+        assert result["skipped"] == 1
+
+
+def test_actions_bulk_revoke_rejects_empty_list():
+    with pytest.raises(UserError, match="At least one"):
+        actions.bulk_revoke_keys([], "reason", ADMIN_ID)
+
+
+def test_actions_bulk_revoke_rejects_over_200():
+    fps = [f"SHA256:{'a' * 43}"] * 201
+    with pytest.raises(UserError, match="200"):
+        actions.bulk_revoke_keys(fps, "reason", ADMIN_ID)
+
+
+def test_actions_bulk_revoke_rejects_empty_reason():
+    fp = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    with pytest.raises(UserError, match="reason"):
+        actions.bulk_revoke_keys([fp], "", ADMIN_ID)

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -1929,3 +1929,33 @@ def test_web_bulk_revoke_viewer_returns_403(client):
         mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer", "role": "viewer"}
         resp = client.post("/api/keys/bulk-revoke", json={"fingerprints": [], "reason": "x"})
     assert resp.status_code == 403
+
+
+def test_web_bulk_validate_rejects_empty_list(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-validate", json={"fingerprints": []})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_validate_rejects_over_200(auth_client):
+    fps = ["SHA256:" + "a" * 43] * 201
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-validate", json={"fingerprints": fps})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_revoke_rejects_empty_list(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-revoke", json={"fingerprints": [], "reason": "audit"})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_revoke_rejects_over_200(auth_client):
+    fps = ["SHA256:" + "a" * 43] * 201
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-revoke", json={"fingerprints": fps, "reason": "audit"})
+    assert resp.status_code == 400

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -1851,3 +1851,81 @@ def test_web_sessions_history_operator_200(client):
             sess["admin_id"] = ADMIN_ID
         res = client.get("/api/servers/server1/sessions/history")
         assert res.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /api/keys/bulk-validate
+# ---------------------------------------------------------------------------
+
+def test_web_bulk_validate_returns_200(auth_client):
+    fps = ["SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.bulk_validate_keys.return_value = {"validated": 1, "skipped": 0}
+        resp = auth_client.post("/api/keys/bulk-validate", json={"fingerprints": fps})
+    assert resp.status_code == 200
+    assert resp.get_json()["validated"] == 1
+
+
+def test_web_bulk_validate_rejects_missing_fingerprints(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-validate", json={})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_validate_rejects_non_list(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-validate", json={"fingerprints": "notalist"})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_validate_viewer_returns_403(client):
+    with client.session_transaction() as sess:
+        sess["admin_id"] = ADMIN_ID
+        sess["admin_username"] = "viewer"
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer", "role": "viewer"}
+        resp = client.post("/api/keys/bulk-validate", json={"fingerprints": []})
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /api/keys/bulk-revoke
+# ---------------------------------------------------------------------------
+
+def test_web_bulk_revoke_returns_200(auth_client):
+    fps = ["SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.bulk_revoke_keys.return_value = {"revoked": 1, "skipped": 0}
+        resp = auth_client.post("/api/keys/bulk-revoke", json={"fingerprints": fps, "reason": "audit"})
+    assert resp.status_code == 200
+    assert resp.get_json()["revoked"] == 1
+
+
+def test_web_bulk_revoke_rejects_missing_reason(auth_client):
+    fps = ["SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-revoke", json={"fingerprints": fps})
+    assert resp.status_code == 400
+    assert "reason" in resp.get_json()["error"]
+
+
+def test_web_bulk_revoke_rejects_missing_fingerprints(auth_client):
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post("/api/keys/bulk-revoke", json={"reason": "audit"})
+    assert resp.status_code == 400
+
+
+def test_web_bulk_revoke_viewer_returns_403(client):
+    with client.session_transaction() as sess:
+        sess["admin_id"] = ADMIN_ID
+        sess["admin_username"] = "viewer"
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = {"id": ADMIN_ID, "username": "viewer", "role": "viewer"}
+        resp = client.post("/api/keys/bulk-revoke", json={"fingerprints": [], "reason": "x"})
+    assert resp.status_code == 403

--- a/app/web.py
+++ b/app/web.py
@@ -659,6 +659,39 @@ def remove_key_expiry(fingerprint):
         return jsonify({"error": str(e)}), 404
 
 
+@app.route("/api/keys/bulk-validate", methods=["POST"])
+@require_auth
+@require_role("sysadmin", "operator")
+def bulk_validate_keys():
+    data = request.get_json(force=True) or {}
+    fingerprints = data.get("fingerprints")
+    if not isinstance(fingerprints, list):
+        return jsonify({"error": "fingerprints must be a list"}), 400
+    try:
+        result = actions.bulk_validate_keys(fingerprints, g.admin_id)
+        return jsonify(result)
+    except UserError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@app.route("/api/keys/bulk-revoke", methods=["POST"])
+@require_auth
+@require_role("sysadmin", "operator")
+def bulk_revoke_keys():
+    data = request.get_json(force=True) or {}
+    fingerprints = data.get("fingerprints")
+    reason = data.get("reason", "").strip()
+    if not isinstance(fingerprints, list):
+        return jsonify({"error": "fingerprints must be a list"}), 400
+    if not reason:
+        return jsonify({"error": "reason is required"}), 400
+    try:
+        result = actions.bulk_revoke_keys(fingerprints, reason, g.admin_id)
+        return jsonify(result)
+    except UserError as e:
+        return jsonify({"error": str(e)}), 400
+
+
 # ---------------------------------------------------------------------------
 # Acces temporaires
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -667,11 +667,12 @@ def bulk_validate_keys():
     fingerprints = data.get("fingerprints")
     if not isinstance(fingerprints, list):
         return jsonify({"error": "fingerprints must be a list"}), 400
-    try:
-        result = actions.bulk_validate_keys(fingerprints, g.admin_id)
-        return jsonify(result)
-    except UserError as e:
-        return jsonify({"error": str(e)}), 400
+    if not fingerprints:
+        return jsonify({"error": "At least one fingerprint is required"}), 400
+    if len(fingerprints) > 200:
+        return jsonify({"error": "Bulk operation limited to 200 keys at a time"}), 400
+    result = actions.bulk_validate_keys(fingerprints, g.admin_id)
+    return jsonify(result)
 
 
 @app.route("/api/keys/bulk-revoke", methods=["POST"])
@@ -683,13 +684,14 @@ def bulk_revoke_keys():
     reason = data.get("reason", "").strip()
     if not isinstance(fingerprints, list):
         return jsonify({"error": "fingerprints must be a list"}), 400
+    if not fingerprints:
+        return jsonify({"error": "At least one fingerprint is required"}), 400
+    if len(fingerprints) > 200:
+        return jsonify({"error": "Bulk operation limited to 200 keys at a time"}), 400
     if not reason:
         return jsonify({"error": "reason is required"}), 400
-    try:
-        result = actions.bulk_revoke_keys(fingerprints, reason, g.admin_id)
-        return jsonify(result)
-    except UserError as e:
-        return jsonify({"error": str(e)}), 400
+    result = actions.bulk_revoke_keys(fingerprints, reason, g.admin_id)
+    return jsonify(result)
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -1,5 +1,27 @@
 <template>
   <div class="anomalies-table">
+    <!-- Bulk action bar (pending only) -->
+    <div
+      v-if="selected.size > 0 && type === 'pending' && props.currentRole !== 'viewer'"
+      class="bulk-bar"
+      data-testid="anomalies-bulk-bar"
+    >
+      <span class="bulk-count">{{ $t('anomalies.bulk_selected', { n: selected.size }) }}</span>
+      <button
+        class="btn-success"
+        @click="emitBulkValidate"
+        data-testid="anomalies-bulk-validate-btn"
+      >
+        {{ $t('anomalies.bulk_validate') }}
+      </button>
+      <button class="btn-danger" @click="emitBulkRevoke" data-testid="anomalies-bulk-revoke-btn">
+        {{ $t('anomalies.bulk_revoke') }}
+      </button>
+      <button class="btn-secondary" @click="selected = new Set()">
+        {{ $t('anomalies.bulk_clear') }}
+      </button>
+    </div>
+
     <div v-if="props.anomalies.length > 0" class="filters" data-testid="anomalies-filters">
       <input
         v-model="filterText"
@@ -31,6 +53,15 @@
     <table v-if="filtered.length > 0">
       <thead>
         <tr>
+          <th v-if="type === 'pending' && props.currentRole !== 'viewer'" class="th-check">
+            <input
+              type="checkbox"
+              :checked="allSelectableChecked"
+              :indeterminate="someSelected"
+              data-testid="anomalies-bulk-select-all"
+              @change="toggleSelectAll"
+            />
+          </th>
           <th>{{ $t('anomalies.col_fingerprint') }}</th>
           <th
             class="th-sortable"
@@ -81,6 +112,13 @@
           :key="k.fingerprint + k.server_hostname"
           :data-testid="`${type}-row-${k.fingerprint}`"
         >
+          <td v-if="type === 'pending' && props.currentRole !== 'viewer'" class="td-check">
+            <input
+              type="checkbox"
+              :checked="selected.has(k.fingerprint + '|' + k.server_hostname)"
+              @change="toggleSelect(k.fingerprint + '|' + k.server_hostname)"
+            />
+          </td>
           <td class="fp">
             <code>{{ k.fingerprint }}</code>
           </td>
@@ -140,7 +178,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
@@ -158,12 +196,13 @@ const props = defineProps({
   type: { type: String, default: 'pending', validator: (v) => ['pending', 'revoked'].includes(v) },
 })
 
-defineEmits(['validate', 'revoke'])
+const emit = defineEmits(['validate', 'revoke', 'bulk-validate', 'bulk-revoke'])
 
 const filterText = ref('')
 const filterType = ref('')
 const filterServer = ref('')
 const filterCompliant = ref('')
+const selected = ref(new Set())
 
 const uniqueTypes = computed(() => {
   return [...new Set(props.anomalies.map((k) => k.key_type).filter(Boolean))].sort()
@@ -194,6 +233,59 @@ const filtered = computed(() => {
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
   usePagination(computed(() => sorted(filtered.value)))
+
+watch(filtered, () => {
+  selected.value = new Set()
+})
+
+const selectableOnPage = computed(() =>
+  paginatedItems.value.map((k) => k.fingerprint + '|' + k.server_hostname)
+)
+
+const allSelectableChecked = computed(
+  () =>
+    selectableOnPage.value.length > 0 &&
+    selectableOnPage.value.every((key) => selected.value.has(key))
+)
+
+const someSelected = computed(
+  () => !allSelectableChecked.value && selectableOnPage.value.some((key) => selected.value.has(key))
+)
+
+function toggleSelect(key) {
+  const s = new Set(selected.value)
+  if (s.has(key)) s.delete(key)
+  else s.add(key)
+  selected.value = s
+}
+
+function toggleSelectAll(e) {
+  const s = new Set(selected.value)
+  if (e.target.checked) {
+    selectableOnPage.value.forEach((key) => s.add(key))
+  } else {
+    selectableOnPage.value.forEach((key) => s.delete(key))
+  }
+  selected.value = s
+}
+
+function emitBulkValidate() {
+  const entries = [...selected.value].map((key) => {
+    const [fp, hostname] = key.split('|')
+    const item =
+      paginatedItems.value.find((k) => k.fingerprint === fp && k.server_hostname === hostname) ||
+      props.anomalies.find((k) => k.fingerprint === fp && k.server_hostname === hostname)
+    return { fingerprint: fp, unix_user: item?.unix_user || null, hostname }
+  })
+  emit('bulk-validate', entries)
+  selected.value = new Set()
+}
+
+function emitBulkRevoke() {
+  const fingerprints = [...selected.value].map((key) => key.split('|')[0])
+  emit('bulk-revoke', fingerprints)
+  selected.value = new Set()
+}
 
 const colDate = computed(() => {
   return props.type === 'pending' ? t('anomalies.col_first_seen') : t('anomalies.col_revoked_at')
@@ -246,6 +338,31 @@ function exportCsv() {
 </script>
 
 <style scoped>
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: #e8f4fd;
+  border: 1px solid #b8d9f5;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.bulk-count {
+  font-weight: 600;
+  color: #0d6efd;
+  margin-right: 0.25rem;
+}
+
+.th-check,
+.td-check {
+  width: 36px;
+  text-align: center;
+  padding: 0.25rem;
+}
+
 .filters {
   display: flex;
   gap: 0.75rem;

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -1,5 +1,23 @@
 <template>
   <div class="keytable-wrapper">
+    <!-- Bulk action bar -->
+    <div
+      v-if="selected.size > 0 && currentRole !== 'viewer'"
+      class="bulk-bar"
+      data-testid="bulk-bar"
+    >
+      <span class="bulk-count">{{ $t('key_table.bulk_selected', { n: selected.size }) }}</span>
+      <button class="btn-success" @click="emitBulkValidate" data-testid="bulk-validate-btn">
+        {{ $t('key_table.bulk_validate') }}
+      </button>
+      <button class="btn-danger" @click="emitBulkRevoke" data-testid="bulk-revoke-btn">
+        {{ $t('key_table.bulk_revoke') }}
+      </button>
+      <button class="btn-secondary" @click="selected = new Set()">
+        {{ $t('key_table.bulk_clear') }}
+      </button>
+    </div>
+
     <div v-if="keys.length > 0" class="filters" data-testid="keytable-filters">
       <input
         v-model="filterText"
@@ -22,6 +40,15 @@
     <table>
       <thead>
         <tr>
+          <th v-if="currentRole !== 'viewer'" class="th-check">
+            <input
+              type="checkbox"
+              :checked="allSelectableChecked"
+              :indeterminate="someSelected"
+              data-testid="bulk-select-all"
+              @change="toggleSelectAll"
+            />
+          </th>
           <th
             class="th-sortable"
             :class="{ active: sortKey === 'status' }"
@@ -94,6 +121,14 @@
           </td>
         </tr>
         <tr v-for="k in paginatedItems" :key="k.fingerprint + '|' + (k.unix_user || '')">
+          <td v-if="currentRole !== 'viewer'" class="td-check">
+            <input
+              v-if="isSelectable(k)"
+              type="checkbox"
+              :checked="selected.has(k.fingerprint)"
+              @change="toggleSelect(k.fingerprint)"
+            />
+          </td>
           <td>
             <span class="badge" :class="statusBadge(k.status)">{{ k.status }}</span>
           </td>
@@ -177,7 +212,7 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
@@ -193,10 +228,19 @@ const props = defineProps({
   currentRole: { type: String, default: 'viewer' },
   scanOk: { type: Boolean, default: null },
 })
-defineEmits(['validate', 'revoke', 'set-expiry', 'remove-expiry', 'assign'])
+const emit = defineEmits([
+  'validate',
+  'revoke',
+  'set-expiry',
+  'remove-expiry',
+  'assign',
+  'bulk-validate',
+  'bulk-revoke',
+])
 
 const filterText = ref('')
 const filterStatus = ref('')
+const selected = ref(new Set())
 
 const filteredKeys = computed(() => {
   const text = filterText.value.trim().toLowerCase()
@@ -214,6 +258,56 @@ const filteredKeys = computed(() => {
 
 const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSize } =
   usePagination(computed(() => sorted(filteredKeys.value)))
+
+// Reset selection when filter changes
+watch(filteredKeys, () => {
+  selected.value = new Set()
+})
+
+function isSelectable(k) {
+  return k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW'
+}
+
+const selectableOnPage = computed(() =>
+  paginatedItems.value.filter(isSelectable).map((k) => k.fingerprint)
+)
+
+const allSelectableChecked = computed(
+  () =>
+    selectableOnPage.value.length > 0 &&
+    selectableOnPage.value.every((fp) => selected.value.has(fp))
+)
+
+const someSelected = computed(
+  () => !allSelectableChecked.value && selectableOnPage.value.some((fp) => selected.value.has(fp))
+)
+
+function toggleSelect(fp) {
+  const s = new Set(selected.value)
+  if (s.has(fp)) s.delete(fp)
+  else s.add(fp)
+  selected.value = s
+}
+
+function toggleSelectAll(e) {
+  const s = new Set(selected.value)
+  if (e.target.checked) {
+    selectableOnPage.value.forEach((fp) => s.add(fp))
+  } else {
+    selectableOnPage.value.forEach((fp) => s.delete(fp))
+  }
+  selected.value = s
+}
+
+function emitBulkValidate() {
+  emit('bulk-validate', [...selected.value])
+  selected.value = new Set()
+}
+
+function emitBulkRevoke() {
+  emit('bulk-revoke', [...selected.value])
+  selected.value = new Set()
+}
 
 function complianceTooltip(k) {
   if (k.key_type === 'ssh-rsa') {
@@ -274,6 +368,30 @@ function exportCsv() {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  background: #e8f4fd;
+  border: 1px solid #b8d9f5;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.bulk-count {
+  font-weight: 600;
+  color: #0d6efd;
+  margin-right: 0.25rem;
+}
+
+.th-check,
+.td-check {
+  width: 36px;
+  text-align: center;
+  padding: 0.25rem;
 }
 
 .filters {

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -158,7 +158,10 @@
     "reprovision_submit": "Neu bereitstellen",
     "reprovision_submitting": "Verbindung…",
     "reprovision_success": "Server erfolgreich neu bereitgestellt.",
-    "reprovision_password_optional_hint": "Leer lassen, wenn der Collector-Schlüssel bereits manuell bereitgestellt wurde (ssh-copy-id oder provision-host.sh)."
+    "reprovision_password_optional_hint": "Leer lassen, wenn der Collector-Schlüssel bereits manuell bereitgestellt wurde (ssh-copy-id oder provision-host.sh).",
+    "bulk_revoke_modal_title": "Ausgewählte Schlüssel widerrufen",
+    "bulk_validated": "Schlüssel validiert: {validated}, übersprungen: {skipped}",
+    "bulk_revoked": "Schlüssel widerrufen: {revoked}, übersprungen: {skipped}"
   },
   "key_table": {
     "col_status": "Status",
@@ -185,7 +188,11 @@
     "no_results": "Keine passenden Schlüssel.",
     "revoke_unavailable": "Widerrufen nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)",
     "validate_unavailable": "Validieren nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)",
-    "export_csv": "CSV exportieren"
+    "export_csv": "CSV exportieren",
+    "bulk_selected": "{n} Schlüssel ausgewählt",
+    "bulk_validate": "Auswahl validieren",
+    "bulk_revoke": "Auswahl widerrufen",
+    "bulk_clear": "Auswahl aufheben"
   },
   "access": {
     "title": "Temporärer Zugriff",
@@ -333,7 +340,14 @@
     "filter_compliant": "Konform",
     "filter_non_compliant": "Nicht konform",
     "no_results": "Keine passenden Anomalien.",
-    "export_csv": "CSV exportieren"
+    "export_csv": "CSV exportieren",
+    "bulk_selected": "{n} Schlüssel ausgewählt",
+    "bulk_validate": "Auswahl validieren",
+    "bulk_revoke": "Auswahl widerrufen",
+    "bulk_clear": "Auswahl aufheben",
+    "bulk_revoke_modal_title": "Ausgewählte Schlüssel widerrufen",
+    "bulk_validated": "Schlüssel validiert: {validated}, übersprungen: {skipped}",
+    "bulk_revoked": "Schlüssel widerrufen: {revoked}, übersprungen: {skipped}"
   },
   "settings": {
     "title": "Einstellungen",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -158,7 +158,10 @@
     "reprovision_submit": "Re-provision",
     "reprovision_submitting": "Connecting…",
     "reprovision_success": "Server re-provisioned successfully.",
-    "reprovision_password_optional_hint": "Leave empty if the collector key was already deployed manually (ssh-copy-id or provision-host.sh)."
+    "reprovision_password_optional_hint": "Leave empty if the collector key was already deployed manually (ssh-copy-id or provision-host.sh).",
+    "bulk_revoke_modal_title": "Revoke selected keys",
+    "bulk_validated": "Keys validated: {validated}, skipped: {skipped}",
+    "bulk_revoked": "Keys revoked: {revoked}, skipped: {skipped}"
   },
   "key_table": {
     "col_status": "Status",
@@ -185,7 +188,11 @@
     "no_results": "No matching keys.",
     "revoke_unavailable": "Cannot revoke: last scan failed (server unreachable)",
     "validate_unavailable": "Cannot validate: last scan failed (server unreachable)",
-    "export_csv": "Export CSV"
+    "export_csv": "Export CSV",
+    "bulk_selected": "{n} key(s) selected",
+    "bulk_validate": "Validate selected",
+    "bulk_revoke": "Revoke selected",
+    "bulk_clear": "Clear selection"
   },
   "access": {
     "title": "Temporary Access",
@@ -333,7 +340,14 @@
     "filter_compliant": "Compliant",
     "filter_non_compliant": "Non-compliant",
     "no_results": "No matching anomalies.",
-    "export_csv": "Export CSV"
+    "export_csv": "Export CSV",
+    "bulk_selected": "{n} key(s) selected",
+    "bulk_validate": "Validate selected",
+    "bulk_revoke": "Revoke selected",
+    "bulk_clear": "Clear selection",
+    "bulk_revoke_modal_title": "Revoke selected keys",
+    "bulk_validated": "Keys validated: {validated}, skipped: {skipped}",
+    "bulk_revoked": "Keys revoked: {revoked}, skipped: {skipped}"
   },
   "settings": {
     "title": "Settings",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -158,7 +158,10 @@
     "reprovision_submit": "Re-aprovisionar",
     "reprovision_submitting": "Conectando…",
     "reprovision_success": "Servidor re-aprovisionado correctamente.",
-    "reprovision_password_optional_hint": "Dejar vacío si la clave del colector ya fue desplegada manualmente (ssh-copy-id o provision-host.sh)."
+    "reprovision_password_optional_hint": "Dejar vacío si la clave del colector ya fue desplegada manualmente (ssh-copy-id o provision-host.sh).",
+    "bulk_revoke_modal_title": "Revocar claves seleccionadas",
+    "bulk_validated": "Claves validadas: {validated}, omitidas: {skipped}",
+    "bulk_revoked": "Claves revocadas: {revoked}, omitidas: {skipped}"
   },
   "key_table": {
     "col_status": "Estado",
@@ -185,7 +188,11 @@
     "no_results": "No se encontraron claves.",
     "revoke_unavailable": "No se puede revocar: último escaneo fallido (servidor inaccesible)",
     "validate_unavailable": "No se puede validar: último escaneo fallido (servidor inaccesible)",
-    "export_csv": "Exportar CSV"
+    "export_csv": "Exportar CSV",
+    "bulk_selected": "{n} clave(s) seleccionada(s)",
+    "bulk_validate": "Validar selección",
+    "bulk_revoke": "Revocar selección",
+    "bulk_clear": "Borrar selección"
   },
   "access": {
     "title": "Acceso temporal",
@@ -333,7 +340,14 @@
     "filter_compliant": "Conforme",
     "filter_non_compliant": "No conforme",
     "no_results": "No se encontraron anomalías.",
-    "export_csv": "Exportar CSV"
+    "export_csv": "Exportar CSV",
+    "bulk_selected": "{n} clave(s) seleccionada(s)",
+    "bulk_validate": "Validar selección",
+    "bulk_revoke": "Revocar selección",
+    "bulk_clear": "Borrar selección",
+    "bulk_revoke_modal_title": "Revocar claves seleccionadas",
+    "bulk_validated": "Claves validadas: {validated}, omitidas: {skipped}",
+    "bulk_revoked": "Claves revocadas: {revoked}, omitidas: {skipped}"
   },
   "settings": {
     "title": "Ajustes",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -158,7 +158,10 @@
     "reprovision_submit": "Re-provisionner",
     "reprovision_submitting": "Connexion…",
     "reprovision_success": "Serveur re-provisionné avec succès.",
-    "reprovision_password_optional_hint": "Laisser vide si la clé collecteur a déjà été déployée manuellement (ssh-copy-id ou provision-host.sh)."
+    "reprovision_password_optional_hint": "Laisser vide si la clé collecteur a déjà été déployée manuellement (ssh-copy-id ou provision-host.sh).",
+    "bulk_revoke_modal_title": "Révoquer les clés sélectionnées",
+    "bulk_validated": "Clés validées : {validated}, ignorées : {skipped}",
+    "bulk_revoked": "Clés révoquées : {revoked}, ignorées : {skipped}"
   },
   "key_table": {
     "col_status": "Statut",
@@ -185,7 +188,11 @@
     "no_results": "Aucune clé correspondante.",
     "revoke_unavailable": "Révocation impossible : dernier scan échoué (serveur injoignable)",
     "validate_unavailable": "Validation impossible : dernier scan échoué (serveur injoignable)",
-    "export_csv": "Exporter CSV"
+    "export_csv": "Exporter CSV",
+    "bulk_selected": "{n} clé(s) sélectionnée(s)",
+    "bulk_validate": "Valider la sélection",
+    "bulk_revoke": "Révoquer la sélection",
+    "bulk_clear": "Effacer la sélection"
   },
   "access": {
     "title": "Accès temporaires",
@@ -333,7 +340,14 @@
     "filter_compliant": "Conforme",
     "filter_non_compliant": "Non conforme",
     "no_results": "Aucune anomalie correspondante.",
-    "export_csv": "Exporter CSV"
+    "export_csv": "Exporter CSV",
+    "bulk_selected": "{n} clé(s) sélectionnée(s)",
+    "bulk_validate": "Valider la sélection",
+    "bulk_revoke": "Révoquer la sélection",
+    "bulk_clear": "Effacer la sélection",
+    "bulk_revoke_modal_title": "Révoquer les clés sélectionnées",
+    "bulk_validated": "Clés validées : {validated}, ignorées : {skipped}",
+    "bulk_revoked": "Clés révoquées : {revoked}, ignorées : {skipped}"
   },
   "settings": {
     "title": "Paramètres",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -158,7 +158,10 @@
     "reprovision_submit": "Re-provisioning",
     "reprovision_submitting": "Connessione…",
     "reprovision_success": "Server re-provisionato con successo.",
-    "reprovision_password_optional_hint": "Lasciare vuoto se la chiave del collettore è già stata distribuita manualmente (ssh-copy-id o provision-host.sh)."
+    "reprovision_password_optional_hint": "Lasciare vuoto se la chiave del collettore è già stata distribuita manualmente (ssh-copy-id o provision-host.sh).",
+    "bulk_revoke_modal_title": "Revocare le chiavi selezionate",
+    "bulk_validated": "Chiavi validate: {validated}, saltate: {skipped}",
+    "bulk_revoked": "Chiavi revocate: {revoked}, saltate: {skipped}"
   },
   "key_table": {
     "col_status": "Stato",
@@ -185,7 +188,11 @@
     "no_results": "Nessuna chiave corrispondente.",
     "revoke_unavailable": "Impossibile revocare: ultima scansione fallita (server non raggiungibile)",
     "validate_unavailable": "Impossibile validare: ultima scansione fallita (server non raggiungibile)",
-    "export_csv": "Esporta CSV"
+    "export_csv": "Esporta CSV",
+    "bulk_selected": "{n} chiave/i selezionata/e",
+    "bulk_validate": "Valida selezionati",
+    "bulk_revoke": "Revoca selezionati",
+    "bulk_clear": "Annulla selezione"
   },
   "access": {
     "title": "Accesso temporaneo",
@@ -333,7 +340,14 @@
     "filter_compliant": "Conforme",
     "filter_non_compliant": "Non conforme",
     "no_results": "Nessuna anomalia corrispondente.",
-    "export_csv": "Esporta CSV"
+    "export_csv": "Esporta CSV",
+    "bulk_selected": "{n} chiave/i selezionata/e",
+    "bulk_validate": "Valida selezionati",
+    "bulk_revoke": "Revoca selezionati",
+    "bulk_clear": "Annulla selezione",
+    "bulk_revoke_modal_title": "Revocare le chiavi selezionate",
+    "bulk_validated": "Chiavi validate: {validated}, saltate: {skipped}",
+    "bulk_revoked": "Chiavi revocate: {revoked}, saltate: {skipped}"
   },
   "settings": {
     "title": "Impostazioni",

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -23,6 +23,8 @@
           type="pending"
           @validate="validate"
           @revoke="openRevokeByFingerprint"
+          @bulk-validate="bulkValidate"
+          @bulk-revoke="openBulkRevoke"
         />
       </section>
 
@@ -43,6 +45,45 @@
         />
       </section>
     </template>
+
+    <!-- Bulk revoke modal -->
+    <div
+      v-if="bulkRevokeFingerprints"
+      class="modal-overlay"
+      @click.self="bulkRevokeFingerprints = null"
+    >
+      <div class="modal">
+        <div class="modal-header">
+          <h3>{{ $t('anomalies.bulk_revoke_modal_title') }}</h3>
+          <button class="modal-close" @click="bulkRevokeFingerprints = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
+        <p>{{ $t('anomalies.bulk_selected', { n: bulkRevokeFingerprints.length }) }}</p>
+        <label for="bulk-revoke-reason"
+          >{{ $t('anomalies.revoke_reason_label') }}
+          <span class="required">{{ $t('common.required') }}</span></label
+        >
+        <textarea
+          id="bulk-revoke-reason"
+          v-model="bulkRevokeReason"
+          rows="3"
+          :placeholder="$t('anomalies.revoke_reason_placeholder')"
+        ></textarea>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="bulkRevokeFingerprints = null">
+            {{ $t('common.cancel') }}
+          </button>
+          <button
+            class="btn-danger"
+            :disabled="!bulkRevokeReason.trim()"
+            @click="confirmBulkRevoke"
+          >
+            {{ $t('anomalies.btn_revoke_confirm') }}
+          </button>
+        </div>
+      </div>
+    </div>
 
     <!-- Revoke modal -->
     <div v-if="revokeTarget" class="modal-overlay" @click.self="revokeTarget = null">
@@ -96,6 +137,8 @@ const error = ref('')
 const message = ref('')
 const revokeTarget = ref(null)
 const revokeReason = ref('')
+const bulkRevokeFingerprints = ref(null)
+const bulkRevokeReason = ref('')
 
 const pendingAll = computed(() => allKeys.value.filter((k) => k.status === 'PENDING_REVIEW'))
 
@@ -151,6 +194,60 @@ async function confirmRevoke() {
     t('anomalies.key_revoked')
   )
   revokeTarget.value = null
+}
+
+async function bulkValidate(entries) {
+  error.value = ''
+  message.value = ''
+  try {
+    const res = await apiFetch('/api/keys/bulk-validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fingerprints: entries.map((e) => e.fingerprint) }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    const data = await res.json()
+    message.value = t('anomalies.bulk_validated', {
+      validated: data.validated,
+      skipped: data.skipped,
+    })
+    await load()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+function openBulkRevoke(fingerprints) {
+  bulkRevokeFingerprints.value = fingerprints
+  bulkRevokeReason.value = ''
+}
+
+async function confirmBulkRevoke() {
+  error.value = ''
+  message.value = ''
+  try {
+    const res = await apiFetch('/api/keys/bulk-revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fingerprints: bulkRevokeFingerprints.value,
+        reason: bulkRevokeReason.value,
+      }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    const data = await res.json()
+    message.value = t('anomalies.bulk_revoked', { revoked: data.revoked, skipped: data.skipped })
+    bulkRevokeFingerprints.value = null
+    await load()
+  } catch (e) {
+    error.value = e.message
+  }
 }
 
 async function apiAction(url, body, successMsg) {

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -106,6 +106,8 @@
           @set-expiry="openExpiry"
           @remove-expiry="removeExpiry"
           @assign="openAssign"
+          @bulk-validate="bulkValidateKeys"
+          @bulk-revoke="openBulkRevoke"
         />
       </section>
     </template>
@@ -126,6 +128,45 @@
           </button>
           <button class="btn-danger" @click="deleteServer">
             {{ $t('server_detail.delete_confirm') }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bulk revoke modal -->
+    <div
+      v-if="bulkRevokeFingerprints"
+      class="modal-overlay"
+      @click.self="bulkRevokeFingerprints = null"
+    >
+      <div class="modal">
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.bulk_revoke_modal_title') }}</h3>
+          <button class="modal-close" @click="bulkRevokeFingerprints = null" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
+        <p>{{ $t('key_table.bulk_selected', { n: bulkRevokeFingerprints.length }) }}</p>
+        <label for="bulk-revoke-reason"
+          >{{ $t('server_detail.revoke_reason_label') }}
+          <span class="required">{{ $t('common.required') }}</span></label
+        >
+        <textarea
+          id="bulk-revoke-reason"
+          v-model="bulkRevokeReason"
+          rows="3"
+          :placeholder="$t('server_detail.revoke_reason_placeholder')"
+        ></textarea>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="bulkRevokeFingerprints = null">
+            {{ $t('common.cancel') }}
+          </button>
+          <button
+            class="btn-danger"
+            :disabled="!bulkRevokeReason.trim()"
+            @click="confirmBulkRevoke"
+          >
+            {{ $t('server_detail.revoke_confirm') }}
           </button>
         </div>
       </div>
@@ -363,6 +404,8 @@ const showReprovisionPassword = ref(false)
 
 const revokeTarget = ref(null)
 const revokeReason = ref('')
+const bulkRevokeFingerprints = ref(null)
+const bulkRevokeReason = ref('')
 const assignTarget = ref(null)
 const assignUsername = ref('')
 const expiryTarget = ref(null)
@@ -480,6 +523,55 @@ async function confirmRevoke() {
     t('server_detail.key_revoked')
   )
   revokeTarget.value = null
+}
+
+async function bulkValidateKeys(fingerprints) {
+  error.value = ''
+  message.value = ''
+  try {
+    const res = await apiFetch('/api/keys/bulk-validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fingerprints }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    const data = await res.json()
+    message.value = t('server_detail.bulk_validated', {
+      validated: data.validated,
+      skipped: data.skipped,
+    })
+    await load()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+function openBulkRevoke(fingerprints) {
+  bulkRevokeFingerprints.value = fingerprints
+  bulkRevokeReason.value = ''
+}
+
+async function confirmBulkRevoke() {
+  const res = await apiFetch('/api/keys/bulk-revoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      fingerprints: bulkRevokeFingerprints.value,
+      reason: bulkRevokeReason.value,
+    }),
+  })
+  bulkRevokeFingerprints.value = null
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    error.value = data.error || `HTTP ${res.status}`
+    return
+  }
+  const data = await res.json()
+  message.value = t('server_detail.bulk_revoked', { revoked: data.revoked, skipped: data.skipped })
+  await load()
 }
 
 function openAssign(fingerprint) {

--- a/ui/tests/AnomaliesTable.spec.js
+++ b/ui/tests/AnomaliesTable.spec.js
@@ -283,4 +283,71 @@ describe('AnomaliesTable.vue', () => {
     expect(wrapper.text()).toContain('SHA256:def456')
     expect(wrapper.text()).not.toContain('SHA256:abc123')
   })
+
+  // --- Bulk actions (pending type only) ---
+
+  it('shows checkbox column for operator on pending', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'operator', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.find('[data-testid="anomalies-bulk-select-all"]').exists()).toBe(true)
+  })
+
+  it('hides checkbox column for viewer', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'viewer', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.find('[data-testid="anomalies-bulk-select-all"]').exists()).toBe(false)
+  })
+
+  it('hides checkbox column for revoked type', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: revokedAnomalies, servers: [], currentRole: 'operator', type: 'revoked' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.find('[data-testid="anomalies-bulk-select-all"]').exists()).toBe(false)
+  })
+
+  it('bulk bar hidden when nothing selected', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'operator', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    expect(wrapper.find('[data-testid="anomalies-bulk-bar"]').exists()).toBe(false)
+  })
+
+  it('shows bulk bar after selecting a row', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'operator', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const checkbox = wrapper.find('tbody input[type="checkbox"]')
+    await checkbox.setChecked(true)
+    expect(wrapper.find('[data-testid="anomalies-bulk-bar"]').exists()).toBe(true)
+  })
+
+  it('emits bulk-validate with entries on bulk validate click', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'operator', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    await wrapper.find('tbody input[type="checkbox"]').setChecked(true)
+    await wrapper.find('[data-testid="anomalies-bulk-validate-btn"]').trigger('click')
+    expect(wrapper.emitted('bulk-validate')).toBeTruthy()
+    const entries = wrapper.emitted('bulk-validate')[0][0]
+    expect(entries[0].fingerprint).toBe('SHA256:abc123')
+  })
+
+  it('emits bulk-revoke with fingerprints on bulk revoke click', async () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: { anomalies: pendingAnomalies, servers: [], currentRole: 'operator', type: 'pending' },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    await wrapper.find('tbody input[type="checkbox"]').setChecked(true)
+    await wrapper.find('[data-testid="anomalies-bulk-revoke-btn"]').trigger('click')
+    expect(wrapper.emitted('bulk-revoke')).toBeTruthy()
+    expect(wrapper.emitted('bulk-revoke')[0][0]).toContain('SHA256:abc123')
+  })
 })

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -316,4 +316,61 @@ describe('KeyTable', () => {
     expect(validateBtn).toBeDefined()
     expect(validateBtn.attributes('disabled')).toBeUndefined()
   })
+
+  // --- Bulk actions ---
+
+  it('shows checkbox column for sysadmin', () => {
+    const w = mountTable([makeKey()])
+    expect(w.find('[data-testid="bulk-select-all"]').exists()).toBe(true)
+  })
+
+  it('hides checkbox column for viewer', () => {
+    const w = mountTable([makeKey()], 'viewer')
+    expect(w.find('[data-testid="bulk-select-all"]').exists()).toBe(false)
+  })
+
+  it('bulk bar hidden when nothing selected', () => {
+    const w = mountTable([makeKey()])
+    expect(w.find('[data-testid="bulk-bar"]').exists()).toBe(false)
+  })
+
+  it('shows bulk bar after selecting a row', async () => {
+    const w = mountTable([makeKey()])
+    const checkbox = w.find('tbody input[type="checkbox"]')
+    await checkbox.setChecked(true)
+    expect(w.find('[data-testid="bulk-bar"]').exists()).toBe(true)
+  })
+
+  it('emits bulk-validate with fingerprints', async () => {
+    const key = makeKey({ status: 'ACTIVE' })
+    const w = mountTable([key])
+    await w.find('tbody input[type="checkbox"]').setChecked(true)
+    await w.find('[data-testid="bulk-validate-btn"]').trigger('click')
+    expect(w.emitted('bulk-validate')).toBeTruthy()
+    expect(w.emitted('bulk-validate')[0][0]).toContain(FP)
+  })
+
+  it('emits bulk-revoke with fingerprints', async () => {
+    const key = makeKey({ status: 'ACTIVE' })
+    const w = mountTable([key])
+    await w.find('tbody input[type="checkbox"]').setChecked(true)
+    await w.find('[data-testid="bulk-revoke-btn"]').trigger('click')
+    expect(w.emitted('bulk-revoke')).toBeTruthy()
+    expect(w.emitted('bulk-revoke')[0][0]).toContain(FP)
+  })
+
+  it('select-all checks all selectable rows on page', async () => {
+    const keys = [
+      makeKey({ fingerprint: 'SHA256:aaaaa', status: 'ACTIVE' }),
+      makeKey({ fingerprint: 'SHA256:bbbbb', status: 'PENDING_REVIEW' }),
+    ]
+    const w = mountTable(keys)
+    await w.find('[data-testid="bulk-select-all"]').setChecked(true)
+    expect(w.find('[data-testid="bulk-bar"]').exists()).toBe(true)
+  })
+
+  it('REVOKED rows are not selectable', async () => {
+    const w = mountTable([makeKey({ status: 'REVOKED' })])
+    expect(w.find('tbody input[type="checkbox"]').exists()).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary

- Add checkbox multi-selection in `KeyTable` (ACTIVE + PENDING_REVIEW) and `AnomaliesTable` (pending type only)
- Bulk action bar with **Validate selected**, **Revoke selected**, **Clear selection** buttons
- Backend: `POST /api/keys/bulk-validate` and `POST /api/keys/bulk-revoke` (max 200 keys, skips per-key errors)
- `actions.py`: `bulk_validate_keys()` and `bulk_revoke_keys()` looping over existing per-key functions
- Bulk revoke reason modal in `ServerDetail.vue` and `Anomalies.vue`
- i18n keys in all 5 locales (EN/FR/ES/IT/DE)
- 15 new Vitest tests + 9 new pytest tests — 317 frontend + 509 backend tests pass

## Test plan

- [ ] Open a server detail page with ACTIVE/PENDING_REVIEW keys → checkboxes visible
- [ ] Select multiple keys → bulk bar appears with count
- [ ] Click "Validate selected" → keys validated, bar disappears
- [ ] Click "Revoke selected" → reason modal opens, confirm → keys revoked
- [ ] Viewer role → no checkboxes, no bulk bar
- [ ] Anomalies page → checkboxes on pending table, bulk validate/revoke work
- [ ] `npx vitest run` → 317 passed
- [ ] `python -m pytest` → 509 passed

Closes #344