### PR TITLE
fix: dark theme — hardcoded colors in table components cause white boxes

### DIFF
--- a/ui/src/components/AdminsTable.vue
+++ b/ui/src/components/AdminsTable.vue
@@ -235,13 +235,13 @@ const { pageSize, currentPage, totalItems, totalPages, paginatedItems, setPageSi
 }
 
 .badge-off {
-  background: #e9ecef;
-  color: #6c757d;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
 }
 
 .empty {
   text-align: center;
-  color: #888;
+  color: var(--text-secondary);
   padding: 1rem 0;
 }
 </style>

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -437,7 +437,7 @@ code {
 }
 
 .empty {
-  color: #888;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   padding: 0.5rem 0;
 }

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -422,6 +422,10 @@ code {
   text-decoration: underline;
 }
 
+:global(html[data-theme='dark'] .server-link) {
+  color: #60a5fa;
+}
+
 .non-compliant {
   cursor: help;
 }

--- a/ui/src/components/AnomaliesTable.vue
+++ b/ui/src/components/AnomaliesTable.vue
@@ -343,8 +343,8 @@ function exportCsv() {
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 1rem;
-  background: #e8f4fd;
-  border: 1px solid #b8d9f5;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 0.875rem;
   margin-bottom: 0.75rem;
@@ -405,7 +405,8 @@ function exportCsv() {
 }
 
 code {
-  background: #f4f4f4;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   padding: 0 3px;
   border-radius: 3px;
   font-size: 0.8rem;

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -323,10 +323,10 @@ code {
 }
 
 :global(html[data-theme='dark'] .row-danger) {
-  background: #3a1515 !important;
+  background: rgba(220, 53, 69, 0.15) !important;
 }
 
 :global(html[data-theme='dark'] .row-warning) {
-  background: #3a3010 !important;
+  background: rgba(255, 193, 7, 0.12) !important;
 }
 </style>

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -226,8 +226,8 @@ function exportCsv() {
 
 <style scoped>
 .card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 1.25rem;
   margin-bottom: 1.25rem;
@@ -266,7 +266,7 @@ function exportCsv() {
 label {
   font-size: 0.8rem;
   font-weight: 600;
-  color: #555;
+  color: var(--text-secondary);
 }
 
 input[type='text'],
@@ -296,13 +296,14 @@ table {
 
 .details {
   font-size: 0.8rem;
-  color: #555;
+  color: var(--text-secondary);
   overflow-wrap: break-word;
   word-break: break-word;
 }
 
 code {
-  background: #f4f4f4;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   padding: 0 3px;
   border-radius: 3px;
 }
@@ -319,5 +320,13 @@ code {
 
 .row-warning {
   background: #fffbf0;
+}
+
+:global(html[data-theme='dark'] .row-danger) {
+  background: #3a1515 !important;
+}
+
+:global(html[data-theme='dark'] .row-warning) {
+  background: #3a3010 !important;
 }
 </style>

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -310,7 +310,7 @@ code {
 
 .empty {
   text-align: center;
-  color: #888;
+  color: var(--text-secondary);
   padding: 1rem 0;
 }
 

--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -357,7 +357,7 @@ select {
 }
 
 .success-panel code {
-  background: #fff;
+  background: var(--bg-secondary);
   padding: 2px 4px;
   border-radius: 3px;
   font-size: 0.85rem;

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -82,7 +82,9 @@
           >
             <td>{{ user.unix_user }}</td>
             <td>
-              <RouterLink :to="`/servers/${user.hostname}`">{{ user.hostname }}</RouterLink>
+              <RouterLink :to="`/servers/${user.hostname}`" class="server-link">{{
+                user.hostname
+              }}</RouterLink>
             </td>
             <td>{{ user.ip_address || '—' }}</td>
             <td>{{ formatExpiry(user.expires_at) }}</td>
@@ -425,6 +427,20 @@ td {
   padding: 0.25rem 0.5rem;
   border-radius: 3px;
   font-size: 0.8rem;
+}
+
+.server-link {
+  color: #0d6efd;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.server-link:hover {
+  text-decoration: underline;
+}
+
+:global(html[data-theme='dark'] .server-link) {
+  color: #60a5fa;
 }
 
 .empty-state,

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -344,15 +344,16 @@ table {
 th {
   text-align: left;
   padding: 0.75rem;
-  background: #f8f9fa;
-  border-bottom: 2px solid #dee2e6;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-bottom: 2px solid var(--border-color);
   font-weight: 600;
   font-size: 0.85rem;
 }
 
 td {
   padding: 0.75rem;
-  border-bottom: 1px solid #dee2e6;
+  border-bottom: 1px solid var(--border-color);
   font-size: 0.9rem;
 }
 

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -375,8 +375,8 @@ function exportCsv() {
   align-items: center;
   gap: 0.75rem;
   padding: 0.6rem 1rem;
-  background: #e8f4fd;
-  border: 1px solid #b8d9f5;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
   border-radius: 4px;
   font-size: 0.875rem;
 }
@@ -473,7 +473,8 @@ td {
 }
 code {
   font-size: 0.8rem;
-  background: #f4f4f4;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   padding: 0 3px;
   border-radius: 3px;
 }

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -454,7 +454,7 @@ function exportCsv() {
 }
 .empty {
   text-align: center;
-  color: #888;
+  color: var(--text-secondary);
   padding: 1rem 0;
 }
 .actions {

--- a/ui/src/components/PaginationBar.vue
+++ b/ui/src/components/PaginationBar.vue
@@ -83,7 +83,7 @@ const to = computed(() => {
 
 .page-size-label {
   font-size: 0.875rem;
-  color: #444;
+  color: var(--text-secondary);
 }
 
 .page-size-select {
@@ -96,13 +96,14 @@ const to = computed(() => {
 
 .showing-info {
   font-size: 0.875rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .btn-pagination {
   padding: 0.35rem 0.75rem;
-  border: 1px solid #ccc;
-  background: #fff;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   border-radius: 4px;
   font-size: 0.875rem;
   cursor: pointer;
@@ -110,12 +111,12 @@ const to = computed(() => {
 }
 
 .btn-pagination:hover:not(:disabled) {
-  background: #f0f0f0;
+  background: var(--bg-tertiary);
 }
 
 .btn-pagination:disabled {
   opacity: 0.45;
   cursor: not-allowed;
-  background: #f9f9f9;
+  background: var(--bg-secondary);
 }
 </style>

--- a/ui/src/components/ServerTable.vue
+++ b/ui/src/components/ServerTable.vue
@@ -218,7 +218,7 @@ function envBadge(env) {
 
 .empty {
   text-align: center;
-  color: #888;
+  color: var(--text-secondary);
   padding: 1rem 0;
 }
 
@@ -237,10 +237,10 @@ function envBadge(env) {
 }
 
 .link-disabled {
-  color: #999;
+  color: var(--text-secondary);
 }
 .link-disabled:hover {
-  color: #777;
+  color: var(--text-secondary);
 }
 
 .badge-disabled {

--- a/ui/src/components/SessionsCard.vue
+++ b/ui/src/components/SessionsCard.vue
@@ -358,7 +358,7 @@ h2 {
 
 .last-collected {
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
   margin: 0 0 1rem 0;
 }
 
@@ -366,7 +366,7 @@ h2 {
   font-weight: 600;
   font-size: 0.95rem;
   margin: 1.25rem 0 0.5rem 0;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .section-title:first-of-type {
@@ -386,18 +386,22 @@ table {
 th {
   text-align: left;
   padding: 0.5rem;
-  border-bottom: 2px solid #ddd;
+  border-bottom: 2px solid var(--border-color);
   font-weight: 600;
-  color: #555;
+  color: var(--text-secondary);
 }
 
 td {
   padding: 0.5rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .row-active {
   background: #f0f9ff;
+}
+
+:global(html[data-theme='dark'] .row-active) {
+  background: rgba(37, 99, 235, 0.12) !important;
 }
 
 .badge {
@@ -445,11 +449,11 @@ td {
 .loading {
   text-align: center;
   padding: 1rem;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .empty {
-  color: #888;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   padding: 0.75rem 0;
 }
@@ -508,7 +512,7 @@ td {
   flex: 1;
   min-width: 150px;
   padding: 0.4rem 0.6rem;
-  border: 1px solid #ccc;
+  border: 1px solid var(--input-border);
   border-radius: 4px;
   font-size: 0.9rem;
 }

--- a/ui/src/views/AccessRequests.vue
+++ b/ui/src/views/AccessRequests.vue
@@ -79,7 +79,7 @@ h1 {
   margin-bottom: 1rem;
 }
 .info-text {
-  color: #555;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   margin-bottom: 1rem;
 }

--- a/ui/src/views/Admins.vue
+++ b/ui/src/views/Admins.vue
@@ -776,8 +776,8 @@ h2 {
 }
 
 .card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 1.25rem;
   margin-bottom: 1.25rem;
@@ -795,7 +795,7 @@ h2 {
 }
 .my-account-hint {
   font-size: 0.875rem;
-  color: #555;
+  color: var(--text-secondary);
   margin: 0;
 }
 
@@ -836,13 +836,13 @@ label {
   border: none;
   padding: 0;
   cursor: pointer;
-  color: #6c757d;
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
   line-height: 1;
 }
 .eye-btn:hover {
-  color: #343a40;
+  color: var(--text-primary);
 }
 
 input[type='text'],
@@ -858,14 +858,14 @@ select {
 }
 
 input.input-readonly {
-  background-color: #f5f5f5;
-  color: #666;
+  background-color: var(--bg-tertiary);
+  color: var(--text-secondary);
   cursor: not-allowed;
 }
 
 .field-hint {
   font-size: 0.8rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-top: 0.25rem;
   display: block;
 }
@@ -903,13 +903,13 @@ input.input-error {
 
 .empty {
   text-align: center;
-  color: #888;
+  color: var(--text-secondary);
   padding: 1rem 0;
 }
 .loading {
   text-align: center;
   padding: 2rem;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .alert-error {
@@ -938,7 +938,7 @@ input.input-error {
   padding: 0.3rem 0.7rem;
   border: 1px solid #6c757d;
   border-radius: 4px;
-  background: #fff;
+  background: var(--bg-secondary);
   color: #6c757d;
   cursor: pointer;
   font-size: 0.85rem;

--- a/ui/src/views/Anomalies.vue
+++ b/ui/src/views/Anomalies.vue
@@ -287,8 +287,8 @@ h2 {
 }
 
 .card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 1.25rem;
   margin-bottom: 1.25rem;
@@ -320,7 +320,7 @@ h2 {
 
 .subtitle {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--text-secondary);
   font-weight: normal;
 }
 
@@ -331,7 +331,8 @@ h2 {
 }
 
 code {
-  background: #f4f4f4;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
   padding: 0 3px;
   border-radius: 3px;
   font-size: 0.8rem;

--- a/ui/src/views/Audit.vue
+++ b/ui/src/views/Audit.vue
@@ -48,7 +48,7 @@ h1 {
 .loading {
   text-align: center;
   padding: 2rem;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .alert-error {

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -636,7 +636,7 @@ h1 {
 .deploy-hint {
   margin: 0;
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-secondary);
 }
 .deploy-hint.small {
   font-size: 0.8rem;

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -713,8 +713,8 @@ h2 {
 
 .btn-back {
   background: none;
-  border: 1px solid #ccc;
-  color: #555;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 0.25rem 0.6rem;
   border-radius: 4px;
@@ -722,8 +722,8 @@ h2 {
 }
 
 .card {
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 1.25rem;
   margin-bottom: 1.25rem;
@@ -736,7 +736,7 @@ h2 {
 }
 dt {
   font-weight: 600;
-  color: #555;
+  color: var(--text-secondary);
   font-size: 0.85rem;
 }
 dd {
@@ -752,19 +752,19 @@ dd {
 }
 .revoke-user-info {
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-secondary);
   margin: 0 0 0.75rem;
 }
 
 .empty {
-  color: #888;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   padding: 0.5rem 0;
 }
 .loading {
   text-align: center;
   padding: 2rem;
-  color: #888;
+  color: var(--text-secondary);
 }
 
 .alert-error {
@@ -841,7 +841,7 @@ dd {
 }
 .hint {
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-secondary);
   margin: 0 0 0.75rem;
 }
 .password-wrapper {
@@ -860,12 +860,12 @@ dd {
   background: none;
   border: none;
   cursor: pointer;
-  color: #666;
+  color: var(--text-secondary);
   padding: 0.2rem;
   display: flex;
   align-items: center;
 }
 .btn-eye:hover {
-  color: #333;
+  color: var(--text-primary);
 }
 </style>

--- a/ui/src/views/Settings.vue
+++ b/ui/src/views/Settings.vue
@@ -310,7 +310,7 @@ h2 {
 }
 
 .card {
-  background: #fff;
+  background: var(--bg-secondary);
   padding: 1.5rem;
   border-radius: 6px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
@@ -320,7 +320,7 @@ h2 {
   margin-bottom: 1rem;
   font-size: 1.1rem;
   font-weight: 600;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-color);
   padding-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #358 (dark theme). Several components used hardcoded light-mode colors that override the CSS variables, causing white/unreadable elements in dark mode.

- `KeyTable.vue` + `AnomaliesTable.vue`: `code { background: #f4f4f4 }` → white boxes on fingerprint/type/unix_user; `.bulk-bar { background: #e8f4fd }` → invisible light-blue bar
- `AuditTable.vue`: `.card { background: #fff }` → white card; `code`, `label`, `.details` all hardcoded; `.row-danger/.row-warning` near-white in dark mode
- `DeployedUsersTable.vue`: `th { background: #f8f9fa }` → white header row; hardcoded border colors

## Fix

All hardcoded colors replaced with CSS variables (`var(--bg-tertiary)`, `var(--bg-secondary)`, `var(--border-color)`, `var(--text-primary)`, `var(--text-secondary)`). Dark mode overrides for `.row-danger` / `.row-warning` added via `:global()`.

## Test plan

- [x] Vitest: 325/325 passed
- [ ] Visual check dark mode: `code` cells readable, bulk-bar visible, AuditTable card dark, DeployedUsersTable header dark, row-danger/warning visible
- [ ] Visual check light mode: no regression

Closes #362