### PR TITLE
fix: add missing -U flag to sam-unlock-user to restore password hash

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -162,7 +162,7 @@ if [ -z "$USER" ]; then
     echo "Usage: sam-unlock-user <username>" >&2
     exit 1
 fi
-usermod -s /bin/bash "$USER"
+usermod -U -s /bin/bash "$USER"
 """
 
 SAM_SESSIONS_PATH = "/usr/local/bin/sam-sessions"


### PR DESCRIPTION
## Summary

`sam-unlock-user` was running `usermod -s /bin/bash` without `-U`, which restored the login shell but left the password hash locked (`!hash` in `/etc/shadow`).

The lock script correctly does `usermod -L -s /sbin/nologin` (locks password + shell). The unlock must mirror it with `usermod -U -s /bin/bash`.

Note: `app/CLAUDE.md` already documented the correct command — this was a divergence between spec and implementation.

## Change

```diff
- usermod -s /bin/bash "$USER"
+ usermod -U -s /bin/bash "$USER"
```

One character change, `app/ssh.py` line 165.

## Test plan

- [x] pytest: 524/524 passed
- [ ] Manual: lock a user via SAM UI → unlock → verify password login still works

Closes #364