### PR TITLE
fix: replace Flask dev server with Waitress WSGI server (#352)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–7
 
 Image finale : **alpine:3.23.4**
 - PostgreSQL 18, Python 3.12, Supervisor, Nginx, msmtp, openssh-client, busybox crond, wget, tzdata
-- pip : flask, click, paramiko, psycopg2-binary, pyyaml, werkzeug
+- pip : flask, click, paramiko, psycopg2-binary, pyyaml, werkzeug, waitress
 
 Stage build UI : **node:24-alpine**
 - Vue.js 3 (^3.4), vue-router (^4.3), vue-i18n (^9.14 — 5 langues : EN/FR/ES/IT/DE), Vite

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apk update && apk add --no-cache \
         paramiko \
         psycopg2-binary \
         pyyaml \
+        waitress \
         --break-system-packages
 
 COPY --from=ui-builder /ui/dist /app/static

--- a/app/web.py
+++ b/app/web.py
@@ -1177,4 +1177,5 @@ def test_smtp():
 if __name__ == "__main__":
     if not os.environ.get("FLASK_SECRET_KEY"):
         raise RuntimeError("FLASK_SECRET_KEY environment variable is required")
-    app.run(host="127.0.0.1", port=5000)
+    from waitress import serve
+    serve(app, host="127.0.0.1", port=5000)


### PR DESCRIPTION
## Summary

- Add `waitress` to Dockerfile pip dependencies
- Replace `app.run()` with `waitress.serve()` in `web.py`
- Update CLAUDE.md stack reference

The Flask development server warning disappears and Flask now runs behind a proper production WSGI server. Nginx continues to proxy `/api/` → Waitress on `127.0.0.1:5000` unchanged.

## Test plan

- [x] pytest → 520/520 passed
- [x] No supervisord changes needed (`command=python3 /app/app/web.py` unchanged)

Closes #352