### PR TITLE
chore: translate code/tests to English and update KeyActions test

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -1,6 +1,6 @@
 """
-actions.py — logique metier partagee entre web.py (API) et manage.py (CLI).
-Jamais de duplication entre les deux consommateurs.
+actions.py — business logic shared between web.py (API) and manage.py (CLI).
+Never duplicate logic between the two consumers.
 """
 import ipaddress
 import json
@@ -60,7 +60,7 @@ def _check_fingerprint(fp: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Cles SSH
+# SSH Keys
 # ---------------------------------------------------------------------------
 
 def validate_key(
@@ -71,9 +71,9 @@ def validate_key(
 ) -> dict:
     """PENDING_REVIEW → ACTIVE. Logs KEY_ADDED for each authorization.
 
-    Si unix_user ET hostname sont fournis : validation ciblée — une seule
-    autorisation (key_id, server_id, unix_user). Sinon : toutes les
-    autorisations PENDING_REVIEW du fingerprint (usage CLI).
+    If unix_user AND hostname are provided: targeted validation — a single
+    authorization (key_id, server_id, unix_user). Otherwise: all
+    PENDING_REVIEW authorizations for the fingerprint (CLI usage).
     """
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
@@ -520,7 +520,7 @@ def remove_key_expiry(fingerprint: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Acces temporaires
+# Temporary access
 # ---------------------------------------------------------------------------
 
 def grant_access(
@@ -761,7 +761,7 @@ def revoke_request(request_id: str, admin_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Serveurs
+# Servers
 # ---------------------------------------------------------------------------
 
 def add_server(
@@ -933,7 +933,7 @@ def delete_server(hostname: str, admin_id: str | None = None) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Administrateurs
+# Administrators
 # ---------------------------------------------------------------------------
 
 def _validate_password_strength(password: str) -> None:

--- a/app/alerts.py
+++ b/app/alerts.py
@@ -1,12 +1,12 @@
 """
-alerts.py — envoi d'emails via msmtp.
+alerts.py — send emails via msmtp.
 
-Niveaux :
-  CRITICAL  → email immediat
-  WARNING   → email immediat (anti-spam 24h gere par actions.py)
-  INFO      → log uniquement, pas d'email
+Levels:
+    CRITICAL  → immediate email
+    WARNING   → immediate email (24h anti-spam handled by actions.py)
+    INFO      → log only, no email
 
-Les destinataires sont les administrateurs actifs avec receive_alerts=true.
+Recipients are active administrators with receive_alerts=true.
 """
 import logging
 import os

--- a/app/collect.py
+++ b/app/collect.py
@@ -1,6 +1,6 @@
 """
-collect.py — orchestration du scan SSH complet.
-Appelee par cron et via manage.py / web.py.
+collect.py — orchestration of the full SSH scan.
+Called by cron and via manage.py / web.py.
 """
 import base64
 import hashlib

--- a/app/expire.py
+++ b/app/expire.py
@@ -1,9 +1,9 @@
 """
-expire.py — gestion des expirations de cles SSH.
-Appelee par cron a chaque cycle (SCAN_INTERVAL_HOURS).
+expire.py — manage SSH key expirations.
+Called by cron on each cycle (SCAN_INTERVAL_HOURS).
 
-warn_expiring_keys() : alerte J-7 et J-2 avec anti-spam 24h
-expire_keys()        : scenario 4 — revocation automatique a echeance
+warn_expiring_keys(): send warnings at J-7 and J-2 with 24h anti-spam
+expire_keys(): scenario 4 — automatic revocation on expiry
 """
 import json
 

--- a/app/manage.py
+++ b/app/manage.py
@@ -1,6 +1,6 @@
 """
-manage.py — CLI click pour ssh-access-manager.
-Importe actions.py pour la logique metier — jamais de duplication.
+manage.py — CLI Click for ssh-access-manager.
+Imports `actions.py` for business logic — no duplication between CLI and API.
 """
 from datetime import datetime, timedelta, timezone
 
@@ -12,7 +12,7 @@ import db
 
 
 # ---------------------------------------------------------------------------
-# Helpers de formatage
+# Formatting helpers
 # ---------------------------------------------------------------------------
 
 def _table(rows: list[dict], columns: list[str]) -> None:
@@ -52,7 +52,7 @@ def _require_admin() -> str:
 
 
 # ---------------------------------------------------------------------------
-# CLI principal
+# Main CLI
 # ---------------------------------------------------------------------------
 
 @click.group()

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -96,7 +96,7 @@ def test_actions_revoke_key_raises_if_key_not_found(sample_key):
 
 
 def test_actions_revoke_key_scoped_calls_sam_revoke_with_unix_user(sample_key):
-    """Revocation ciblée (hostname + unix_user) appelle revoke_on_server avec unix_user."""
+    """Targeted revocation (hostname + unix_user) calls revoke_on_server with unix_user."""
     server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
     auth = {"status": "ACTIVE"}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
@@ -112,7 +112,7 @@ def test_actions_revoke_key_scoped_calls_sam_revoke_with_unix_user(sample_key):
 
 
 def test_actions_revoke_key_scoped_sets_revoked_for_unix_user_only(sample_key):
-    """Revocation ciblée — l'UPDATE inclut unix_user dans le WHERE."""
+    """Targeted revocation — the UPDATE includes unix_user in the WHERE clause."""
     server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
     auth = {"status": "ACTIVE"}
     with patch("actions.db") as mock_db, patch("actions.ssh"):
@@ -127,7 +127,7 @@ def test_actions_revoke_key_scoped_sets_revoked_for_unix_user_only(sample_key):
 
 
 # ---------------------------------------------------------------------------
-# handle_disappeared_key — scenario 2 (hors systeme, revoked_automatically=True)
+# handle_disappeared_key — scenario 2 (out-of-system, revoked_automatically=True)
 # ---------------------------------------------------------------------------
 
 def test_actions_handle_disappeared_key_scenario2_sets_revoked_automatically():
@@ -699,7 +699,7 @@ def test_actions_delete_admin_raises_if_not_found():
 # ---------------------------------------------------------------------------
 
 def test_actions_update_admin_success():
-    """update_admin met à jour email et role, log ADMIN_UPDATED."""
+    """update_admin updates email and role, logs ADMIN_UPDATED."""
     admin = {"id": ADMIN_ID, "email": "old@example.com", "role": "sysadmin"}
     current_admin = {"username": "admin"}
     with patch("actions.db") as mock_db:
@@ -719,7 +719,7 @@ def test_actions_update_admin_success():
 
 
 def test_actions_update_admin_not_found():
-    """update_admin lève ValueError si admin introuvable."""
+    """update_admin raises UserError if admin not found."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
         with pytest.raises(UserError, match="Admin not found"):
@@ -727,7 +727,7 @@ def test_actions_update_admin_not_found():
 
 
 def test_actions_update_admin_self_role_change_raises():
-    """update_admin lève ValueError si admin modifie son propre rôle."""
+    """update_admin raises UserError if admin changes their own role."""
     admin = {"id": ADMIN_ID, "email": "admin@example.com", "role": "sysadmin"}
     current_admin = {"username": "admin"}
     with patch("actions.db") as mock_db:
@@ -737,7 +737,7 @@ def test_actions_update_admin_self_role_change_raises():
 
 
 def test_actions_update_admin_prevents_demoting_last_sysadmin():
-    """update_admin lève ValueError si on dégrade le dernier sysadmin actif."""
+    """update_admin raises UserError when demoting the last active sysadmin."""
     admin = {"id": ADMIN_ID, "email": "admin@example.com", "role": "sysadmin"}
     current_admin = {"username": "other-admin"}
     with patch("actions.db") as mock_db:
@@ -747,7 +747,7 @@ def test_actions_update_admin_prevents_demoting_last_sysadmin():
 
 
 def test_actions_update_admin_allows_demotion_with_other_sysadmin():
-    """update_admin autorise la dégradation si un autre sysadmin actif existe."""
+    """update_admin allows demotion if another active sysadmin exists."""
     admin = {"id": ADMIN_ID, "email": "admin@example.com", "role": "sysadmin"}
     current_admin = {"username": "other-admin"}
     with patch("actions.db") as mock_db:
@@ -898,7 +898,7 @@ def test_actions_remove_expiry_rejects_invalid_fingerprint_format():
 
 
 def test_actions_fingerprint_valid_format_passes_check():
-    """Un fingerprint SHA256 valide ne lève pas d'exception au niveau du format."""
+    """A valid SHA256 fingerprint does not raise a formatting error."""
     import actions as act
     act._check_fingerprint("SHA256:abc123+/=ABCXYZ")
 
@@ -969,7 +969,7 @@ def test_actions_unlock_user_ssh_user_raises():
 # ---------------------------------------------------------------------------
 
 def test_actions_deploy_key_includes_unix_user_in_key_authorization(sample_server, sample_key):
-    """deploy_key insère unix_user dans key_authorizations."""
+    """deploy_key inserts unix_user into key_authorizations."""
     with patch("actions.db") as mock_db, patch("actions.ssh"):
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
@@ -991,7 +991,7 @@ def test_actions_deploy_key_includes_unix_user_in_key_authorization(sample_serve
 
 
 def test_actions_deploy_key_on_conflict_uses_three_column_pk(sample_server, sample_key):
-    """Le ON CONFLICT doit référencer (key_id, server_id, unix_user)."""
+    """ON CONFLICT must reference (key_id, server_id, unix_user)."""
     with patch("actions.db") as mock_db, patch("actions.ssh"):
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
@@ -1053,7 +1053,7 @@ def test_actions_handle_reappeared_key_includes_unix_user_in_where():
 
 
 def test_actions_validate_key_includes_unix_user_in_update(sample_key):
-    """validate_key met à jour chaque ligne par (key_id, server_id, unix_user)."""
+    """validate_key updates each row by (key_id, server_id, unix_user)."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": KEY_ID}
         mock_db.query.return_value = [
@@ -1071,7 +1071,7 @@ def test_actions_validate_key_includes_unix_user_in_update(sample_key):
 
 
 def test_actions_validate_key_scoped_only_validates_target_unix_user(sample_key):
-    """Avec unix_user+hostname, seule l'autorisation ciblée est validée."""
+    """With unix_user+hostname, only the targeted authorization is validated."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             {"id": KEY_ID},          # ssh_keys
@@ -1088,7 +1088,7 @@ def test_actions_validate_key_scoped_only_validates_target_unix_user(sample_key)
 
 
 def test_actions_validate_key_scoped_raises_if_server_not_found(sample_key):
-    """Avec hostname inconnu, ValueError levée."""
+    """With unknown hostname, ValueError is raised."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             {"id": KEY_ID},  # ssh_keys found
@@ -1103,7 +1103,7 @@ def test_actions_validate_key_scoped_raises_if_server_not_found(sample_key):
 # ---------------------------------------------------------------------------
 
 def test_actions_update_server_success():
-    """update_server met à jour les champs et log SERVER_UPDATED."""
+    """update_server updates fields and logs SERVER_UPDATED."""
     server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22, "max_sessions": 2}
     with patch("actions.db") as mock_db, patch("servers.add_to_known_hosts"):
         mock_db.query_one.side_effect = [server, None]
@@ -1127,7 +1127,7 @@ def test_actions_update_server_blank_environment_is_stored_as_null():
 
 
 def test_actions_update_server_ip_change_calls_keyscan():
-    """Si l'IP change, add_to_known_hosts est appelé."""
+    """If the IP changes, add_to_known_hosts is called."""
     server = {"id": SERVER_ID, "ip_address": "192.168.1.10", "environment": "lab", "os_family": "rhel", "ssh_port": 22, "max_sessions": 2}
     with patch("actions.db") as mock_db, patch("servers.add_to_known_hosts") as mock_keyscan:
         mock_db.query_one.side_effect = [server, None]
@@ -1136,7 +1136,7 @@ def test_actions_update_server_ip_change_calls_keyscan():
 
 
 def test_actions_update_server_not_found():
-    """Si le serveur n'existe pas, ValueError levée."""
+    """If the server does not exist, ValueError is raised."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
         with pytest.raises(UserError, match="Server not found"):

--- a/app/tests/test_alerts.py
+++ b/app/tests/test_alerts.py
@@ -14,13 +14,13 @@ def _make_recipients(*emails):
 
 
 # ---------------------------------------------------------------------------
-# CRITICAL — envoie un email via msmtp pour chaque destinataire éligible
+# CRITICAL — send an email via msmtp to each eligible recipient
 # ---------------------------------------------------------------------------
 
 def test_alerts_critical_sends_to_single_recipient(mock_smtp):
     with patch("alerts.db") as mock_db:
         mock_db.query.return_value = _make_recipients("admin@example.com")
-        alerts.send_alert("CRITICAL", "Cle inconnue detectee", "Fingerprint: SHA256:abc")
+        alerts.send_alert("CRITICAL", "Unknown key detected", "Fingerprint: SHA256:abc")
     mock_smtp.assert_called_once()
     args = mock_smtp.call_args[0][0]
     assert "msmtp" in args
@@ -71,13 +71,13 @@ def test_alerts_critical_to_header_matches_recipient(mock_smtp):
 
 
 # ---------------------------------------------------------------------------
-# WARNING — envoie un email via msmtp
+# WARNING — send an email via msmtp
 # ---------------------------------------------------------------------------
 
 def test_alerts_warning_sends_email(mock_smtp):
     with patch("alerts.db") as mock_db:
         mock_db.query.return_value = _make_recipients("admin@example.com")
-        alerts.send_alert("WARNING", "Cle expirant bientot", "Expires dans 2 jours")
+        alerts.send_alert("WARNING", "Key expiring soon", "Expires in 2 days")
     mock_smtp.assert_called_once()
 
 
@@ -98,7 +98,7 @@ def test_alerts_warning_sets_normal_priority(mock_smtp):
 
 
 # ---------------------------------------------------------------------------
-# INFO — log uniquement, pas d'email
+# INFO — log only, no email
 # ---------------------------------------------------------------------------
 
 def test_alerts_info_does_not_send_email(mock_smtp):
@@ -112,7 +112,7 @@ def test_alerts_info_unknown_level_does_not_send_email(mock_smtp):
 
 
 # ---------------------------------------------------------------------------
-# Robustesse — msmtp manquant ou erreur
+# Robustness — msmtp missing or error
 # ---------------------------------------------------------------------------
 
 def test_alerts_msmtp_not_found_does_not_raise():

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -78,11 +78,11 @@ def test_collect_parse_key_line_root_user():
 
 
 # ---------------------------------------------------------------------------
-# Tests unix_user — même clé pour plusieurs utilisateurs
+# Tests unix_user — same key for multiple users
 # ---------------------------------------------------------------------------
 
 def test_collect_scan_server_same_key_two_users_creates_two_auth_rows():
-    """La même clé déployée pour alice et bob → deux lignes key_authorizations."""
+    """The same key deployed for alice and bob → two key_authorizations rows."""
     alice_line = f"alice\tssh-ed25519 {ED25519_B64} alice@host"
     bob_line = f"bob\tssh-ed25519 {ED25519_B64} bob@host"
 
@@ -112,7 +112,7 @@ def test_collect_scan_server_same_key_two_users_creates_two_auth_rows():
 
 
 def test_collect_scan_server_unix_user_passed_to_handle_unknown_key():
-    """unix_user est passé à handle_unknown_key pour les clés inconnues."""
+    """unix_user is passed to handle_unknown_key for unknown keys."""
     with patch("collect.ssh") as mock_ssh, \
          patch("collect.db") as mock_db, \
          patch("collect.actions") as mock_actions, \
@@ -130,7 +130,7 @@ def test_collect_scan_server_unix_user_passed_to_handle_unknown_key():
 
 def test_collect_scan_server_only_disappeared_unix_user_row_triggers_scenario2():
     """
-    Si alice disparaît mais bob est encore présent, seul alice est détecté comme disparu.
+    If alice disappears but bob remains present, only alice is detected as disappeared.
     """
     fp = collect._compute_fingerprint(ED25519_B64)
     bob_line = f"bob\tssh-ed25519 {ED25519_B64} bob@host"
@@ -161,7 +161,7 @@ def test_collect_scan_server_only_disappeared_unix_user_row_triggers_scenario2()
 
 
 # ---------------------------------------------------------------------------
-# Tests scan_server() — scenario 3 (cle inconnue)
+# Tests scan_server() — scenario 3 (unknown key)
 # ---------------------------------------------------------------------------
 
 def test_collect_scan_server_scenario3_unknown_key_calls_handle_unknown_key():
@@ -200,7 +200,7 @@ def test_collect_scan_server_scenario3_logs_scan_completed():
 
 
 # ---------------------------------------------------------------------------
-# Tests scan_server() — scenario 2 (cle disparue)
+# Tests scan_server() — scenario 2 (disappeared key)
 # ---------------------------------------------------------------------------
 
 def test_collect_scan_server_scenario2_disappeared_key_calls_handle_disappeared():
@@ -225,7 +225,7 @@ def test_collect_scan_server_scenario2_disappeared_key_calls_handle_disappeared(
 
 
 # ---------------------------------------------------------------------------
-# Tests scan_server() — scenario 5 (cle revoquee/expiree reapparue)
+# Tests scan_server() — scenario 5 (revoked/expired key reappeared)
 # ---------------------------------------------------------------------------
 
 def test_collect_scan_server_scenario5_revoked_key_reappeared_calls_handle_reappeared():
@@ -551,7 +551,7 @@ def test_collect_scan_server_updates_key_size_bits_on_rescan():
 
 
 # ---------------------------------------------------------------------------
-# Tests _should_run() — skip si dernier scan trop récent
+# Tests _should_run() — skip if last scan is too recent
 # ---------------------------------------------------------------------------
 
 def test_collect_should_run_true_when_no_scan_completed():

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -43,7 +43,7 @@ def _make_client(stdout_data=b"", stderr_data=b"", exit_status=0, sha_out=None):
 
 
 # ---------------------------------------------------------------------------
-# RejectPolicy présent sur chaque connexion
+# RejectPolicy present on every connection
 # ---------------------------------------------------------------------------
 
 def test_ssh_connect_uses_reject_policy():
@@ -75,7 +75,7 @@ def test_ssh_connect_never_uses_auto_add_policy():
 
 
 # ---------------------------------------------------------------------------
-# ensure_scripts — déploie si hash différent
+# ensure_scripts — deploys if hash differs
 # ---------------------------------------------------------------------------
 
 def test_ssh_ensure_scripts_deploys_when_hash_differs(sample_server):
@@ -140,7 +140,7 @@ def test_ssh_ensure_scripts_skips_when_hash_identical(sample_server):
 
 
 # ---------------------------------------------------------------------------
-# revoke_on_server — appelle sam-revoke avec le bon fingerprint
+# revoke_on_server — calls sam-revoke with the correct fingerprint
 # ---------------------------------------------------------------------------
 
 def test_ssh_revoke_on_server_calls_sam_revoke_with_fingerprint(sample_key):
@@ -198,7 +198,7 @@ def test_ssh_revoke_on_server_raises_on_nonzero_exit(sample_key):
 
 
 # ---------------------------------------------------------------------------
-# SAM_COLLECT et SAM_REVOKE — vérifications de contenu
+# SAM_COLLECT and SAM_REVOKE — content checks
 # ---------------------------------------------------------------------------
 
 def test_ssh_sam_collect_is_bytes():
@@ -233,11 +233,11 @@ def test_ssh_sam_revoke_atomic_rewrite_only_when_changed():
 
 
 # ---------------------------------------------------------------------------
-# Sécurité déploiement — staging hors /tmp, destination exacte
+# Deployment security — staging outside /tmp, exact destination
 # ---------------------------------------------------------------------------
 
 def test_ssh_ensure_scripts_staging_not_in_tmp(sample_server):
-    """Le fichier staging doit être dans le home de l'utilisateur, pas /tmp."""
+    """The staging file must be in the user's home directory, not /tmp."""
     wrong_hash = "0" * 64
     with patch("ssh._connect") as mock_connect, patch("ssh.db"):
         client = MagicMock()
@@ -254,12 +254,12 @@ def test_ssh_ensure_scripts_staging_not_in_tmp(sample_server):
         ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
 
         staged_path = sftp.putfo.call_args[0][1]
-        assert not staged_path.startswith("/tmp"), "Staging ne doit pas utiliser /tmp (world-writable)"
+        assert not staged_path.startswith("/tmp"), "Staging must not use /tmp (world-writable)"
         assert "/home/" in staged_path
 
 
 def test_ssh_ensure_scripts_install_uses_exact_destination(sample_server):
-    """sudo install doit spécifier le chemin de destination exact, pas un répertoire."""
+    """sudo install must specify the exact destination path, not a directory."""
     wrong_hash = "0" * 64
     with patch("ssh._connect") as mock_connect, patch("ssh.db"):
         client = MagicMock()
@@ -277,7 +277,7 @@ def test_ssh_ensure_scripts_install_uses_exact_destination(sample_server):
 
         commands = [c[0][0] for c in client.exec_command.call_args_list]
         install_cmds = [c for c in commands if "/usr/bin/install" in c]
-        assert install_cmds, "Aucune commande install trouvée"
+        assert install_cmds, "No install command found"
         valid_destinations = (
             "/usr/local/bin/sam-collect",
             "/usr/local/bin/sam-revoke",
@@ -289,12 +289,12 @@ def test_ssh_ensure_scripts_install_uses_exact_destination(sample_server):
         for cmd in install_cmds:
             dest = cmd.split()[-1]
             assert dest in valid_destinations, (
-                f"La destination install doit être un chemin exact, pas un répertoire : {cmd}"
+                f"Install destination must be an exact path, not a directory: {cmd}"
             )
 
 
 def test_ssh_ensure_scripts_install_uses_mode_750(sample_server):
-    """sudo install doit utiliser -m 750 pour interdire la lecture aux autres utilisateurs."""
+    """sudo install must use -m 750 to prevent others from reading the files."""
     wrong_hash = "0" * 64
     with patch("ssh._connect") as mock_connect, patch("ssh.db"):
         client = MagicMock()
@@ -312,14 +312,14 @@ def test_ssh_ensure_scripts_install_uses_mode_750(sample_server):
 
         commands = [c[0][0] for c in client.exec_command.call_args_list]
         install_cmds = [c for c in commands if "/usr/bin/install" in c]
-        assert install_cmds, "Aucune commande install trouvée"
+        assert install_cmds, "No install command found"
         for cmd in install_cmds:
-            assert "-m 750" in cmd, f"install doit utiliser -m 750, pas -m 755 : {cmd}"
+            assert "-m 750" in cmd, f"install must use -m 750, not -m 755: {cmd}"
             assert "-m 755" not in cmd
 
 
 def test_ssh_deploy_script_sets_staging_permissions(sample_server):
-    """Le fichier staging doit être chmod 600 avant sudo install."""
+    """The staging file must be chmod 600 before sudo install."""
     wrong_hash = "0" * 64
     with patch("ssh._connect") as mock_connect, patch("ssh.db"):
         client = MagicMock()
@@ -340,7 +340,7 @@ def test_ssh_deploy_script_sets_staging_permissions(sample_server):
 
 
 def test_ssh_deploy_script_removes_staging_file_after_install(sample_server):
-    """Le fichier staging doit être supprimé après sudo install."""
+    """The staging file must be removed after sudo install."""
     wrong_hash = "0" * 64
     with patch("ssh._connect") as mock_connect, patch("ssh.db"):
         client = MagicMock()
@@ -360,12 +360,12 @@ def test_ssh_deploy_script_removes_staging_file_after_install(sample_server):
         commands = [c[0][0] for c in client.exec_command.call_args_list]
         cleanup_cmds = [c for c in commands if c.startswith("rm -f")]
         assert any(staged_path in c for c in cleanup_cmds), (
-            f"Le fichier staging {staged_path} doit être supprimé après install"
+            f"The staging file {staged_path} must be removed after install"
         )
 
 
 # ---------------------------------------------------------------------------
-# SAM_ADD — vérifications de contenu
+# SAM_ADD — content checks
 # ---------------------------------------------------------------------------
 
 def test_ssh_sam_add_is_bytes():
@@ -428,11 +428,11 @@ def test_ssh_add_key_on_server_raises_on_nonzero_exit(sample_server):
 
 
 # ---------------------------------------------------------------------------
-# Sécurité — JSON injection : audit_log.details sérialisé avec json.dumps
+# Security — JSON injection: audit_log.details serialized with json.dumps
 # ---------------------------------------------------------------------------
 
 def test_ssh_ensure_scripts_audit_details_valid_json(sample_server):
-    """audit_log.details doit être du JSON valide même avec des caractères spéciaux."""
+    """audit_log.details must be valid JSON even with special characters."""
     import json
     hostile_server = dict(sample_server)
     hostile_server["hostname"] = 'server"}, "injected": "true'
@@ -460,7 +460,7 @@ def test_ssh_ensure_scripts_audit_details_valid_json(sample_server):
 
 
 # ---------------------------------------------------------------------------
-# SAM_LOCK_USER et SAM_UNLOCK_USER — vérifications de contenu
+# SAM_LOCK_USER and SAM_UNLOCK_USER — content checks
 # ---------------------------------------------------------------------------
 
 def test_ssh_sam_lock_user_is_bytes():
@@ -515,7 +515,7 @@ def test_ssh_unlock_user_on_server_calls_sam_unlock_user(sample_server):
 
 
 # ---------------------------------------------------------------------------
-# SAM_SESSIONS — vérifications de contenu et fonctions
+# SAM_SESSIONS — content checks and functions
 # ---------------------------------------------------------------------------
 
 def test_ssh_sam_sessions_is_bytes():

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -40,7 +40,7 @@ def auth_client(client):
 
 
 # ---------------------------------------------------------------------------
-# Authentification
+# Authentication
 # ---------------------------------------------------------------------------
 
 def test_web_no_auth_returns_401(client):
@@ -57,7 +57,7 @@ def test_web_invalid_admin_returns_401(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# GET /api/keys — retourne 200 + liste JSON
+# GET /api/keys — returns 200 + JSON list
 # ---------------------------------------------------------------------------
 
 def test_web_get_keys_returns_200_and_list(auth_client):
@@ -86,7 +86,7 @@ def test_web_get_keys_with_status_filter(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# GET /api/keys — champ owner présent dans la réponse
+# GET /api/keys — owner field present in response
 # ---------------------------------------------------------------------------
 
 def test_web_get_keys_includes_owner_field(auth_client):
@@ -131,7 +131,7 @@ def test_web_get_keys_sql_includes_revocation_and_server_fields(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/keys/validate/<fp> — 200 si authentifié, 401 sinon, scoped
+# POST /api/keys/validate/<fp> — 200 if authenticated, 401 otherwise, scoped
 # ---------------------------------------------------------------------------
 
 def test_web_validate_key_returns_200_if_authenticated(auth_client):
@@ -163,7 +163,7 @@ def test_web_validate_key_passes_none_when_fields_absent(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/keys/revoke/<fp> — fingerprint malformé rejeté avec 400
+# POST /api/keys/revoke/<fp> — malformed fingerprint rejected with 400
 # ---------------------------------------------------------------------------
 
 def test_web_revoke_key_rejects_invalid_fingerprint_format(auth_client):
@@ -178,7 +178,7 @@ def test_web_revoke_key_rejects_invalid_fingerprint_format(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/keys/revoke/<fp> — 200 si authentifie, 401 si non authentifie
+# POST /api/keys/revoke/<fp> — 200 if authenticated, 401 if not authenticated
 # ---------------------------------------------------------------------------
 
 def test_web_revoke_key_returns_200_if_authenticated(auth_client):
@@ -224,7 +224,7 @@ def test_web_revoke_key_returns_404_if_key_not_found(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/access/grant — 201 avec expires_at calculé
+# POST /api/access/grant — 201 with expires_at computed
 # ---------------------------------------------------------------------------
 
 def test_web_grant_access_returns_201_with_expires_at(auth_client):
@@ -262,7 +262,7 @@ def test_web_grant_access_returns_400_without_expiry(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# POST /api/keys/set-expiry — datetime-local format (sans secondes)
+# POST /api/keys/set-expiry — datetime-local format (without seconds)
 # ---------------------------------------------------------------------------
 
 def test_web_set_expiry_accepts_datetime_local_format(auth_client):
@@ -1121,7 +1121,7 @@ def test_web_deploy_key_returns_201(auth_client):
                 "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test",
                 "unix_user": "alice",
                 "hostname": "server-01",
-                "justification": "Accès maintenance",
+                "justification": "Maintenance access",
             },
         )
         assert resp.status_code == 201
@@ -1205,11 +1205,11 @@ def test_web_deploy_key_expires_at_invalid_format_returns_400(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# Sécurité — log injection : newlines sanitisées avant logging
+# Security — log injection: newlines sanitized before logging
 # ---------------------------------------------------------------------------
 
 def test_web_log_injection_newlines_sanitized_in_warning(auth_client):
-    """Une ValueError avec \\n ne doit pas produire de fausses lignes de log."""
+    """A ValueError containing \n must not produce fake log lines."""
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
          patch("web.logging") as mock_logging:
         mock_db.query_one.return_value = _admin_row()
@@ -1228,7 +1228,7 @@ def test_web_log_injection_newlines_sanitized_in_warning(auth_client):
 
 
 def test_web_log_injection_carriage_return_sanitized(auth_client):
-    """Une ValueError avec \\r ne doit pas produire de fausses lignes de log."""
+    """A ValueError containing \r must not produce fake log lines."""
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions, \
          patch("web.logging") as mock_logging:
         mock_db.query_one.return_value = _admin_row()
@@ -1246,7 +1246,7 @@ def test_web_log_injection_carriage_return_sanitized(auth_client):
 
 
 # ---------------------------------------------------------------------------
-# Sécurité — GET /api/admins ne doit pas exposer password_hash
+# Security — GET /api/admins must not expose password_hash
 # ---------------------------------------------------------------------------
 
 def test_web_list_admins_does_not_expose_password_hash(auth_client):

--- a/app/web.py
+++ b/app/web.py
@@ -260,7 +260,7 @@ def _ssh_error_code(msg: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Serveurs
+# Servers
 # ---------------------------------------------------------------------------
 
 @app.route("/api/servers", methods=["GET"])
@@ -515,7 +515,7 @@ def get_server_sessions_history(hostname):
 
 
 # ---------------------------------------------------------------------------
-# Cles SSH
+# SSH Keys
 # ---------------------------------------------------------------------------
 
 @app.route("/api/keys", methods=["GET"])
@@ -656,7 +656,7 @@ def bulk_revoke_keys():
 
 
 # ---------------------------------------------------------------------------
-# Acces temporaires
+# Temporary access
 # ---------------------------------------------------------------------------
 
 @app.route("/api/access", methods=["GET"])
@@ -874,7 +874,7 @@ def revoke_request(request_id):
     actions.revoke_request(request_id, g.admin_id)
     return jsonify({"status": "revoked"})
 # ---------------------------------------------------------------------------
-# Administrateurs
+# Administrators
 # ---------------------------------------------------------------------------
 
 @app.route("/api/admins", methods=["GET"])

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,312 +1,312 @@
 -- =============================================================================
--- ssh-access-manager — schéma PostgreSQL 18
--- Ordre de création respectant les dépendances FK :
---   servers → administrators → ssh_keys →
---   key_authorizations → access_requests → audit_log
+-- ssh-access-manager - PostgreSQL 18 schema
+-- Creation order respecting FK dependencies:
+--   servers -> administrators -> ssh_keys ->
+--   key_authorizations -> access_requests -> audit_log
 -- =============================================================================
 
 -- ---------------------------------------------------------------------------
 -- TABLE : servers
--- Inventaire déclaratif des serveurs SSH surveillés.
--- Alimenté depuis /data/config/servers.yml via servers.py.
+-- Declarative inventory of monitored SSH servers.
+-- Populated from /data/config/servers.yml by servers.py.
 -- ---------------------------------------------------------------------------
 CREATE TABLE servers (
-    -- Identifiant unique généré automatiquement
+    -- Auto-generated unique identifier
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- Nom d'hôte unique du serveur (correspond à servers.yml)
+    -- Unique server hostname (matches servers.yml)
     hostname    VARCHAR(255) NOT NULL UNIQUE,
-    -- Adresse IP au format INET (supporte IPv4 et IPv6)
+    -- IP address in INET format (supports IPv4 and IPv6)
     ip_address  INET NOT NULL,
-    -- Port SSH du serveur (défaut 22)
+    -- SSH port of the server (default 22)
     ssh_port    INTEGER NOT NULL DEFAULT 22,
-    -- Famille d'OS : rhel, debian, alpine, etc.
+    -- OS family: rhel, debian, alpine, etc.
     os_family   VARCHAR(50),
-    -- Version précise de l'OS (ex: "RHEL 9.3", "Debian 12")
+    -- Precise OS version (e.g., 'RHEL 9.3', 'Debian 12')
     os_version  VARCHAR(50),
-    -- Environnement du serveur — valeurs contrôlées
+    -- Server environment - controlled values
     environment VARCHAR(20) CHECK (environment IN (
                     'production',
                     'staging',
                     'lab'
                 )),
-    -- Serveur actif dans le périmètre de collecte
+    -- Server active in the collection scope
     is_active   BOOLEAN DEFAULT true,
-    -- Nombre maximum de sessions SSH simultanées autorisées (alerte si dépassé)
+    -- Maximum allowed concurrent SSH sessions (alert if exceeded)
     max_sessions INTEGER NOT NULL DEFAULT 2,
-    -- Date d'enregistrement dans le système
+    -- Timestamp when added to the system
     added_at    TIMESTAMPTZ DEFAULT now()
 );
 
-COMMENT ON TABLE servers IS 'Inventaire des serveurs SSH surveillés, alimenté depuis servers.yml';
-COMMENT ON COLUMN servers.id IS 'UUID généré automatiquement';
-COMMENT ON COLUMN servers.hostname IS 'Nom d''hôte unique, clé de réconciliation avec servers.yml';
-COMMENT ON COLUMN servers.ip_address IS 'Adresse IP (INET, supporte IPv4 et IPv6)';
-COMMENT ON COLUMN servers.ssh_port IS 'Port SSH du serveur (défaut 22)';
-COMMENT ON COLUMN servers.os_family IS 'Famille d''OS : rhel, debian, alpine...';
-COMMENT ON COLUMN servers.os_version IS 'Version précise de l''OS';
-COMMENT ON COLUMN servers.environment IS 'Environnement : production, staging ou lab';
-COMMENT ON COLUMN servers.is_active IS 'False = exclu du périmètre de collecte SSH';
-COMMENT ON COLUMN servers.max_sessions IS 'Seuil max de sessions SSH simultanées — alerte WARNING si dépassé (anti-spam 24h)';
-COMMENT ON COLUMN servers.added_at IS 'Horodatage d''enregistrement dans le système';
+COMMENT ON TABLE servers IS 'Inventory of monitored SSH servers, populated from servers.yml';
+COMMENT ON COLUMN servers.id IS 'Auto-generated UUID';
+COMMENT ON COLUMN servers.hostname IS 'Unique hostname, reconciliation key with servers.yml';
+COMMENT ON COLUMN servers.ip_address IS 'IP address (INET, supports IPv4 and IPv6)';
+COMMENT ON COLUMN servers.ssh_port IS 'SSH port of the server (default 22)';
+COMMENT ON COLUMN servers.os_family IS 'OS family: rhel, debian, alpine...';
+COMMENT ON COLUMN servers.os_version IS 'Precise OS version';
+COMMENT ON COLUMN servers.environment IS 'Environment: production, staging or lab';
+COMMENT ON COLUMN servers.is_active IS 'False = excluded from SSH collection scope';
+COMMENT ON COLUMN servers.max_sessions IS 'Max concurrent SSH sessions threshold - WARNING alert if exceeded (24h anti-spam)';
+COMMENT ON COLUMN servers.added_at IS 'Record timestamp in the system';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : administrators
--- Utilisateurs autorisés à gérer le système (valider, révoquer, approuver).
--- L'administrateur initial est inséré par bootstrap.sh depuis ENV.
+-- Users authorized to manage the system (validate, revoke, approve).
+-- The initial administrator is inserted by bootstrap.sh from ENV.
 -- ---------------------------------------------------------------------------
 CREATE TABLE administrators (
-    -- Identifiant unique généré automatiquement
+    -- Auto-generated unique identifier
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- Login unique de l'administrateur
+    -- Administrator unique login
     username    VARCHAR(100) NOT NULL UNIQUE,
-    -- Adresse email pour les notifications
+    -- Email address for notifications
     email       VARCHAR(255),
-    -- Rôle fonctionnel (extensible)
-    role          VARCHAR(50) DEFAULT 'sysadmin' CHECK (role IN ('sysadmin', 'operator', 'viewer')),
-    -- Hash du mot de passe (werkzeug generate_password_hash)
+    -- Functional role (extensible)
+    role        VARCHAR(50) DEFAULT 'sysadmin' CHECK (role IN ('sysadmin', 'operator', 'viewer')),
+    -- Password hash (werkzeug generate_password_hash)
     password_hash VARCHAR(255),
-    -- Compte actif ou désactivé (jamais supprimé pour préserver l'audit)
+    -- Account active or disabled (never deleted to preserve audit)
     is_active     BOOLEAN DEFAULT true,
-    -- Reçoit les emails d'alerte CRITICAL/WARNING
+    -- Receives CRITICAL/WARNING alert emails
     receive_alerts BOOLEAN DEFAULT true NOT NULL,
-    -- Date de création du compte
+    -- Account creation timestamp
     created_at    TIMESTAMPTZ DEFAULT now(),
     -- NULL = password never changed since account creation
     password_changed_at TIMESTAMPTZ
 );
 
-COMMENT ON TABLE administrators IS 'Utilisateurs autorisés à gérer les accès SSH';
-COMMENT ON COLUMN administrators.id IS 'UUID généré automatiquement';
-COMMENT ON COLUMN administrators.username IS 'Login unique de l''administrateur';
-COMMENT ON COLUMN administrators.email IS 'Email pour les alertes et notifications';
-COMMENT ON COLUMN administrators.role IS 'Rôle fonctionnel, défaut : sysadmin';
-COMMENT ON COLUMN administrators.password_hash IS 'Hash werkzeug (pbkdf2:sha256) du mot de passe';
-COMMENT ON COLUMN administrators.is_active IS 'False = compte désactivé (jamais supprimé)';
-COMMENT ON COLUMN administrators.receive_alerts IS 'True = reçoit les emails CRITICAL/WARNING';
-COMMENT ON COLUMN administrators.created_at IS 'Horodatage de création du compte';
+COMMENT ON TABLE administrators IS 'Users authorized to manage SSH access';
+COMMENT ON COLUMN administrators.id IS 'Auto-generated UUID';
+COMMENT ON COLUMN administrators.username IS 'Administrator unique login';
+COMMENT ON COLUMN administrators.email IS 'Email for alerts and notifications';
+COMMENT ON COLUMN administrators.role IS 'Functional role, default: sysadmin';
+COMMENT ON COLUMN administrators.password_hash IS 'Werkzeug hash (pbkdf2:sha256) of the password';
+COMMENT ON COLUMN administrators.is_active IS 'False = account disabled (never deleted)';
+COMMENT ON COLUMN administrators.receive_alerts IS 'True = receives CRITICAL/WARNING emails';
+COMMENT ON COLUMN administrators.created_at IS 'Account creation timestamp';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : ssh_keys
--- Clés SSH collectées sur les serveurs distants via sam-collect.
--- La colonne is_compliant est calculée automatiquement (GENERATED STORED).
+-- SSH keys collected from remote servers via sam-collect.
+-- The is_compliant column is computed automatically (GENERATED STORED).
 -- ---------------------------------------------------------------------------
 CREATE TABLE ssh_keys (
-    -- Identifiant unique généré automatiquement
+    -- Auto-generated unique identifier
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- Fingerprint SHA256 au format "SHA256:<base64>" — identifiant technique unique
+    -- SHA256 fingerprint in format 'SHA256:<base64>' - unique technical identifier
     fingerprint     VARCHAR(64) NOT NULL UNIQUE,
-    -- Type de clé — valeurs contrôlées par politique de sécurité
+    -- Key type - values controlled by security policy
     key_type        VARCHAR(30) NOT NULL CHECK (key_type IN (
                         'ssh-ed25519',
                         'ssh-rsa',
                         'ecdsa-sha2-nistp256'
                     )),
-    -- Taille en bits (pertinent pour RSA : doit être >= 4096 pour être conforme)
+    -- Size in bits (relevant for RSA: must be >= 4096 to be compliant)
     key_size_bits   SMALLINT,
-    -- Contenu complet de la clé publique (type + base64 + commentaire)
+    -- Full public key content (type + base64 + comment)
     public_key      TEXT NOT NULL,
-    -- Commentaire extrait de la clé publique (champ libre)
+    -- Comment field extracted from the public key (free text)
     comment         VARCHAR(255),
-    -- Propriétaire libre de la clé (nom complet ou identifiant quelconque, nullable)
+    -- Free-form owner of the key (full name or any identifier, nullable)
     owner           VARCHAR(255),
-    -- Conformité calculée : ED25519 toujours conforme, RSA conforme si >= 4096 bits
-    -- GENERATED ALWAYS AS STORED : jamais à écrire manuellement
+    -- Compliance computed: ED25519 always compliant, RSA compliant if >= 4096 bits
+    -- GENERATED ALWAYS AS STORED: never write this column manually
     is_compliant    BOOLEAN GENERATED ALWAYS AS (
                         key_type = 'ssh-ed25519'
                         OR (key_type = 'ssh-rsa' AND key_size_bits >= 4096)
                     ) STORED,
-    -- Première détection de la clé sur un serveur
+    -- First detection of the key on a server
     first_seen      TIMESTAMPTZ DEFAULT now(),
-    -- Dernière détection lors du dernier scan
+    -- Last detection during the latest scan
     last_seen       TIMESTAMPTZ DEFAULT now()
 );
 
-COMMENT ON TABLE ssh_keys IS 'Clés SSH collectées sur les serveurs via sam-collect';
-COMMENT ON COLUMN ssh_keys.id IS 'UUID généré automatiquement';
-COMMENT ON COLUMN ssh_keys.fingerprint IS 'SHA256:<base64> — calculé par compute_fingerprint() dans ssh.py';
-COMMENT ON COLUMN ssh_keys.key_type IS 'Type de clé : ssh-ed25519, ssh-rsa ou ecdsa-sha2-nistp256';
-COMMENT ON COLUMN ssh_keys.key_size_bits IS 'Taille en bits, NULL pour ED25519, obligatoire pour RSA';
-COMMENT ON COLUMN ssh_keys.public_key IS 'Clé publique complète au format authorized_keys';
-COMMENT ON COLUMN ssh_keys.comment IS 'Commentaire extrait de la clé (souvent user@host)';
-COMMENT ON COLUMN ssh_keys.owner IS 'Nom libre du propriétaire (peut être un non-admin), NULL si inconnu';
-COMMENT ON COLUMN ssh_keys.is_compliant IS 'GENERATED: ED25519=true, RSA>=4096=true, sinon false';
-COMMENT ON COLUMN ssh_keys.first_seen IS 'Premier horodatage de détection de la clé';
-COMMENT ON COLUMN ssh_keys.last_seen IS 'Dernier horodatage de détection lors d''un scan';
+COMMENT ON TABLE ssh_keys IS 'SSH keys collected from servers via sam-collect';
+COMMENT ON COLUMN ssh_keys.id IS 'Auto-generated UUID';
+COMMENT ON COLUMN ssh_keys.fingerprint IS 'SHA256:<base64> - computed by compute_fingerprint() in ssh.py';
+COMMENT ON COLUMN ssh_keys.key_type IS 'Key type: ssh-ed25519, ssh-rsa or ecdsa-sha2-nistp256';
+COMMENT ON COLUMN ssh_keys.key_size_bits IS 'Size in bits, NULL for ED25519, required for RSA';
+COMMENT ON COLUMN ssh_keys.public_key IS 'Full public key in authorized_keys format';
+COMMENT ON COLUMN ssh_keys.comment IS 'Comment extracted from the key (often user@host)';
+COMMENT ON COLUMN ssh_keys.owner IS 'Free-form owner name (may be non-admin), NULL if unknown';
+COMMENT ON COLUMN ssh_keys.is_compliant IS 'GENERATED: ED25519=true, RSA>=4096=true, otherwise false';
+COMMENT ON COLUMN ssh_keys.first_seen IS 'First timestamp the key was detected';
+COMMENT ON COLUMN ssh_keys.last_seen IS 'Last timestamp the key was detected during a scan';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : key_authorizations
--- Association clé SSH ↔ serveur ↔ utilisateur Unix avec statut du cycle de vie.
--- Clé primaire composite (key_id, server_id, unix_user) : la même clé peut
--- être déployée pour plusieurs utilisateurs Unix sur le même serveur.
+-- Association between SSH key -> server -> unix user with lifecycle status.
+-- Composite primary key (key_id, server_id, unix_user): the same key can
+-- be deployed for multiple unix users on the same server.
 -- ---------------------------------------------------------------------------
 CREATE TABLE key_authorizations (
-    -- Référence vers la clé SSH concernée
+    -- Reference to the SSH key
     key_id                   UUID NOT NULL REFERENCES ssh_keys(id),
-    -- Référence vers le serveur concerné
+    -- Reference to the related server
     server_id                UUID NOT NULL REFERENCES servers(id),
-    -- Utilisateur Unix propriétaire de la clé sur ce serveur
+    -- Unix user owning the key on that server
     unix_user                VARCHAR(100) NOT NULL DEFAULT '',
-    -- Administrateur ayant validé l'autorisation (NULL si détection automatique)
+    -- Administrator who authorized it (NULL if auto-detected)
     authorized_by            UUID REFERENCES administrators(id) ON DELETE SET NULL,
-    -- Date de première autorisation ou détection
+    -- Date of first authorization or detection
     authorized_at            TIMESTAMPTZ DEFAULT now(),
-    -- Date d'expiration programmée (NULL = pas d'expiration)
+    -- Scheduled expiration date (NULL = no expiration)
     expires_at               TIMESTAMPTZ,
-    -- Statut du cycle de vie de l'autorisation
+    -- Lifecycle status of the authorization
     status                   VARCHAR(20) NOT NULL DEFAULT 'PENDING_REVIEW'
                                  CHECK (status IN (
-                                     'ACTIVE',           -- clé validée et active
-                                     'REVOKED',          -- révoquée manuellement ou hors système
-                                     'PENDING_REVIEW',   -- détectée, en attente de validation
-                                     'UNAUTHORIZED',     -- non autorisée explicitement
-                                     'EXPIRED'           -- expiration programmée atteinte
+                                     'ACTIVE',
+                                     'REVOKED',
+                                     'PENDING_REVIEW',
+                                     'UNAUTHORIZED',
+                                     'EXPIRED'
                                  )),
-    -- Date effective de révocation
+    -- Effective revocation date
     revoked_at               TIMESTAMPTZ,
-    -- Administrateur ayant révoqué (NULL si révocation automatique hors système)
+    -- Administrator who revoked (NULL if automatic/revoked outside system)
     revoked_by               UUID REFERENCES administrators(id) ON DELETE SET NULL,
-    -- True si révocation déclenchée automatiquement (expiration ou hors système)
+    -- True if revocation was triggered automatically (expiration or external)
     revoked_automatically    BOOLEAN DEFAULT false,
-    -- Justification de révocation ou d'anomalie
+    -- Justification for revocation or anomaly description
     revocation_justification TEXT,
-    -- Clé primaire composite : une clé par utilisateur Unix par serveur
+    -- Composite primary key: one key per unix user per server
     PRIMARY KEY (key_id, server_id, unix_user)
 );
 
-COMMENT ON TABLE key_authorizations IS 'Association clé SSH↔serveur↔unix_user avec statut du cycle de vie';
-COMMENT ON COLUMN key_authorizations.key_id IS 'FK vers ssh_keys — partie de la PK composite';
-COMMENT ON COLUMN key_authorizations.server_id IS 'FK vers servers — partie de la PK composite';
-COMMENT ON COLUMN key_authorizations.unix_user IS 'Utilisateur Unix sur le serveur — partie de la PK composite';
-COMMENT ON COLUMN key_authorizations.authorized_by IS 'FK vers administrators, NULL si détection automatique';
-COMMENT ON COLUMN key_authorizations.authorized_at IS 'Date de première autorisation ou détection';
-COMMENT ON COLUMN key_authorizations.expires_at IS 'Expiration programmée, NULL si permanente';
+COMMENT ON TABLE key_authorizations IS 'Association key_authorizations: SSH key->server->unix_user with lifecycle status';
+COMMENT ON COLUMN key_authorizations.key_id IS 'FK to ssh_keys - part of composite PK';
+COMMENT ON COLUMN key_authorizations.server_id IS 'FK to servers - part of composite PK';
+COMMENT ON COLUMN key_authorizations.unix_user IS 'Unix user on the server - part of composite PK';
+COMMENT ON COLUMN key_authorizations.authorized_by IS 'FK to administrators, NULL if auto-detected';
+COMMENT ON COLUMN key_authorizations.authorized_at IS 'Timestamp of first authorization or detection';
+COMMENT ON COLUMN key_authorizations.expires_at IS 'Scheduled expiration, NULL if permanent';
 COMMENT ON COLUMN key_authorizations.status IS 'ACTIVE|REVOKED|PENDING_REVIEW|UNAUTHORIZED|EXPIRED';
-COMMENT ON COLUMN key_authorizations.revoked_at IS 'Horodatage effectif de révocation';
-COMMENT ON COLUMN key_authorizations.revoked_by IS 'FK administrateur révocateur, NULL si automatique';
-COMMENT ON COLUMN key_authorizations.revoked_automatically IS 'True = révocation par expiration ou anomalie hors système';
-COMMENT ON COLUMN key_authorizations.revocation_justification IS 'Motif de révocation ou description de l''anomalie';
+COMMENT ON COLUMN key_authorizations.revoked_at IS 'Actual revocation timestamp';
+COMMENT ON COLUMN key_authorizations.revoked_by IS 'FK to administrator who revoked, NULL if automatic';
+COMMENT ON COLUMN key_authorizations.revoked_automatically IS 'True = revoked by expiration or external anomaly';
+COMMENT ON COLUMN key_authorizations.revocation_justification IS 'Reason for revocation or anomaly description';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : access_requests
--- Demandes d'accès temporaire — workflow de validation.
--- Une demande approuvée crée ou met à jour une key_authorization.
+-- Temporary access requests - approval workflow.
+-- An approved request creates or updates a key_authorization.
 -- ---------------------------------------------------------------------------
 CREATE TABLE access_requests (
-    -- Identifiant unique généré automatiquement
+    -- Auto-generated unique identifier
     id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- Administrateur demandeur
+    -- Requesting administrator
     requested_by         UUID REFERENCES administrators(id) ON DELETE SET NULL,
-    -- Administrateur approbateur (NULL tant que non traité)
+    -- Approving administrator (NULL while pending)
     approved_by          UUID REFERENCES administrators(id) ON DELETE SET NULL,
-    -- Clé SSH pour laquelle l'accès est demandé
+    -- SSH key for which access is requested
     key_id               UUID REFERENCES ssh_keys(id),
-    -- Serveur cible de la demande
+    -- Target server of the request
     server_id            UUID REFERENCES servers(id),
-    -- Durée demandée en heures (alternatif à expires_at_requested)
+    -- Requested duration in hours (alternative to expires_at_requested)
     duration_hours       SMALLINT,
-    -- Date d'expiration explicitement demandée (alternatif à duration_hours)
+    -- Explicitly requested expiration date (alternative to duration_hours)
     expires_at_requested TIMESTAMPTZ,
-    -- Justification métier obligatoire
+    -- Business justification (required)
     justification        TEXT NOT NULL,
-    -- Statut de la demande dans le workflow
+    -- Request status in the workflow
     status               VARCHAR(20) NOT NULL DEFAULT 'PENDING'
                              CHECK (status IN (
-                                 'PENDING',   -- en attente de traitement
-                                 'APPROVED',  -- approuvée par un administrateur
-                                 'REJECTED',  -- rejetée par un administrateur
-                                 'EXPIRED'    -- expirée sans traitement
+                                 'PENDING',
+                                 'APPROVED',
+                                 'REJECTED',
+                                 'EXPIRED'
                              )),
-    -- Date de soumission de la demande
+    -- Submission timestamp
     requested_at         TIMESTAMPTZ DEFAULT now(),
-    -- Date d'approbation ou de rejet
+    -- Decision timestamp (approval or rejection)
     approved_at          TIMESTAMPTZ,
-    -- Date d'expiration de l'accès accordé (calculée à l'approbation)
+    -- Expiration date of the granted access (computed at approval)
     expires_at           TIMESTAMPTZ
 );
 
-COMMENT ON TABLE access_requests IS 'Demandes d''accès temporaire avec workflow de validation';
-COMMENT ON COLUMN access_requests.id IS 'UUID généré automatiquement';
-COMMENT ON COLUMN access_requests.requested_by IS 'FK vers administrators — demandeur';
-COMMENT ON COLUMN access_requests.approved_by IS 'FK vers administrators — approbateur, NULL si non traité';
-COMMENT ON COLUMN access_requests.key_id IS 'FK vers ssh_keys — clé concernée par la demande';
-COMMENT ON COLUMN access_requests.server_id IS 'FK vers servers — serveur cible';
-COMMENT ON COLUMN access_requests.duration_hours IS 'Durée en heures, alternatif à expires_at_requested';
-COMMENT ON COLUMN access_requests.expires_at_requested IS 'Date d''expiration demandée, alternatif à duration_hours';
-COMMENT ON COLUMN access_requests.justification IS 'Motif métier obligatoire de la demande';
+COMMENT ON TABLE access_requests IS 'Temporary access requests with approval workflow';
+COMMENT ON COLUMN access_requests.id IS 'Auto-generated UUID';
+COMMENT ON COLUMN access_requests.requested_by IS 'FK to administrators - requester';
+COMMENT ON COLUMN access_requests.approved_by IS 'FK to administrators - approver, NULL if pending';
+COMMENT ON COLUMN access_requests.key_id IS 'FK to ssh_keys - key concerned by the request';
+COMMENT ON COLUMN access_requests.server_id IS 'FK to servers - target server';
+COMMENT ON COLUMN access_requests.duration_hours IS 'Duration in hours, alternative to expires_at_requested';
+COMMENT ON COLUMN access_requests.expires_at_requested IS 'Requested expiration date, alternative to duration_hours';
+COMMENT ON COLUMN access_requests.justification IS 'Required business justification for the request';
 COMMENT ON COLUMN access_requests.status IS 'PENDING|APPROVED|REJECTED|EXPIRED';
-COMMENT ON COLUMN access_requests.requested_at IS 'Horodatage de soumission';
-COMMENT ON COLUMN access_requests.approved_at IS 'Horodatage de décision (approbation ou rejet)';
-COMMENT ON COLUMN access_requests.expires_at IS 'Expiration de l''accès accordé, calculée à l''approbation';
+COMMENT ON COLUMN access_requests.requested_at IS 'Submission timestamp';
+COMMENT ON COLUMN access_requests.approved_at IS 'Decision timestamp (approval or rejection)';
+COMMENT ON COLUMN access_requests.expires_at IS 'Expiration of granted access, computed at approval';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : audit_log
--- Journal immuable de toutes les actions sensibles du système.
--- Aucune ligne n'est jamais modifiée ou supprimée.
+-- Immutable journal of all sensitive system actions.
+-- No row is ever updated or deleted.
 -- ---------------------------------------------------------------------------
 CREATE TABLE audit_log (
-    -- Identifiant unique généré automatiquement
+    -- Auto-generated unique identifier
     id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- Type d'action — valeurs contrôlées et exhaustives
+    -- Action type - controlled and exhaustive values
     action        VARCHAR(50) NOT NULL CHECK (action IN (
-                      'KEY_ADDED',          -- clé validée (PENDING_REVIEW → ACTIVE)
-                      'KEY_REVOKED',        -- révocation manuelle via le système
-                      'KEY_EXPIRED',        -- expiration programmée atteinte
-                      'EXPIRY_WARNING',     -- alerte d'expiration imminente (anti-spam 24h)
-                      'REQUEST_APPROVED',   -- demande d'accès approuvée
-                      'REQUEST_REJECTED',   -- demande d'accès rejetée
-                      'ANOMALY_DETECTED',   -- clé inconnue ou révocation hors système
-                      'SCAN_COMPLETED',     -- scan SSH terminé avec succès
-                      'SCAN_FAILED',        -- scan SSH échoué (serveur injoignable)
-                      'SCRIPT_DEPLOYED',    -- sam-collect ou sam-revoke redéployé
-                      'SERVER_ADDED',       -- nouveau serveur enregistré
-                      'SERVER_DISABLED',    -- serveur désactivé du périmètre
-                      'SERVER_UPDATED',     -- serveur modifié (IP, env, OS)
-                      'ADMIN_ADDED',        -- nouvel administrateur créé
-                      'ADMIN_DISABLED',     -- administrateur désactivé
-                      'ADMIN_ENABLED',      -- administrateur réactivé
-                      'ADMIN_DELETED',      -- administrateur supprimé définitivement
-                      'ADMIN_UPDATED',      -- administrateur modifié (email, rôle)
-                      'USER_LOCKED',        -- compte Unix verrouillé (SSH bloqué)
-                      'USER_UNLOCKED',      -- compte Unix déverrouillé
-                      'LOGIN_FAILED',       -- tentative de connexion échouée (mauvais mot de passe)
-                      'LOGIN_BANNED',       -- IP bannie après trop de tentatives échouées
-                      'PASSWORD_RESET',     -- réinitialisation de mot de passe via CLI
-                      'SERVER_PROVISIONED',  -- provisionnement automatique via SSH password
-                      'SESSION_LIMIT_EXCEEDED' -- nombre de sessions actives > max_sessions (anti-spam 24h)
+                      'KEY_ADDED',
+                      'KEY_REVOKED',
+                      'KEY_EXPIRED',
+                      'EXPIRY_WARNING',
+                      'REQUEST_APPROVED',
+                      'REQUEST_REJECTED',
+                      'ANOMALY_DETECTED',
+                      'SCAN_COMPLETED',
+                      'SCAN_FAILED',
+                      'SCRIPT_DEPLOYED',
+                      'SERVER_ADDED',
+                      'SERVER_DISABLED',
+                      'SERVER_UPDATED',
+                      'ADMIN_ADDED',
+                      'ADMIN_DISABLED',
+                      'ADMIN_ENABLED',
+                      'ADMIN_DELETED',
+                      'ADMIN_UPDATED',
+                      'USER_LOCKED',
+                      'USER_UNLOCKED',
+                      'LOGIN_FAILED',
+                      'LOGIN_BANNED',
+                      'PASSWORD_RESET',
+                      'SERVER_PROVISIONED',
+                      'SESSION_LIMIT_EXCEEDED'
                   )),
-    -- Administrateur ayant déclenché l'action (NULL si automatique)
+    -- Administrator who triggered the action (NULL if automatic)
     performed_by  UUID REFERENCES administrators(id) ON DELETE SET NULL,
-    -- Clé SSH concernée par l'action (NULL si non applicable)
+    -- SSH key targeted by the action (NULL if not applicable)
     target_key    UUID REFERENCES ssh_keys(id),
-    -- Serveur concerné par l'action (NULL si non applicable)
+    -- Server targeted by the action (NULL if not applicable)
     target_server UUID REFERENCES servers(id),
-    -- Horodatage de l'action
+    -- Timestamp of the action
     performed_at  TIMESTAMPTZ DEFAULT now(),
-    -- Données contextuelles libres (fingerprint, hostname, raison, etc.)
+    -- Free-form contextual data (fingerprint, hostname, reason, etc.)
     details       JSONB
 );
 
-COMMENT ON TABLE audit_log IS 'Journal immuable de toutes les actions — jamais modifié ni supprimé';
-COMMENT ON COLUMN audit_log.id IS 'UUID généré automatiquement';
-COMMENT ON COLUMN audit_log.action IS 'Type d''action parmi 18 valeurs contrôlées';
-COMMENT ON COLUMN audit_log.performed_by IS 'FK administrateur, NULL si action automatique (cron, expiration)';
-COMMENT ON COLUMN audit_log.target_key IS 'FK ssh_keys, NULL si action non liée à une clé';
-COMMENT ON COLUMN audit_log.target_server IS 'FK servers, NULL si action non liée à un serveur';
-COMMENT ON COLUMN audit_log.performed_at IS 'Horodatage précis de l''action (TIMESTAMPTZ)';
-COMMENT ON COLUMN audit_log.details IS 'Contexte JSON libre : fingerprint, hostname, raison, etc.';
+COMMENT ON TABLE audit_log IS 'Immutable journal of all actions - never modified or deleted';
+COMMENT ON COLUMN audit_log.id IS 'Auto-generated UUID';
+COMMENT ON COLUMN audit_log.action IS 'Action type among controlled values';
+COMMENT ON COLUMN audit_log.performed_by IS 'FK to administrator, NULL if automatic (cron, expiry)';
+COMMENT ON COLUMN audit_log.target_key IS 'FK to ssh_keys, NULL if action not related to a key';
+COMMENT ON COLUMN audit_log.target_server IS 'FK to servers, NULL if action not related to a server';
+COMMENT ON COLUMN audit_log.performed_at IS 'Precise timestamp of the action (TIMESTAMPTZ)';
+COMMENT ON COLUMN audit_log.details IS 'Free JSON context: fingerprint, hostname, reason, etc.';
 
 -- ---------------------------------------------------------------------------
 -- TABLE : settings
--- Configuration dynamique modifiable via l'API sans redémarrer le container.
+-- Dynamic configuration editable via the API without restarting the container.
 -- ---------------------------------------------------------------------------
 CREATE TABLE settings (
     key   VARCHAR(100) PRIMARY KEY,
     value TEXT NOT NULL
 );
 
-COMMENT ON TABLE settings IS 'Configuration dynamique du système — clé/valeur';
-COMMENT ON COLUMN settings.key IS 'Clé de configuration (ex: scan_interval_hours)';
-COMMENT ON COLUMN settings.value IS 'Valeur texte';
+COMMENT ON TABLE settings IS 'Dynamic system configuration - key/value';
+COMMENT ON COLUMN settings.key IS 'Configuration key (e.g., scan_interval_hours)';
+COMMENT ON COLUMN settings.value IS 'Text value';
 
 INSERT INTO settings (key, value) VALUES ('scan_interval_hours', '4');
 INSERT INTO settings (key, value) VALUES ('expire_warn_days', '7');
@@ -317,45 +317,46 @@ INSERT INTO settings (key, value) VALUES ('audit_retention_days', '365');
 
 -- =============================================================================
 -- INDEX
--- Optimisent les requêtes fréquentes : filtres sur statut, expiration,
--- audit récent, et recherche par fingerprint.
+-- Optimize frequent queries: status filters, expiration, recent audit,
+-- and fingerprint lookup.
 -- =============================================================================
 
--- Filtrage par statut dans key_authorizations (ACTIVE, PENDING_REVIEW, etc.)
+-- Filter by status in key_authorizations (ACTIVE, PENDING_REVIEW, etc.)
 CREATE INDEX idx_key_auth_status
     ON key_authorizations(status);
 
--- Clés avec expiration définie — index partiel pour exclure les NULL
+-- Keys with expiration defined - partial index to exclude NULL
 CREATE INDEX idx_key_auth_expires
     ON key_authorizations(expires_at)
     WHERE expires_at IS NOT NULL;
 
--- Audit log trié par date décroissante (vue Audit.vue, rapports)
+-- Audit log sorted by descending date (Audit.vue view, reports)
 CREATE INDEX idx_audit_log_performed_at
     ON audit_log(performed_at DESC);
 
--- Filtrage combiné action + date (requêtes anti-spam EXPIRY_WARNING)
+-- Combined filter action + date (anti-spam EXPIRY_WARNING queries)
 CREATE INDEX idx_audit_log_action
     ON audit_log(action, performed_at DESC);
 
--- Filtrage des clés conformes / non conformes (rapport sécurité)
+-- Filter compliant / non-compliant keys (security report)
 CREATE INDEX idx_ssh_keys_compliant
     ON ssh_keys(is_compliant);
 
--- Recherche par fingerprint (opération la plus fréquente sur ssh_keys)
+-- Lookup by fingerprint (most frequent operation on ssh_keys)
 CREATE INDEX idx_ssh_keys_fingerprint
     ON ssh_keys(fingerprint);
 
--- Une IP ne peut appartenir qu'à un seul serveur (désactivé = temporaire, pas libéré)
+-- An IP can belong to only one server (disabled = temporary, not freed)
 CREATE UNIQUE INDEX servers_ip_unique
     ON servers (ip_address);
 
 -- ---------------------------------------------------------------------------
 -- TABLE : ssh_sessions
--- Sessions SSH collectées sur les serveurs lors du scan ou à la demande.
+-- SSH sessions collected from servers during scans or on demand.
 -- Upsert via ON CONFLICT (server_id, unix_user, tty, login_at).
 -- ---------------------------------------------------------------------------
 CREATE TABLE ssh_sessions (
+    -- Auto-generated unique identifier
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     server_id    UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
     unix_user    VARCHAR(100) NOT NULL,
@@ -368,7 +369,7 @@ CREATE TABLE ssh_sessions (
     UNIQUE (server_id, unix_user, tty, login_at)
 );
 
-COMMENT ON TABLE ssh_sessions IS 'Sessions SSH collectées via sam-sessions lors des scans';
+COMMENT ON TABLE ssh_sessions IS 'SSH sessions collected via sam-sessions during scans';
 
 CREATE INDEX idx_sessions_server ON ssh_sessions(server_id, is_active, login_at DESC);
 CREATE INDEX idx_sessions_collected ON ssh_sessions(collected_at DESC);

--- a/ui/tests/Admins.spec.js
+++ b/ui/tests/Admins.spec.js
@@ -28,7 +28,7 @@ function mk(admins, meUsername = 'admin', meRole = 'sysadmin') {
 }
 
 describe('Admins', () => {
-  it('affiche le bouton Disable pour un admin actif autre que soi', async () => {
+  it('shows Disable button for an active admin other than self', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -36,7 +36,7 @@ describe('Admins', () => {
     expect(aliceRow.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('masque le bouton Disable pour le compte courant', async () => {
+  it('hides Disable button for the current account', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -44,7 +44,7 @@ describe('Admins', () => {
     expect(adminRow.find('.btn-danger').exists()).toBe(false)
   })
 
-  it('affiche les boutons Enable et Delete pour un admin désactivé', async () => {
+  it('shows Enable and Delete buttons for a disabled admin', async () => {
     const w = mk([DISABLED_ADMIN])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -53,7 +53,7 @@ describe('Admins', () => {
     expect(bobRow.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('ouvre la modal Enable au clic sur Enable', async () => {
+  it('opens Enable modal when clicking Enable', async () => {
     const w = mk([DISABLED_ADMIN])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -62,7 +62,7 @@ describe('Admins', () => {
     expect(w.find('.modal').exists()).toBe(true)
   })
 
-  it('ouvre la modal Delete au clic sur Delete', async () => {
+  it('opens Delete modal when clicking Delete', async () => {
     const w = mk([DISABLED_ADMIN])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -71,7 +71,7 @@ describe('Admins', () => {
     expect(w.find('.modal').exists()).toBe(true)
   })
 
-  it('appelle PUT /enable à la confirmation Enable', async () => {
+  it('calls PUT /enable on Enable confirmation', async () => {
     const fetchMock = mkFetch([DISABLED_ADMIN])
     global.fetch = fetchMock
     const w = mount(Admins, { global: { plugins: [i18n] } })
@@ -86,7 +86,7 @@ describe('Admins', () => {
     expect(calls).toContain('/api/admins/bob/enable|PUT')
   })
 
-  it('appelle DELETE à la confirmation Delete', async () => {
+  it('calls DELETE on Delete confirmation', async () => {
     const fetchMock = mkFetch([DISABLED_ADMIN])
     global.fetch = fetchMock
     const w = mount(Admins, { global: { plugins: [i18n] } })
@@ -101,7 +101,7 @@ describe('Admins', () => {
     expect(calls).toContain('/api/admins/bob|DELETE')
   })
 
-  it('ferme la modal Enable au clic sur annuler', async () => {
+  it('closes Enable modal when clicking cancel', async () => {
     const w = mk([DISABLED_ADMIN])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -114,7 +114,7 @@ describe('Admins', () => {
     expect(w.find('.modal').exists()).toBe(false)
   })
 
-  it('affiche le bouton Edit pour un admin actif', async () => {
+  it('shows Edit button for an active admin', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -123,7 +123,7 @@ describe('Admins', () => {
     expect(editBtn).toBeTruthy()
   })
 
-  it('ouvre la modal Edit au clic sur Edit', async () => {
+  it('opens Edit modal when clicking Edit', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -134,7 +134,7 @@ describe('Admins', () => {
     expect(w.find('.modal h3').text()).toContain('Edit administrator')
   })
 
-  it('le champ role est désactivé si admin édité est le courant', async () => {
+  it('role field is disabled if the edited admin is the current one', async () => {
     const w = mk([ACTIVE_ADMIN])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -145,7 +145,7 @@ describe('Admins', () => {
     expect(roleInput.element.disabled).toBe(true)
   })
 
-  it('le champ role est activé si admin édité n\'est pas le courant', async () => {
+  it('role field is enabled if the edited admin is not the current one', async () => {
     const w = mk([ACTIVE_ADMIN, OTHER_ACTIVE])
     await flushPromises()
     const rows = w.findAll('tr')
@@ -156,7 +156,7 @@ describe('Admins', () => {
     expect(roleInput.element.disabled).toBe(false)
   })
 
-  it('appelle PUT /api/admins/<username> à la confirmation Edit', async () => {
+  it('calls PUT /api/admins/<username> on Edit confirmation', async () => {
     const fetchMock = mkFetch([OTHER_ACTIVE], 'admin', 'sysadmin')
     global.fetch = fetchMock
     const w = mount(Admins, { global: { plugins: [i18n] } })

--- a/ui/tests/Anomalies.spec.js
+++ b/ui/tests/Anomalies.spec.js
@@ -60,37 +60,37 @@ describe('Anomalies', () => {
     vi.clearAllMocks()
   })
 
-  it('affiche une ligne dans la section pending', async () => {
+  it('shows a row in pending section', async () => {
     const w = await mountView([makePending()])
     expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').exists()).toBe(true)
   })
 
-  it('affiche une ligne dans la section revoked hors système', async () => {
+  it('shows a row in revoked out-of-system section', async () => {
     const w = await mountView([makeRevoked()])
     expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').exists()).toBe(true)
   })
 
-  it('affiche le message vide pending quand aucune clé PENDING_REVIEW', async () => {
+  it('shows pending empty message when no PENDING_REVIEW keys', async () => {
     const w = await mountView([])
     expect(w.find('[data-testid="pending-empty"]').exists()).toBe(true)
   })
 
-  it('affiche le message vide revoked quand aucune révocation hors système', async () => {
+  it('shows revoked empty message when no out-of-system revocations', async () => {
     const w = await mountView([])
     expect(w.find('[data-testid="revoked-empty"]').exists()).toBe(true)
   })
 
-  it('affiche la barre de filtres quand il y a des clés', async () => {
+  it('shows filters bar when keys present', async () => {
     const w = await mountView([makePending()])
     expect(w.find('[data-testid="anomalies-filters"]').exists()).toBe(true)
   })
 
-  it("n'affiche pas la barre de filtres quand la liste est vide", async () => {
+  it("does not show filters bar when list is empty", async () => {
     const w = await mountView([])
     expect(w.find('[data-testid="anomalies-filters"]').exists()).toBe(false)
   })
 
-  it('filtre la section pending par fingerprint', async () => {
+  it('filters pending section by fingerprint', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-a' }),
       makePending({ fingerprint: 'SHA256:zzzz', server_hostname: 'srv-b' }),
@@ -101,7 +101,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:zzzz"]').exists()).toBe(false)
   })
 
-  it('filtre la section pending par serveur', async () => {
+  it('filters pending section by server', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-prod' }),
       makePending({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-staging' }),
@@ -112,7 +112,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
-  it('filtre la section pending par unix_user', async () => {
+  it('filters pending section by unix_user', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', unix_user: 'alice' }),
       makePending({ fingerprint: 'SHA256:bbbb', unix_user: 'bob' }),
@@ -123,7 +123,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
-  it('filtre la section revoked par fingerprint', async () => {
+  it('filters revoked section by fingerprint', async () => {
     const keys = [
       makeRevoked({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-a' }),
       makeRevoked({ fingerprint: 'SHA256:cccc', server_hostname: 'srv-b' }),
@@ -134,7 +134,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="revoked-row-SHA256:cccc"]').exists()).toBe(false)
   })
 
-  it('filtre par dropdown type', async () => {
+  it('filters by type dropdown', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', key_type: 'ssh-ed25519' }),
       makePending({ fingerprint: 'SHA256:bbbb', key_type: 'ssh-rsa' }),
@@ -145,7 +145,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
-  it('filtre par dropdown serveur', async () => {
+  it('filters by server dropdown', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', server_hostname: 'srv-prod' }),
       makePending({ fingerprint: 'SHA256:bbbb', server_hostname: 'srv-staging' }),
@@ -156,7 +156,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
-  it('filtre par dropdown compliant=yes', async () => {
+  it('filters by compliant=yes dropdown', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', is_compliant: true }),
       makePending({ fingerprint: 'SHA256:bbbb', is_compliant: false }),
@@ -167,7 +167,7 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(false)
   })
 
-  it('filtre par dropdown compliant=no', async () => {
+  it('filters by compliant=no dropdown', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa', is_compliant: true }),
       makePending({ fingerprint: 'SHA256:bbbb', is_compliant: false }),
@@ -178,19 +178,19 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(true)
   })
 
-  it('affiche no_results dans pending quand filtre masque tout', async () => {
+  it('shows no_results in pending when filter hides everything', async () => {
     const w = await mountView([makePending()])
     await w.find('[data-testid="anomalies-filter-text"]').setValue('zzz_inexistant')
     expect(w.find('[data-testid="pending-no-results"]').exists()).toBe(true)
   })
 
-  it('affiche no_results dans revoked quand filtre masque tout', async () => {
+  it('shows no_results in revoked when filter hides everything', async () => {
     const w = await mountView([makeRevoked()])
     await w.find('[data-testid="anomalies-filter-text"]').setValue('zzz_inexistant')
     expect(w.find('[data-testid="revoked-no-results"]').exists()).toBe(true)
   })
 
-  it('le badge de compteur affiche le total réel (pas le filtré)', async () => {
+  it('count badge shows real total (not filtered)', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa' }),
       makePending({ fingerprint: 'SHA256:bbbb' }),
@@ -200,7 +200,7 @@ describe('Anomalies', () => {
     expect(w.find('.count-badge').text()).toBe('2')
   })
 
-  it('vider le filtre réaffiche toutes les clés', async () => {
+  it('clearing filter shows all keys again', async () => {
     const keys = [
       makePending({ fingerprint: 'SHA256:aaaa' }),
       makePending({ fingerprint: 'SHA256:bbbb' }),
@@ -213,12 +213,12 @@ describe('Anomalies', () => {
     expect(w.find('[data-testid="pending-row-SHA256:bbbb"]').exists()).toBe(true)
   })
 
-  it('affiche unix_user dans la section pending', async () => {
+  it('shows unix_user in pending section', async () => {
     const w = await mountView([makePending({ unix_user: 'charlie' })])
     expect(w.find('[data-testid="pending-row-SHA256:aaaa"]').text()).toContain('charlie')
   })
 
-  it('affiche unix_user dans la section revoked', async () => {
+  it('shows unix_user in revoked section', async () => {
     const w = await mountView([makeRevoked({ unix_user: 'diana' })])
     expect(w.find('[data-testid="revoked-row-SHA256:bbbb"]').text()).toContain('diana')
   })

--- a/ui/tests/DeployKeyForm.spec.js
+++ b/ui/tests/DeployKeyForm.spec.js
@@ -28,7 +28,7 @@ afterEach(() => {
 })
 
 describe('DeployKeyForm', () => {
-  it('affiche tous les champs requis', async () => {
+  it('renders all required fields', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(w.find('[data-testid="input-unix-user"]').exists()).toBe(true)
@@ -37,7 +37,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="input-justification"]').exists()).toBe(true)
   })
 
-  it('peuple le dropdown serveur depuis l\'API', async () => {
+  it('populates server dropdown from API', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     const options = w.findAll('[data-testid="select-server"] option')
@@ -46,7 +46,7 @@ describe('DeployKeyForm', () => {
     expect(options[2].text()).toBe('staging-01')
   })
 
-  it('filtre les serveurs inactifs du dropdown', async () => {
+  it('filters out inactive servers from dropdown', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     const serverValues = w
@@ -57,20 +57,20 @@ describe('DeployKeyForm', () => {
     expect(serverValues).not.toContain('disabled-01')
   })
 
-  it('le bouton soumettre est désactivé par défaut', async () => {
+  it('submit button is disabled by default', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(w.find('[data-testid="submit-btn"]').attributes('disabled')).toBeDefined()
   })
 
-  it('démarre en mode heures', async () => {
+  it('starts in hours mode', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
     expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
   })
 
-  it('passe en mode date quand on sélectionne date précise', async () => {
+  it('switches to date mode when date selected', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     await w.find('[data-testid="mode-date"]').setChecked(true)
@@ -78,7 +78,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="input-hours"]').exists()).toBe(false)
   })
 
-  it('en mode illimité aucun champ de durée n\'est affiché', async () => {
+  it('in unlimited mode no duration fields are shown', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     await w.find('[data-testid="mode-unlimited"]').setChecked(true)
@@ -86,7 +86,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
   })
 
-  it('le bouton soumettre est actif avec tous les champs valides (mode heures)', async () => {
+  it('submit button enabled when fields valid (hours mode)', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
     await w.find('[data-testid="input-unix-user"]').setValue('alice')
@@ -97,7 +97,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="submit-btn"]').attributes('disabled')).toBeUndefined()
   })
 
-  it('appelle POST /api/access/deploy avec le bon payload en mode heures', async () => {
+  it('calls POST /api/access/deploy with correct payload in hours mode', async () => {
     let capturedPayload = null
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
@@ -141,7 +141,7 @@ describe('DeployKeyForm', () => {
     })
   })
 
-  it('appelle POST /api/access/deploy avec expires_at en mode date', async () => {
+  it('calls POST /api/access/deploy with expires_at in date mode', async () => {
     let capturedPayload = null
     const future = new Date(Date.now() + 86400000).toISOString().slice(0, 16)
     vi.stubGlobal('fetch', (url, opts) => {
@@ -188,7 +188,7 @@ describe('DeployKeyForm', () => {
     expect(capturedPayload.hours).toBeUndefined()
   })
 
-  it('en mode illimité le payload n\'a ni hours ni expires_at', async () => {
+  it('in unlimited mode payload has neither hours nor expires_at', async () => {
     let capturedPayload = null
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
@@ -219,7 +219,7 @@ describe('DeployKeyForm', () => {
     await w.find('[data-testid="input-pubkey"]').setValue(VALID_KEY)
     await w.find('[data-testid="select-server"]').setValue('prod-01')
     await w.find('[data-testid="mode-unlimited"]').setChecked(true)
-    await w.find('[data-testid="input-justification"]').setValue('Accès permanent')
+    await w.find('[data-testid="input-justification"]').setValue('Permanent access')
     await w.find('form').trigger('submit')
     await flushPromises()
 
@@ -227,13 +227,13 @@ describe('DeployKeyForm', () => {
       unix_user: 'alice',
       public_key: VALID_KEY,
       hostname: 'prod-01',
-      justification: 'Accès permanent',
+      justification: 'Permanent access',
     })
     expect(capturedPayload.hours).toBeUndefined()
     expect(capturedPayload.expires_at).toBeUndefined()
   })
 
-  it('affiche le résultat de succès avec le fingerprint', async () => {
+  it('shows success result with fingerprint', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -271,7 +271,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="success-panel"]').text()).toContain('alice')
   })
 
-  it('affiche un message d\'erreur en cas d\'échec de l\'API', async () => {
+  it('shows error message on API failure', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -302,7 +302,7 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="error-msg"]').text()).toBe('Invalid key format')
   })
 
-  it('désactive le bouton soumettre pendant la soumission', async () => {
+  it('disables submit button during submission', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -347,7 +347,7 @@ describe('DeployKeyForm', () => {
     expect(submitBtn.attributes('disabled')).toBeDefined()
   })
 
-  it('le bouton "New deployment" réinitialise le formulaire', async () => {
+  it('the "New deployment" button resets the form', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -390,14 +390,14 @@ describe('DeployKeyForm', () => {
     expect(w.find('[data-testid="input-unix-user"]').element.value).toBe('')
   })
 
-  it('valide que tous les champs sont requis', async () => {
+  it('validates that all fields are required', async () => {
     const w = mount(DeployKeyForm, { global: { plugins: [i18n] } })
     await flushPromises()
 
-    // Remplir seulement quelques champs
+    // Fill only some fields
     await w.find('[data-testid="input-unix-user"]').setValue('alice')
     await w.find('[data-testid="input-pubkey"]').setValue(VALID_KEY)
-    // Laisser serveur et justification vides
+    // Leave server and justification empty
 
     expect(w.find('[data-testid="submit-btn"]').attributes('disabled')).toBeDefined()
   })

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -52,7 +52,7 @@ afterEach(() => {
 })
 
 describe('DeployedUsersTable', () => {
-  it('se monte sans erreur et appelle GET /api/access/deployed-users', async () => {
+  it('mounts without error and calls GET /api/access/deployed-users', async () => {
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(MOCK_USERS),
@@ -66,7 +66,7 @@ describe('DeployedUsersTable', () => {
     expect(w.find('[data-testid="table-deployed-users"]').exists()).toBe(true)
   })
 
-  it('affiche les lignes avec unix_user et hostname', async () => {
+  it('renders rows with unix_user and hostname', async () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
@@ -82,7 +82,7 @@ describe('DeployedUsersTable', () => {
     expect(row2.text()).toContain('staging-01')
   })
 
-  it('le hostname est un lien vers /servers/{hostname}', async () => {
+  it('hostname is a link to /servers/{hostname}', async () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
@@ -92,7 +92,7 @@ describe('DeployedUsersTable', () => {
     expect(hrefs).toContain('/servers/staging-01')
   })
 
-  it('affiche la colonne IP avec ip_address', async () => {
+  it('shows IP column with ip_address', async () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
@@ -100,7 +100,7 @@ describe('DeployedUsersTable', () => {
     expect(w.find('[data-testid="row-bob-staging-01"]').text()).toContain('10.0.0.2')
   })
 
-  it('affiche "—" si ip_address est null', async () => {
+  it('shows "—" if ip_address is null', async () => {
     const usersNoIp = [{ ...MOCK_USERS[0], ip_address: null }]
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(usersNoIp) }))
 
@@ -111,7 +111,7 @@ describe('DeployedUsersTable', () => {
     expect(row.text()).toContain('—')
   })
 
-  it('affiche "Unlimited" si expires_at null', async () => {
+  it('shows "Unlimited" if expires_at null', async () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
@@ -119,7 +119,7 @@ describe('DeployedUsersTable', () => {
     expect(row1.text()).toContain('Unlimited')
   })
 
-  it('affiche la date formatée si expires_at non null', async () => {
+  it('shows formatted date if expires_at non null', async () => {
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
 
@@ -128,7 +128,7 @@ describe('DeployedUsersTable', () => {
     expect(row2.text()).not.toContain('—')
   })
 
-  it('affiche le message "empty" si liste vide', async () => {
+  it('shows "empty" message if list empty', async () => {
     vi.stubGlobal('fetch', () =>
       Promise.resolve({
         ok: true,
@@ -143,7 +143,7 @@ describe('DeployedUsersTable', () => {
     expect(w.find('[data-testid="empty-state"]').text()).toBe('No deployed users.')
   })
 
-  it('bouton Lock appelle POST /api/access/lock-user avec bons paramètres', async () => {
+  it('Lock button calls POST /api/access/lock-user with correct parameters', async () => {
     let capturedUrl = null
     let capturedPayload = null
 
@@ -182,7 +182,7 @@ describe('DeployedUsersTable', () => {
     })
   })
 
-  it('bouton Unlock appelle POST /api/access/unlock-user avec bons paramètres', async () => {
+  it('Unlock button calls POST /api/access/unlock-user with correct parameters', async () => {
     let capturedUrl = null
     let capturedPayload = null
 
@@ -223,7 +223,7 @@ describe('DeployedUsersTable', () => {
     })
   })
 
-  it('affiche succès lock inline sur la ligne', async () => {
+  it('shows lock success inline on row', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url === '/api/access/deployed-users') {
         return Promise.resolve({
@@ -256,7 +256,7 @@ describe('DeployedUsersTable', () => {
     expect(success.text()).toContain('prod-01')
   })
 
-  it('affiche succès unlock inline sur la ligne', async () => {
+  it('shows unlock success inline on row', async () => {
     const lockedUsers = [{ ...MOCK_USERS[1], lock_status: 'USER_LOCKED' }]
 
     vi.stubGlobal('fetch', (url, opts) => {
@@ -291,7 +291,7 @@ describe('DeployedUsersTable', () => {
     expect(success.text()).toContain('staging-01')
   })
 
-  it("affiche erreur inline si l'API répond en erreur", async () => {
+  it("shows inline error if API responds with error", async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url === '/api/access/deployed-users') {
         return Promise.resolve({
@@ -319,7 +319,7 @@ describe('DeployedUsersTable', () => {
     expect(error.text()).toContain('User not found')
   })
 
-  it('operator voit le bouton Lock', async () => {
+  it('operator sees Lock button', async () => {
     mockAdmin.value = { username: 'operator', role: 'operator' }
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()
@@ -327,7 +327,7 @@ describe('DeployedUsersTable', () => {
     expect(w.find('[data-testid="btn-lock-alice-prod-01"]').exists()).toBe(true)
   })
 
-  it('viewer ne voit pas le bouton Lock ni la colonne Actions', async () => {
+  it('viewer does not see Lock button nor Actions column', async () => {
     mockAdmin.value = { username: 'viewer', role: 'viewer' }
     const w = mount(DeployedUsersTable, mountOpts)
     await flushPromises()

--- a/ui/tests/ExpiryPicker.spec.js
+++ b/ui/tests/ExpiryPicker.spec.js
@@ -8,20 +8,20 @@ const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
 const mk = () => mount(ExpiryPicker, { global: { plugins: [i18n] } })
 
 describe('ExpiryPicker', () => {
-  it('démarre en mode heures', () => {
+  it('starts in hours mode', () => {
     const w = mk()
     expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
     expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
   })
 
-  it('passe en mode date quand on sélectionne date précise', async () => {
+  it('switches to date mode when date selected', async () => {
     const w = mk()
     await w.find('[data-testid="mode-date"]').setChecked(true)
     expect(w.find('[data-testid="input-date"]').exists()).toBe(true)
     expect(w.find('[data-testid="input-hours"]').exists()).toBe(false)
   })
 
-  it('repasse en mode heures depuis le mode date', async () => {
+  it('switches back to hours mode from date mode', async () => {
     const w = mk()
     await w.find('[data-testid="mode-date"]').setChecked(true)
     await w.find('[data-testid="mode-hours"]').setChecked(true)
@@ -29,7 +29,7 @@ describe('ExpiryPicker', () => {
     expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
   })
 
-  it('les deux modes ne sont jamais affichés simultanément', async () => {
+  it('both modes are never shown at the same time', async () => {
     const w = mk()
     expect(w.find('[data-testid="input-hours"]').exists()).toBe(true)
     expect(w.find('[data-testid="input-date"]').exists()).toBe(false)
@@ -39,7 +39,7 @@ describe('ExpiryPicker', () => {
     expect(w.find('[data-testid="input-date"]').exists()).toBe(true)
   })
 
-  it('émet { hours } valide quand une durée positive est saisie', async () => {
+  it('emits { hours } when a positive duration is entered', async () => {
     const w = mk()
     await w.find('[data-testid="input-hours"]').setValue('48')
     await w.find('[data-testid="input-hours"]').trigger('input')
@@ -48,7 +48,7 @@ describe('ExpiryPicker', () => {
     expect(emitted[emitted.length - 1][0]).toEqual({ hours: 48 })
   })
 
-  it('émet null si la durée est 0 ou négative', async () => {
+  it('emits null if duration is 0 or negative', async () => {
     const w = mk()
     await w.find('[data-testid="input-hours"]').setValue('0')
     await w.find('[data-testid="input-hours"]').trigger('input')
@@ -56,7 +56,7 @@ describe('ExpiryPicker', () => {
     expect(emitted[emitted.length - 1][0]).toBeNull()
   })
 
-  it('émet null quand on change de mode', async () => {
+  it('emits null when switching mode', async () => {
     const w = mk()
     await w.find('[data-testid="input-hours"]').setValue('10')
     await w.find('[data-testid="input-hours"]').trigger('input')
@@ -65,14 +65,14 @@ describe('ExpiryPicker', () => {
     expect(emitted[emitted.length - 1][0]).toBeNull()
   })
 
-  it('affiche une erreur si durée < 1', async () => {
+  it('shows an error if duration < 1', async () => {
     const w = mk()
     await w.find('[data-testid="input-hours"]').setValue('0')
     await w.find('[data-testid="input-hours"]').trigger('input')
     expect(w.find('.field-error').exists()).toBe(true)
   })
 
-  it('n\'affiche pas d\'erreur si durée >= 1', async () => {
+  it('does not show an error if duration >= 1', async () => {
     const w = mk()
     await w.find('[data-testid="input-hours"]').setValue('1')
     await w.find('[data-testid="input-hours"]').trigger('input')

--- a/ui/tests/KeyActions.spec.js
+++ b/ui/tests/KeyActions.spec.js
@@ -70,7 +70,7 @@ describe('KeyActions', () => {
     await w.find('textarea').setValue('Test reason')
     await w.find('[data-testid="confirm-revoke"]').trigger('click')
     expect(w.emitted('revoke')).toBeTruthy()
-    expect(w.emitted('revoke')[0][0]).toEqual({ fingerprint: FP, reason: 'Motif test' })
+    expect(w.emitted('revoke')[0][0]).toEqual({ fingerprint: FP, reason: 'Test reason' })
   })
 
   it('closes modal after cancel', async () => {

--- a/ui/tests/KeyActions.spec.js
+++ b/ui/tests/KeyActions.spec.js
@@ -10,83 +10,83 @@ const FP = 'SHA256:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
 const mk = (props) => mount(KeyActions, { props, global: { plugins: [i18n] } })
 
 describe('KeyActions', () => {
-  it('affiche Valider uniquement si status PENDING_REVIEW', () => {
+  it('shows Validate only if status PENDING_REVIEW', () => {
     const w = mk({ fingerprint: FP, status: 'PENDING_REVIEW' })
     expect(w.find('.btn-success').exists()).toBe(true)
   })
 
-  it('n\'affiche pas Valider si status ACTIVE', () => {
+  it('does not show Validate if status ACTIVE', () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     expect(w.find('.btn-success').exists()).toBe(false)
   })
 
-  it('affiche Révoquer si status ACTIVE', () => {
+  it('shows Revoke if status ACTIVE', () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     expect(w.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('affiche Révoquer si status PENDING_REVIEW', () => {
+  it('shows Revoke if status PENDING_REVIEW', () => {
     const w = mk({ fingerprint: FP, status: 'PENDING_REVIEW' })
     expect(w.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('n\'affiche pas Révoquer si status REVOKED', () => {
+  it('does not show Revoke if status REVOKED', () => {
     const w = mk({ fingerprint: FP, status: 'REVOKED' })
     expect(w.find('.btn-danger').exists()).toBe(false)
   })
 
-  it('affiche Expiry uniquement si status ACTIVE', () => {
+  it('shows Expiry only if status ACTIVE', () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     expect(w.find('.btn-warning').exists()).toBe(true)
   })
 
-  it('n\'affiche pas Expiry si status PENDING_REVIEW', () => {
+  it('does not show Expiry if status PENDING_REVIEW', () => {
     const w = mk({ fingerprint: FP, status: 'PENDING_REVIEW' })
     expect(w.find('.btn-warning').exists()).toBe(false)
   })
 
-  it('ouvre la modal de confirmation au clic sur Révoquer', async () => {
+  it('opens confirmation modal on Revoke click', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-danger').trigger('click')
     expect(w.find('.modal').exists()).toBe(true)
   })
 
-  it('le bouton confirmer est désactivé si le motif est vide', async () => {
+  it('confirm button is disabled if reason is empty', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-danger').trigger('click')
     expect(w.find('[data-testid="confirm-revoke"]').attributes('disabled')).toBeDefined()
   })
 
-  it('le bouton confirmer est actif quand un motif est saisi', async () => {
+  it('confirm button enabled when a reason is entered', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-danger').trigger('click')
-    await w.find('textarea').setValue('Clé compromise')
+    await w.find('textarea').setValue('Compromised key')
     expect(w.find('[data-testid="confirm-revoke"]').attributes('disabled')).toBeUndefined()
   })
 
-  it('émet revoke avec fingerprint et reason à la confirmation', async () => {
+  it('emits revoke with fingerprint and reason on confirm', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-danger').trigger('click')
-    await w.find('textarea').setValue('Motif test')
+    await w.find('textarea').setValue('Test reason')
     await w.find('[data-testid="confirm-revoke"]').trigger('click')
     expect(w.emitted('revoke')).toBeTruthy()
     expect(w.emitted('revoke')[0][0]).toEqual({ fingerprint: FP, reason: 'Motif test' })
   })
 
-  it('ferme la modal après annulation', async () => {
+  it('closes modal after cancel', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-danger').trigger('click')
     await w.find('[data-testid="cancel-revoke"]').trigger('click')
     expect(w.find('.modal').exists()).toBe(false)
   })
 
-  it('émet validate avec le fingerprint', async () => {
+  it('emits validate with fingerprint', async () => {
     const w = mk({ fingerprint: FP, status: 'PENDING_REVIEW' })
     await w.find('.btn-success').trigger('click')
     expect(w.emitted('validate')[0][0]).toBe(FP)
   })
 
-  it('émet set-expiry avec le fingerprint', async () => {
+  it('emits set-expiry with fingerprint', async () => {
     const w = mk({ fingerprint: FP, status: 'ACTIVE' })
     await w.find('.btn-warning').trigger('click')
     expect(w.emitted('set-expiry')[0][0]).toBe(FP)

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -31,95 +31,95 @@ function mountTable(keys, currentRole = 'sysadmin') {
 }
 
 describe('KeyTable', () => {
-  it('affiche une ligne par clé', () => {
+  it('displays one row per key', () => {
     const keys = [makeKey(), makeKey({ fingerprint: 'SHA256:other', status: 'REVOKED' })]
     const w = mountTable(keys)
     const rows = w.findAll('tbody tr').filter((r) => !r.classes('empty'))
     expect(rows.length).toBe(2)
   })
 
-  it('affiche le message vide quand aucune clé', () => {
+  it('displays empty message when no keys', () => {
     const w = mountTable([])
     expect(w.find('[data-testid="keytable-empty"]').exists()).toBe(true)
   })
 
-  it('PENDING_REVIEW affiche le bouton Valider (btn-success)', () => {
+  it('PENDING_REVIEW shows Validate button (btn-success)', () => {
     const w = mountTable([makeKey({ status: 'PENDING_REVIEW' })])
     expect(w.find('.btn-success').exists()).toBe(true)
   })
 
-  it("ACTIVE n'affiche pas le bouton Valider", () => {
+  it("ACTIVE does not show Validate button", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     expect(w.find('.btn-success').exists()).toBe(false)
   })
 
-  it('ACTIVE affiche le bouton Révoquer (btn-danger)', () => {
+  it('ACTIVE shows Revoke button (btn-danger)', () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     expect(w.find('.btn-danger').exists()).toBe(true)
   })
 
-  it('PENDING_REVIEW affiche le bouton Révoquer', () => {
+  it('PENDING_REVIEW shows Revoke button', () => {
     const w = mountTable([makeKey({ status: 'PENDING_REVIEW' })])
     expect(w.find('.btn-danger').exists()).toBe(true)
   })
 
-  it("REVOKED n'affiche pas le bouton Révoquer", () => {
+  it("REVOKED does not show Revoke button", () => {
     const w = mountTable([makeKey({ status: 'REVOKED' })])
     expect(w.find('.btn-danger').exists()).toBe(false)
   })
 
-  it('ACTIVE affiche le bouton Expiration (btn-warning)', () => {
+  it('ACTIVE shows Expire button (btn-warning)', () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     expect(w.find('.btn-warning').exists()).toBe(true)
   })
 
-  it("PENDING_REVIEW n'affiche pas le bouton Expiration", () => {
+  it("PENDING_REVIEW does not show Expire button", () => {
     const w = mountTable([makeKey({ status: 'PENDING_REVIEW' })])
     expect(w.find('.btn-warning').exists()).toBe(false)
   })
 
-  it('ACTIVE avec expires_at affiche le bouton Illimité (btn-unlimited)', () => {
+  it('ACTIVE with expires_at shows Unlimited button (btn-unlimited)', () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', expires_at: '2099-01-01T00:00:00' })])
     expect(w.find('.btn-unlimited').exists()).toBe(true)
   })
 
-  it("ACTIVE sans expires_at n'affiche pas le bouton Illimité", () => {
+  it("ACTIVE without expires_at does not show Unlimited button", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', expires_at: null })])
     expect(w.find('.btn-unlimited').exists()).toBe(false)
   })
 
-  it('ACTIVE sans owner affiche le bouton Assigner (btn-primary)', () => {
+  it('ACTIVE without owner shows Assign button (btn-primary)', () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', owner: null })])
     expect(w.find('.btn-primary').exists()).toBe(true)
   })
 
-  it("ACTIVE avec owner n'affiche pas le bouton Assigner", () => {
+  it("ACTIVE with owner does not show Assign button", () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', owner: 'alice' })])
     expect(w.find('.btn-primary').exists()).toBe(false)
   })
 
-  it('affiche le nom du propriétaire dans la colonne owner', () => {
+  it('displays owner name in the owner column', () => {
     const w = mountTable([makeKey({ owner: 'alice' })])
     expect(w.text()).toContain('alice')
   })
 
-  it('affiche — quand le propriétaire est null', () => {
+  it('displays — when owner is null', () => {
     const w = mountTable([makeKey({ owner: null })])
     expect(w.text()).toContain('—')
   })
 
-  it('affiche ✅ pour une clé conforme', () => {
+  it('displays ✅ for a compliant key', () => {
     const w = mountTable([makeKey({ is_compliant: true })])
     expect(w.text()).toContain('✅')
     expect(w.find('.non-compliant').exists()).toBe(false)
   })
 
-  it('affiche ⚠️ pour une clé non conforme', () => {
+  it('displays ⚠️ for a non-compliant key', () => {
     const w = mountTable([makeKey({ is_compliant: false, key_type: 'ecdsa-sha2-nistp256' })])
     expect(w.find('.non-compliant').exists()).toBe(true)
   })
 
-  it("émet validate avec l'objet clé", async () => {
+  it("emits validate with key object", async () => {
     const key = makeKey({ status: 'PENDING_REVIEW' })
     const w = mountTable([key])
     await w.find('.btn-success').trigger('click')
@@ -127,7 +127,7 @@ describe('KeyTable', () => {
     expect(w.emitted('validate')[0][0].fingerprint).toBe(FP)
   })
 
-  it("émet revoke avec l'objet clé", async () => {
+  it("emits revoke with key object", async () => {
     const key = makeKey({ status: 'ACTIVE' })
     const w = mountTable([key])
     await w.find('.btn-danger').trigger('click')
@@ -135,20 +135,20 @@ describe('KeyTable', () => {
     expect(w.emitted('revoke')[0][0].fingerprint).toBe(FP)
   })
 
-  it("émet set-expiry avec l'objet clé", async () => {
+  it("emits set-expiry with key object", async () => {
     const w = mountTable([makeKey({ status: 'ACTIVE' })])
     await w.find('.btn-warning').trigger('click')
     expect(w.emitted('set-expiry')).toBeTruthy()
   })
 
-  it('émet remove-expiry avec le fingerprint', async () => {
+  it('emits remove-expiry with fingerprint', async () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', expires_at: '2099-01-01T00:00:00' })])
     await w.find('.btn-unlimited').trigger('click')
     expect(w.emitted('remove-expiry')).toBeTruthy()
     expect(w.emitted('remove-expiry')[0][0]).toBe(FP)
   })
 
-  it('émet assign avec le fingerprint', async () => {
+  it('emits assign with fingerprint', async () => {
     const w = mountTable([makeKey({ status: 'ACTIVE', owner: null })])
     await w.find('.btn-primary').trigger('click')
     expect(w.emitted('assign')).toBeTruthy()
@@ -157,17 +157,17 @@ describe('KeyTable', () => {
 
   // --- Filtres ---
 
-  it('affiche la barre de filtres quand il y a des clés', () => {
+  it('shows filter bar when keys are present', () => {
     const w = mountTable([makeKey()])
     expect(w.find('[data-testid="keytable-filters"]').exists()).toBe(true)
   })
 
-  it("n'affiche pas la barre de filtres quand la liste est vide", () => {
+  it("does not show filter bar when list is empty", () => {
     const w = mountTable([])
     expect(w.find('[data-testid="keytable-filters"]').exists()).toBe(false)
   })
 
-  it('filtre par texte sur le fingerprint', async () => {
+  it('filters by text on fingerprint', async () => {
     const keys = [
       makeKey({ fingerprint: 'SHA256:aaaaa' }),
       makeKey({ fingerprint: 'SHA256:bbbbb' }),
@@ -179,7 +179,7 @@ describe('KeyTable', () => {
     expect(rows[0].text()).toContain('SHA256:aaaaa')
   })
 
-  it('filtre par texte sur unix_user', async () => {
+  it('filters by text on unix_user', async () => {
     const keys = [
       makeKey({ fingerprint: 'SHA256:aaaaa', unix_user: 'alice' }),
       makeKey({ fingerprint: 'SHA256:bbbbb', unix_user: 'bob' }),
@@ -190,7 +190,7 @@ describe('KeyTable', () => {
     expect(rows.length).toBe(1)
   })
 
-  it('filtre par texte sur owner', async () => {
+  it('filters by text on owner', async () => {
     const keys = [
       makeKey({ fingerprint: 'SHA256:aaaaa', owner: 'alice@example.com' }),
       makeKey({ fingerprint: 'SHA256:bbbbb', owner: 'bob@example.com' }),
@@ -201,7 +201,7 @@ describe('KeyTable', () => {
     expect(rows.length).toBe(1)
   })
 
-  it('filtre par statut', async () => {
+  it('filters by status', async () => {
     const keys = [
       makeKey({ fingerprint: 'SHA256:aaaaa', status: 'ACTIVE' }),
       makeKey({ fingerprint: 'SHA256:bbbbb', status: 'REVOKED' }),
@@ -213,13 +213,13 @@ describe('KeyTable', () => {
     expect(rows[0].text()).toContain('SHA256:aaaaa')
   })
 
-  it('affiche le message no_results quand le filtre ne correspond à rien', async () => {
+  it('displays no_results message when filter matches nothing', async () => {
     const w = mountTable([makeKey()])
     await w.find('[data-testid="keytable-filter-text"]').setValue('zzz_inexistant')
     expect(w.find('[data-testid="keytable-no-results"]').exists()).toBe(true)
   })
 
-  it('réinitialiser le filtre texte affiche toutes les clés', async () => {
+  it('resetting text filter shows all keys', async () => {
     const keys = [
       makeKey({ fingerprint: 'SHA256:aaaaa' }),
       makeKey({ fingerprint: 'SHA256:bbbbb' }),

--- a/ui/tests/ServerTable.spec.js
+++ b/ui/tests/ServerTable.spec.js
@@ -35,13 +35,13 @@ function mountTable(servers = SERVERS, currentRole = 'sysadmin') {
 }
 
 describe('ServerTable', () => {
-  it('affiche une ligne par serveur', () => {
+  it('displays one row per server', () => {
     const w = mountTable()
     const rows = w.findAll('tbody tr').filter(r => !r.classes('empty'))
     expect(rows.length).toBe(SERVERS.length)
   })
 
-  it('filtre par hostname', async () => {
+  it('filters by hostname', async () => {
     const w = mountTable()
     await w.find('input').setValue('prod')
     const rows = w.findAll('tbody tr')
@@ -49,7 +49,7 @@ describe('ServerTable', () => {
     expect(rows[0].text()).toContain('prod-01')
   })
 
-  it('filtre par adresse IP', async () => {
+  it('filters by IP address', async () => {
     const w = mountTable()
     await w.find('input').setValue('10.0.0.2')
     const rows = w.findAll('tbody tr')
@@ -57,7 +57,7 @@ describe('ServerTable', () => {
     expect(rows[0].text()).toContain('staging-01')
   })
 
-  it('filtre par environment', async () => {
+  it('filters by environment', async () => {
     const w = mountTable()
     await w.find('input').setValue('lab')
     const rows = w.findAll('tbody tr')
@@ -65,66 +65,66 @@ describe('ServerTable', () => {
     expect(rows[0].text()).toContain('disabled-01')
   })
 
-  it('affiche le badge DÉSACTIVÉ pour un serveur inactif', () => {
+  it('shows DISABLED badge for inactive server', () => {
     const w = mountTable()
     const badges = w.findAll('.badge-disabled')
     expect(badges.length).toBe(1)
   })
 
-  it('applique la classe row-danger pour un serveur désactivé', () => {
+  it('applies row-danger class for disabled server', () => {
     const w = mountTable()
     const dangerRows = w.findAll('tr.row-danger')
     expect(dangerRows.length).toBe(1)
     expect(dangerRows[0].text()).toContain('disabled-01')
   })
 
-  it('applique la classe row-warning pour un serveur avec anomalies', () => {
+  it('applies row-warning class for server with anomalies', () => {
     const w = mountTable()
     const warningRows = w.findAll('tr.row-warning')
     expect(warningRows.length).toBe(1)
     expect(warningRows[0].text()).toContain('staging-01')
   })
 
-  it('affiche ✅ pour un serveur actif sans anomalies', () => {
+  it('shows ✅ for an active server without anomalies', () => {
     const w = mountTable([SERVERS[0]])
     expect(w.text()).toContain('✅')
   })
 
-  it('affiche 🔴 pour un serveur désactivé', () => {
+  it('shows 🔴 for a disabled server', () => {
     const w = mountTable([SERVERS[2]])
     expect(w.text()).toContain('🔴')
   })
 
-  it('affiche 🟡 pour un serveur actif avec anomalies', () => {
+  it('shows 🟡 for an active server with anomalies', () => {
     const w = mountTable([SERVERS[1]])
     expect(w.text()).toContain('🟡')
   })
 
-  it('affiche le message vide quand aucun résultat', async () => {
+  it('displays empty message when no results', async () => {
     const w = mountTable()
     await w.find('input').setValue('xxxxxxnotfound')
     expect(w.find('.empty').exists()).toBe(true)
   })
 
-  it('le bouton scan émet scan avec le hostname', async () => {
+  it('scan button emits scan with hostname', async () => {
     const w = mountTable([SERVERS[0]])
     await w.find('button').trigger('click')
     expect(w.emitted('scan')).toBeTruthy()
     expect(w.emitted('scan')[0][0]).toBe('prod-01')
   })
 
-  it('affiche os_family ou — si absent', () => {
+  it('displays os_family or — if absent', () => {
     const w = mountTable([SERVERS[2]])
     expect(w.text()).toContain('—')
   })
 
-  it('affiche le bouton Edit dans chaque ligne', () => {
+  it('displays Edit button in each row', () => {
     const w = mountTable()
     const editButtons = w.findAll('button').filter((btn) => btn.text().includes('Edit'))
     expect(editButtons.length).toBe(SERVERS.length)
   })
 
-  it('le bouton Edit émet edit avec le serveur correspondant', async () => {
+  it('Edit button emits edit with corresponding server', async () => {
     const w = mountTable([SERVERS[0]])
     const buttons = w.findAll('button')
     const editButton = buttons.find((btn) => btn.text().includes('Edit'))
@@ -133,7 +133,7 @@ describe('ServerTable', () => {
     expect(w.emitted('edit')[0][0]).toEqual(SERVERS[0])
   })
 
-  it('affiche seulement 10 items par défaut sur la première page', () => {
+  it('shows only 10 items by default on the first page', () => {
     const manyServers = Array.from({ length: 25 }, (_, i) => ({
       id: String(i + 1),
       hostname: `server-${i + 1}`,
@@ -218,7 +218,7 @@ describe('ServerTable', () => {
     expect(hostnameHeader.text()).toContain('↕')
   })
 
-  it('affiche 🟠 pour un serveur actif dont le dernier scan a échoué', () => {
+  it('shows 🟠 for an active server whose last scan failed', () => {
     const server = {
       id: '4', hostname: 'fail-01', ip_address: '10.0.0.4',
       environment: 'lab', os_family: null, added_at: null,
@@ -228,7 +228,7 @@ describe('ServerTable', () => {
     expect(w.text()).toContain('🟠')
   })
 
-  it('applique la classe row-scan-fail quand last_scan_ok est false', () => {
+  it('applies row-scan-fail class when last_scan_ok is false', () => {
     const server = {
       id: '4', hostname: 'fail-01', ip_address: '10.0.0.4',
       environment: 'lab', os_family: null, added_at: null,
@@ -239,7 +239,7 @@ describe('ServerTable', () => {
     expect(row.classes()).toContain('row-scan-fail')
   })
 
-  it('🟠 a priorité sur 🟡 (scan failed + anomalies)', () => {
+  it('🟠 takes precedence over 🟡 (scan failed + anomalies)', () => {
     const server = {
       id: '5', hostname: 'fail-anomaly', ip_address: '10.0.0.5',
       environment: 'lab', os_family: null, added_at: null,

--- a/ui/tests/UserLockForm.spec.js
+++ b/ui/tests/UserLockForm.spec.js
@@ -27,7 +27,7 @@ afterEach(() => {
 })
 
 describe('UserLockForm', () => {
-  it('se monte sans erreur', async () => {
+  it('mounts without error', async () => {
     const w = mount(UserLockForm, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(w.find('[data-testid="input-unix-user"]').exists()).toBe(true)
@@ -36,30 +36,30 @@ describe('UserLockForm', () => {
     expect(w.find('[data-testid="btn-unlock"]').exists()).toBe(true)
   })
 
-  it('charge les serveurs depuis /api/servers', async () => {
+  it('loads servers from /api/servers', async () => {
     const w = mount(UserLockForm, { global: { plugins: [i18n] } })
     await flushPromises()
     const options = w.findAll('[data-testid="select-server"] option')
-    expect(options.length).toBe(3) // 1 placeholder + 2 actifs
+    expect(options.length).toBe(3) // 1 placeholder + 2 active
     expect(options[1].text()).toBe('prod-01')
     expect(options[2].text()).toBe('staging-01')
   })
 
-  it('les boutons Lock et Unlock sont désactivés si le formulaire est vide', async () => {
+  it('Lock and Unlock buttons disabled when form empty', async () => {
     const w = mount(UserLockForm, { global: { plugins: [i18n] } })
     await flushPromises()
     expect(w.find('[data-testid="btn-lock"]').attributes('disabled')).toBeDefined()
     expect(w.find('[data-testid="btn-unlock"]').attributes('disabled')).toBeDefined()
   })
 
-  it('affiche une erreur de validation pour un username invalide avec espace', async () => {
+  it('shows validation error for username with space', async () => {
     const w = mount(UserLockForm, { global: { plugins: [i18n] } })
     await flushPromises()
     await w.find('[data-testid="input-unix-user"]').setValue('alice bob')
     expect(w.find('[data-testid="error-unix-user"]').exists()).toBe(true)
   })
 
-  it('active les boutons avec un username valide + serveur sélectionné', async () => {
+  it('enables buttons with valid username + selected server', async () => {
     const w = mount(UserLockForm, { global: { plugins: [i18n] } })
     await flushPromises()
     await w.find('[data-testid="input-unix-user"]').setValue('alice')
@@ -68,7 +68,7 @@ describe('UserLockForm', () => {
     expect(w.find('[data-testid="btn-unlock"]').attributes('disabled')).toBeUndefined()
   })
 
-  it('clic sur Lock envoie POST /api/access/lock-user avec le bon payload', async () => {
+  it('clicking Lock sends POST /api/access/lock-user with correct payload', async () => {
     let capturedUrl = null
     let capturedPayload = null
     vi.stubGlobal('fetch', (url, opts) => {
@@ -107,7 +107,7 @@ describe('UserLockForm', () => {
     })
   })
 
-  it('clic sur Unlock envoie POST /api/access/unlock-user avec le bon payload', async () => {
+  it('clicking Unlock sends POST /api/access/unlock-user with correct payload', async () => {
     let capturedUrl = null
     let capturedPayload = null
     vi.stubGlobal('fetch', (url, opts) => {
@@ -146,7 +146,7 @@ describe('UserLockForm', () => {
     })
   })
 
-  it('succès Lock affiche le message de succès', async () => {
+  it('Lock success shows success message', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -179,7 +179,7 @@ describe('UserLockForm', () => {
     expect(w.find('[data-testid="success-msg"]').text()).toContain('prod-01')
   })
 
-  it('succès Unlock affiche le message de succès', async () => {
+  it('Unlock success shows success message', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({
@@ -212,7 +212,7 @@ describe('UserLockForm', () => {
     expect(w.find('[data-testid="success-msg"]').text()).toContain('prod-01')
   })
 
-  it('erreur API affiche le message d\'erreur', async () => {
+  it('API error shows error message', async () => {
     vi.stubGlobal('fetch', (url, opts) => {
       if (url.includes('/api/servers')) {
         return Promise.resolve({


### PR DESCRIPTION
This pull request focuses on improving code readability and maintainability by translating all French comments, docstrings, and test descriptions into English across the codebase. No functional or logic changes were made. This will make the project more accessible to non-French-speaking developers and maintainers.

Key changes by theme:

**Code Documentation and Comments:**
* Translated all module-level and section comments in files such as `app/actions.py`, `app/alerts.py`, `app/collect.py`, `app/expire.py`, and `app/manage.py` from French to English. This includes section headers and inline explanations. [[1]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L2-R3) [[2]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L63-R63) [[3]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L74-R76) [[4]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L523-R523) [[5]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L764-R764) [[6]](diffhunk://#diff-19f839ff3bca0f044efcf1af769413e69fb89efa792bcc3066dcf559b3426354L936-R936) [[7]](diffhunk://#diff-cc3a58bc10f23ebb9552c0159e9ba55b6744754f7a3a81bb146e315a30d68c26L2-R9) [[8]](diffhunk://#diff-a96f1a846c3b94a405def051d8de5fc1dc332b9e96ea50a67f45e446edb38730L2-R3) [[9]](diffhunk://#diff-44199a85b377e45f7ad77a8b5a28528767fb953afe3b1329180d53ec7b43c357L2-R6) [[10]](diffhunk://#diff-98005908835aa8c2b46c7366103af0078fe40c5e5998d4dea121340fb23ca528L2-R3) [[11]](diffhunk://#diff-98005908835aa8c2b46c7366103af0078fe40c5e5998d4dea121340fb23ca528L15-R15) [[12]](diffhunk://#diff-98005908835aa8c2b46c7366103af0078fe40c5e5998d4dea121340fb23ca528L55-R55)

**Test Descriptions and Docstrings:**
* Updated all test docstrings and comments in `app/tests/test_actions.py`, `app/tests/test_alerts.py` from French to English, ensuring consistency and clarity for future contributors. [[1]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L99-R99) [[2]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L115-R115) [[3]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L130-R130) [[4]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L702-R702) [[5]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L722-R730) [[6]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L740-R740) [[7]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L750-R750) [[8]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L901-R901) [[9]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L972-R972) [[10]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L994-R994) [[11]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1056-R1056) [[12]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1074-R1074) [[13]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1091-R1091) [[14]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1106-R1106) [[15]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1130-R1130) [[16]](diffhunk://#diff-9944694e3c56293e0258b8cba9baeb6e50d9c6850bcaa4ed53edd52dd6826704L1139-R1139) [[17]](diffhunk://#diff-6ec0f3990746e6793ed1898d096a7f6e8adc5c26730fde73a231428de24037ccL17-R23) [[18]](diffhunk://#diff-6ec0f3990746e6793ed1898d096a7f6e8adc5c26730fde73a231428de24037ccL74-R80) [[19]](diffhunk://#diff-6ec0f3990746e6793ed1898d096a7f6e8adc5c26730fde73a231428de24037ccL101-R101)

**Test Data and Alert Messages:**
* Changed hardcoded test alert messages and example strings from French to English in test cases, improving uniformity and test clarity. [[1]](diffhunk://#diff-6ec0f3990746e6793ed1898d096a7f6e8adc5c26730fde73a231428de24037ccL17-R23) [[2]](diffhunk://#diff-6ec0f3990746e6793ed1898d096a7f6e8adc5c26730fde73a231428de24037ccL74-R80)

These changes collectively enhance the accessibility and maintainability of the project for a broader developer audience.