### PR TITLE
feat: add CSV export to audit log, keys and anomalies tables (#343)

### DIFF
--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -25,6 +25,7 @@
         <option value="yes">{{ $t('anomalies.filter_compliant') }}</option>
         <option value="no">{{ $t('anomalies.filter_non_compliant') }}</option>
       </select>
+      <button class="btn-export" @click="exportCsv">{{ $t('anomalies.export_csv') }}</button>
     </div>
 
     <table v-if="filtered.length > 0">
@@ -213,6 +214,35 @@ function complianceTooltip(k) {
   }
   return t('key_table.non_compliant_type')
 }
+
+function exportCsv() {
+  const headers = [
+    t('anomalies.col_fingerprint'),
+    t('anomalies.col_type'),
+    t('anomalies.col_server'),
+    t('anomalies.col_unix_user'),
+    colDate.value,
+    t('anomalies.col_compliant'),
+  ]
+  const rows = filtered.value.map((k) => [
+    k.fingerprint || '',
+    k.key_type || '',
+    k.server_hostname || '',
+    k.unix_user || '',
+    k[dateField.value] ? formatDate(k[dateField.value]) : '',
+    k.is_compliant ? t('key_table.compliant_ok') : '⚠️',
+  ])
+  const csv = [headers, ...rows]
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `anomalies-${props.type}-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
 </script>
 
 <style scoped>
@@ -236,6 +266,19 @@ function complianceTooltip(k) {
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 0.875rem;
+}
+
+.btn-export {
+  background: #6c757d;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.btn-export:hover {
+  background: #5a6268;
 }
 
 .fp {

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -19,6 +19,7 @@
         </div>
         <button class="btn-primary" @click="applyFilters">{{ $t('audit.filter_btn') }}</button>
         <button @click="resetFilters">{{ $t('audit.reset_btn') }}</button>
+        <button class="btn-export" @click="exportCsv">{{ $t('audit.export_csv') }}</button>
       </div>
     </section>
 
@@ -107,11 +108,13 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useFormatDate } from '../composables/useFormatDate.js'
 import { usePagination } from '../composables/usePagination.js'
 import { useSort } from '../composables/useSort.js'
 import PaginationBar from './PaginationBar.vue'
 
+const { t } = useI18n()
 const { formatDate } = useFormatDate()
 const { sortKey, toggleSort, sorted, sortIndicator } = useSort()
 
@@ -190,6 +193,35 @@ function resetFilters() {
   filters.value = { server: '', action: '', since: '' }
   currentPage.value = 1
 }
+
+function exportCsv() {
+  const headers = [
+    t('audit.col_date'),
+    t('audit.col_action'),
+    t('audit.col_by'),
+    t('audit.col_server'),
+    t('audit.col_key'),
+    t('audit.col_details'),
+  ]
+  const rows = filtered.value.map((e) => [
+    e.performed_at ? formatDate(e.performed_at) : '',
+    e.action || '',
+    e.performed_by_username || '',
+    e.server_hostname || '',
+    e.key_fingerprint || '',
+    formatDetails(e.details),
+  ])
+  const csv = [headers, ...rows]
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `audit-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
 </script>
 
 <style scoped>
@@ -210,6 +242,19 @@ function resetFilters() {
   align-items: flex-end;
   gap: 1rem;
   flex-wrap: wrap;
+}
+
+.btn-export {
+  background: #6c757d;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.btn-export:hover {
+  background: #5a6268;
 }
 
 .field {

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -16,6 +16,7 @@
         <option value="EXPIRED">EXPIRED</option>
         <option value="UNAUTHORIZED">UNAUTHORIZED</option>
       </select>
+      <button class="btn-export" @click="exportCsv">{{ $t('key_table.export_csv') }}</button>
     </div>
 
     <table>
@@ -233,6 +234,39 @@ function statusBadge(status) {
     }[status] || 'badge-expired'
   )
 }
+
+function exportCsv() {
+  const headers = [
+    t('key_table.col_status'),
+    t('key_table.col_type'),
+    t('key_table.col_fingerprint'),
+    t('key_table.col_unix_user'),
+    t('key_table.col_comment'),
+    t('key_table.col_owner'),
+    t('key_table.col_expires'),
+    t('key_table.col_compliant'),
+  ]
+  const rows = filteredKeys.value.map((k) => [
+    k.status || '',
+    k.key_type || '',
+    k.fingerprint || '',
+    k.unix_user || '',
+    k.comment || '',
+    k.owner || '',
+    k.expires_at ? formatDate(k.expires_at) : '',
+    k.is_compliant ? t('key_table.compliant_ok') : '⚠️',
+  ])
+  const csv = [headers, ...rows]
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `keys-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
 </script>
 
 <style scoped>
@@ -263,6 +297,19 @@ function statusBadge(status) {
   border-radius: 4px;
   font-size: 0.875rem;
   min-width: 160px;
+}
+
+.btn-export {
+  background: #6c757d;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.btn-export:hover {
+  background: #5a6268;
 }
 
 .fp {

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -184,7 +184,8 @@
     "filter_all_statuses": "Alle Status",
     "no_results": "Keine passenden Schlüssel.",
     "revoke_unavailable": "Widerrufen nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)",
-    "validate_unavailable": "Validieren nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)"
+    "validate_unavailable": "Validieren nicht möglich: letzter Scan fehlgeschlagen (Server nicht erreichbar)",
+    "export_csv": "CSV exportieren"
   },
   "access": {
     "title": "Temporärer Zugriff",
@@ -221,7 +222,8 @@
     "filter_since": "Seit",
     "filter_btn": "Filtern",
     "reset_btn": "Zurücksetzen",
-    "load_error": "Audit kann nicht geladen werden: {error}"
+    "load_error": "Audit kann nicht geladen werden: {error}",
+    "export_csv": "CSV exportieren"
   },
   "admins_table": {
     "search_placeholder": "Administratoren suchen...",
@@ -330,7 +332,8 @@
     "filter_all_compliant": "Konformität",
     "filter_compliant": "Konform",
     "filter_non_compliant": "Nicht konform",
-    "no_results": "Keine passenden Anomalien."
+    "no_results": "Keine passenden Anomalien.",
+    "export_csv": "CSV exportieren"
   },
   "settings": {
     "title": "Einstellungen",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -184,7 +184,8 @@
     "filter_all_statuses": "All statuses",
     "no_results": "No matching keys.",
     "revoke_unavailable": "Cannot revoke: last scan failed (server unreachable)",
-    "validate_unavailable": "Cannot validate: last scan failed (server unreachable)"
+    "validate_unavailable": "Cannot validate: last scan failed (server unreachable)",
+    "export_csv": "Export CSV"
   },
   "access": {
     "title": "Temporary Access",
@@ -221,7 +222,8 @@
     "filter_since": "Since",
     "filter_btn": "Filter",
     "reset_btn": "Reset",
-    "load_error": "Unable to load audit: {error}"
+    "load_error": "Unable to load audit: {error}",
+    "export_csv": "Export CSV"
   },
   "admins_table": {
     "search_placeholder": "Search administrators...",
@@ -330,7 +332,8 @@
     "filter_all_compliant": "Compliance",
     "filter_compliant": "Compliant",
     "filter_non_compliant": "Non-compliant",
-    "no_results": "No matching anomalies."
+    "no_results": "No matching anomalies.",
+    "export_csv": "Export CSV"
   },
   "settings": {
     "title": "Settings",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -184,7 +184,8 @@
     "filter_all_statuses": "Todos los estados",
     "no_results": "No se encontraron claves.",
     "revoke_unavailable": "No se puede revocar: último escaneo fallido (servidor inaccesible)",
-    "validate_unavailable": "No se puede validar: último escaneo fallido (servidor inaccesible)"
+    "validate_unavailable": "No se puede validar: último escaneo fallido (servidor inaccesible)",
+    "export_csv": "Exportar CSV"
   },
   "access": {
     "title": "Acceso temporal",
@@ -221,7 +222,8 @@
     "filter_since": "Desde",
     "filter_btn": "Filtrar",
     "reset_btn": "Restablecer",
-    "load_error": "No se puede cargar la auditoría: {error}"
+    "load_error": "No se puede cargar la auditoría: {error}",
+    "export_csv": "Exportar CSV"
   },
   "admins_table": {
     "search_placeholder": "Buscar administradores...",
@@ -330,7 +332,8 @@
     "filter_all_compliant": "Conformidad",
     "filter_compliant": "Conforme",
     "filter_non_compliant": "No conforme",
-    "no_results": "No se encontraron anomalías."
+    "no_results": "No se encontraron anomalías.",
+    "export_csv": "Exportar CSV"
   },
   "settings": {
     "title": "Ajustes",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -184,7 +184,8 @@
     "filter_all_statuses": "Tous les statuts",
     "no_results": "Aucune clé correspondante.",
     "revoke_unavailable": "Révocation impossible : dernier scan échoué (serveur injoignable)",
-    "validate_unavailable": "Validation impossible : dernier scan échoué (serveur injoignable)"
+    "validate_unavailable": "Validation impossible : dernier scan échoué (serveur injoignable)",
+    "export_csv": "Exporter CSV"
   },
   "access": {
     "title": "Accès temporaires",
@@ -221,7 +222,8 @@
     "filter_since": "Depuis",
     "filter_btn": "Filtrer",
     "reset_btn": "Réinitialiser",
-    "load_error": "Impossible de charger l'audit : {error}"
+    "load_error": "Impossible de charger l'audit : {error}",
+    "export_csv": "Exporter CSV"
   },
   "admins_table": {
     "search_placeholder": "Rechercher administrateurs...",
@@ -330,7 +332,8 @@
     "filter_all_compliant": "Conformité",
     "filter_compliant": "Conforme",
     "filter_non_compliant": "Non conforme",
-    "no_results": "Aucune anomalie correspondante."
+    "no_results": "Aucune anomalie correspondante.",
+    "export_csv": "Exporter CSV"
   },
   "settings": {
     "title": "Paramètres",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -184,7 +184,8 @@
     "filter_all_statuses": "Tutti gli stati",
     "no_results": "Nessuna chiave corrispondente.",
     "revoke_unavailable": "Impossibile revocare: ultima scansione fallita (server non raggiungibile)",
-    "validate_unavailable": "Impossibile validare: ultima scansione fallita (server non raggiungibile)"
+    "validate_unavailable": "Impossibile validare: ultima scansione fallita (server non raggiungibile)",
+    "export_csv": "Esporta CSV"
   },
   "access": {
     "title": "Accesso temporaneo",
@@ -221,7 +222,8 @@
     "filter_since": "Dal",
     "filter_btn": "Filtra",
     "reset_btn": "Reimposta",
-    "load_error": "Impossibile caricare l'audit: {error}"
+    "load_error": "Impossibile caricare l'audit: {error}",
+    "export_csv": "Esporta CSV"
   },
   "admins_table": {
     "search_placeholder": "Cerca amministratori...",
@@ -330,7 +332,8 @@
     "filter_all_compliant": "Conformità",
     "filter_compliant": "Conforme",
     "filter_non_compliant": "Non conforme",
-    "no_results": "Nessuna anomalia corrispondente."
+    "no_results": "Nessuna anomalia corrispondente.",
+    "export_csv": "Esporta CSV"
   },
   "settings": {
     "title": "Impostazioni",

--- a/ui/tests/AnomaliesTable.spec.js
+++ b/ui/tests/AnomaliesTable.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AnomaliesTable from '../src/components/AnomaliesTable.vue'
 import PaginationBar from '../src/components/PaginationBar.vue'
@@ -225,6 +225,47 @@ describe('AnomaliesTable.vue', () => {
     await select.setValue('ssh-rsa')
     expect(wrapper.text()).toContain('SHA256:def456')
     expect(wrapper.text()).not.toContain('SHA256:abc123')
+  })
+
+  it('shows export CSV button when anomalies exist', () => {
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons.some((b) => b.text().includes('Export CSV'))).toBe(true)
+  })
+
+  it('triggers CSV download on export button click', async () => {
+    const createObjectURL = vi.fn(() => 'blob:fake')
+    const revokeObjectURL = vi.fn()
+    const click = vi.fn()
+    global.URL.createObjectURL = createObjectURL
+    global.URL.revokeObjectURL = revokeObjectURL
+    const originalCreate = document.createElement.bind(document)
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') return { href: '', download: '', click }
+      return originalCreate(tag)
+    })
+    const wrapper = mount(AnomaliesTable, {
+      props: {
+        anomalies: pendingAnomalies,
+        servers: [],
+        currentRole: 'operator',
+        type: 'pending',
+      },
+      global: { plugins: [i18n], stubs: { PaginationBar, RouterLink: true } },
+    })
+    const exportBtn = wrapper.findAll('button').find((b) => b.text().includes('Export CSV'))
+    await exportBtn.trigger('click')
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(click).toHaveBeenCalled()
+    createElement.mockRestore()
   })
 
   it('filters by compliance dropdown', async () => {

--- a/ui/tests/AuditTable.spec.js
+++ b/ui/tests/AuditTable.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import AuditTable from '../src/components/AuditTable.vue'
 import PaginationBar from '../src/components/PaginationBar.vue'
@@ -120,6 +120,37 @@ describe('AuditTable.vue', () => {
     const rows = wrapper.findAll('tbody tr')
     const warningRow = rows.find((r) => r.text().includes('EXPIRY_WARNING'))
     expect(warningRow.classes()).toContain('row-warning')
+  })
+
+  it('shows export CSV button', () => {
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const buttons = wrapper.findAll('button')
+    expect(buttons.some((b) => b.text().includes('Export CSV'))).toBe(true)
+  })
+
+  it('triggers CSV download on export button click', async () => {
+    const createObjectURL = vi.fn(() => 'blob:fake')
+    const revokeObjectURL = vi.fn()
+    const click = vi.fn()
+    global.URL.createObjectURL = createObjectURL
+    global.URL.revokeObjectURL = revokeObjectURL
+    const originalCreate = document.createElement.bind(document)
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') return { href: '', download: '', click }
+      return originalCreate(tag)
+    })
+    const wrapper = mount(AuditTable, {
+      props: { logs, servers: [] },
+      global: { plugins: [i18n], stubs: { PaginationBar } },
+    })
+    const exportBtn = wrapper.findAll('button').find((b) => b.text().includes('Export CSV'))
+    await exportBtn.trigger('click')
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(click).toHaveBeenCalled()
+    createElement.mockRestore()
   })
 
   it('resets filters on reset button click', async () => {

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import en from '../src/locales/en.json'
@@ -276,6 +276,31 @@ describe('KeyTable', () => {
     expect(validateBtn).toBeDefined()
     expect(validateBtn.attributes('disabled')).toBeDefined()
     expect(validateBtn.attributes('title')).toContain('Cannot validate')
+  })
+
+  it('shows export CSV button when keys exist', () => {
+    const w = mountTable([makeKey()])
+    const buttons = w.findAll('button')
+    expect(buttons.some((b) => b.text().includes('Export CSV'))).toBe(true)
+  })
+
+  it('triggers CSV download on export button click', async () => {
+    const createObjectURL = vi.fn(() => 'blob:fake')
+    const revokeObjectURL = vi.fn()
+    const click = vi.fn()
+    global.URL.createObjectURL = createObjectURL
+    global.URL.revokeObjectURL = revokeObjectURL
+    const originalCreate = document.createElement.bind(document)
+    const createElement = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      if (tag === 'a') return { href: '', download: '', click }
+      return originalCreate(tag)
+    })
+    const w = mountTable([makeKey()])
+    const exportBtn = w.findAll('button').find((b) => b.text().includes('Export CSV'))
+    await exportBtn.trigger('click')
+    expect(createObjectURL).toHaveBeenCalled()
+    expect(click).toHaveBeenCalled()
+    createElement.mockRestore()
   })
 
   it('validate button is enabled when scanOk is true', () => {


### PR DESCRIPTION
This pull request adds CSV export functionality to the Key Table, Audit Table, and Anomalies Table components in the UI. It introduces an "Export CSV" button to each table, allowing users to download the currently displayed data as a CSV file. The implementation includes internationalization support for the new button and column headers, as well as unit tests to verify the new feature. Additionally, consistent styling is applied to the export buttons across all tables.

**CSV Export Feature Implementation:**

- Added an `exportCsv` function and "Export CSV" button to `KeyTable.vue`, `AuditTable.vue`, and `AnomaliesTable.vue`, enabling users to download filtered table data as a CSV file. The function dynamically generates the CSV content based on the current table view and applies proper escaping for CSV format. [[1]](diffhunk://#diff-ea1cf6b51a041bfdf98b4f0005138b265acdb72e199d977a55f1755616418d56R19) [[2]](diffhunk://#diff-ea1cf6b51a041bfdf98b4f0005138b265acdb72e199d977a55f1755616418d56R237-R269) [[3]](diffhunk://#diff-7818448ba769c6fd5607ac85cb77e40d877ddbe0b4f68a406bd850cd14489aa1R28) [[4]](diffhunk://#diff-7818448ba769c6fd5607ac85cb77e40d877ddbe0b4f68a406bd850cd14489aa1R217-R245) [[5]](diffhunk://#diff-e0502060b09d683f98c542632bc3bde24874089e45e111347b92e9ed8dac1a12R22) [[6]](diffhunk://#diff-e0502060b09d683f98c542632bc3bde24874089e45e111347b92e9ed8dac1a12R196-R224)

- Standardized the `.btn-export` class styling for the export buttons across all three components to ensure a consistent UI/UX. [[1]](diffhunk://#diff-ea1cf6b51a041bfdf98b4f0005138b265acdb72e199d977a55f1755616418d56R302-R314) [[2]](diffhunk://#diff-7818448ba769c6fd5607ac85cb77e40d877ddbe0b4f68a406bd850cd14489aa1R271-R283) [[3]](diffhunk://#diff-e0502060b09d683f98c542632bc3bde24874089e45e111347b92e9ed8dac1a12R247-R259)

**Internationalization (i18n):**

- Added the `export_csv` translation key (e.g., "Export CSV", "Exporter CSV", etc.) to the English, German, French, Spanish, and Italian locale files for all relevant table contexts. This ensures the export button and CSV headers are properly localized. [[1]](diffhunk://#diff-ae41ec29e38159999fccfc6110477387032cb99e3b23a2d8413a644fcc1eb561L187-R188) [[2]](diffhunk://#diff-ae41ec29e38159999fccfc6110477387032cb99e3b23a2d8413a644fcc1eb561L224-R226) [[3]](diffhunk://#diff-ae41ec29e38159999fccfc6110477387032cb99e3b23a2d8413a644fcc1eb561L333-R336) [[4]](diffhunk://#diff-1e1fa1ed2f6acdf4081d124b97e443369eccac6013b58a9a87cbcf0788b4eceaL187-R188) [[5]](diffhunk://#diff-1e1fa1ed2f6acdf4081d124b97e443369eccac6013b58a9a87cbcf0788b4eceaL224-R226) [[6]](diffhunk://#diff-1e1fa1ed2f6acdf4081d124b97e443369eccac6013b58a9a87cbcf0788b4eceaL333-R336) [[7]](diffhunk://#diff-ec40d256454334b02a90caf957f58838720a728353478d560c0af4cbedb29886L187-R188) [[8]](diffhunk://#diff-ec40d256454334b02a90caf957f58838720a728353478d560c0af4cbedb29886L224-R226) [[9]](diffhunk://#diff-ec40d256454334b02a90caf957f58838720a728353478d560c0af4cbedb29886L333-R336) [[10]](diffhunk://#diff-b164d99d48833cb63babc653bf22daa427ccd345f86b02f8186977b601585459L187-R188) [[11]](diffhunk://#diff-b164d99d48833cb63babc653bf22daa427ccd345f86b02f8186977b601585459L224-R226) [[12]](diffhunk://#diff-b164d99d48833cb63babc653bf22daa427ccd345f86b02f8186977b601585459L333-R336) [[13]](diffhunk://#diff-3f0d9f82e84454bfbf96e46fd4fe02c16a544e10335368784d131a2ccfb3ee33L187-R188) [[14]](diffhunk://#diff-3f0d9f82e84454bfbf96e46fd4fe02c16a544e10335368784d131a2ccfb3ee33L224-R226) [[15]](diffhunk://#diff-3f0d9f82e84454bfbf96e46fd4fe02c16a544e10335368784d131a2ccfb3ee33L333-R336)

**Testing:**

- Added and updated unit tests in `AuditTable.spec.js` and `AnomaliesTable.spec.js` to verify that the "Export CSV" button appears and that clicking it triggers the CSV download process as expected. [[1]](diffhunk://#diff-93dad7f6099377b4fbf8f55fdca9a68911d22174656224a93b2eef8b06cf10c2L1-R1) [[2]](diffhunk://#diff-93dad7f6099377b4fbf8f55fdca9a68911d22174656224a93b2eef8b06cf10c2R125-R155) [[3]](diffhunk://#diff-19ee1ae9b44f5ea1854b925c59aff796c7cf47595732419cbf8141bf432cd82aL1-R1) [[4]](diffhunk://#diff-19ee1ae9b44f5ea1854b925c59aff796c7cf47595732419cbf8141bf432cd82aR230-R270)


closes #343 