### PR TITLE
docs: update CLAUDE.md and DESIGN.md post-340 features

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -57,27 +57,30 @@ known_hosts : `/data/keys/known_hosts`. Clé privée : `/data/keys/collector_key
 **Connexions SSH via ip_address uniquement** — pas le hostname (non résolvable depuis le container, #80, #84).
 known_hosts indexé par IP : `ssh-keyscan -H -T 10 <ip_address>`.
 
-### Scripts distants — 5 constantes Python `bytes` dans ssh.py
+### Scripts distants — 6 constantes Python `bytes` dans ssh.py
 
 | Constante | Path distant | Action |
 |-----------|-------------|--------|
-| SAM_COLLECT | /usr/local/bin/sam-collect (root, 755) | Lit toutes les authorized_keys → stdout : `unix_user\tkey_type key_b64 [comment]` |
-| SAM_REVOKE | /usr/local/bin/sam-revoke \<fp_hex\> (root, 755) | Révoque par fingerprint SHA256 hex. Atomique mktemp+mv. Préserve ownership (#104) |
-| SAM_ADD | /usr/local/bin/sam-add \<unix_user\> \<pubkey\> (root, 755) | Crée user Unix + authorized_keys idempotent (#164) |
-| SAM_LOCK_USER | /usr/local/bin/sam-lock-user \<unix_user\> (root, 755) | `usermod -L -s /sbin/nologin` (#181) |
-| SAM_UNLOCK_USER | /usr/local/bin/sam-unlock-user \<unix_user\> (root, 755) | `usermod -U -s /bin/bash` (#181) |
+| SAM_COLLECT | /usr/local/bin/sam-collect (root, 750) | Lit toutes les authorized_keys → stdout : `unix_user\tkey_type key_b64 [comment]` |
+| SAM_REVOKE | /usr/local/bin/sam-revoke \<fp_hex\> (root, 750) | Révoque par fingerprint SHA256 hex. Atomique mktemp+mv. Préserve ownership (#104) |
+| SAM_ADD | /usr/local/bin/sam-add \<unix_user\> \<pubkey\> (root, 750) | Crée user Unix + authorized_keys idempotent (#164) |
+| SAM_LOCK_USER | /usr/local/bin/sam-lock-user \<unix_user\> (root, 750) | `usermod -L -s /sbin/nologin` (#181) |
+| SAM_UNLOCK_USER | /usr/local/bin/sam-unlock-user \<unix_user\> (root, 750) | `usermod -U -s /bin/bash` (#181) |
+| SAM_SESSIONS | /usr/local/bin/sam-sessions (root, 750) | Collecte sessions SSH actives + historique → stdout : `A\|H\tuser\ttty\tip\trest`. `utmpdump /var/run/utmp` + fallback `LANG=C last -F` (#253, #322) |
 
 ### ensure_scripts()
 
 - Compare hash SHA256 du script distant avec la constante locale
-- Si absent ou hash différent : déploie via SFTP puis `sudo install -m 755 -o root -g root` (#161 — évite ":" dans sudoers)
+- Si absent ou hash différent : déploie via SFTP puis `sudo install -m 750 -o root -g root` (#161 — évite ":" dans sudoers)
 - Trace dans audit_log : `SCRIPT_DEPLOYED`
 
 ## actions.py — fonctions complètes
 
 ### Clés SSH
 - `validate_key(fingerprint, admin_id, unix_user=None, hostname=None)` — sans args : toutes PENDING_REVIEW ; avec args : uniquement (fp, server, unix_user) (#193)
+- `bulk_validate_keys(fingerprints, admin_id)` — valide en masse ; retourne `{validated: N, errors: [...]}`
 - `revoke_key(fingerprint, admin_id, reason, db)` — ACTIVE et PENDING_REVIEW (#85)
+- `bulk_revoke_keys(fingerprints, reason, admin_id)` — révoque en masse ; retourne `{revoked: N, errors: [...]}`
 - `handle_disappeared_key`, `handle_unknown_key`, `handle_reappeared_key` (#123)
 - `warn_expiring_key`, `assign_key`, `set_key_expiry`, `remove_key_expiry`
 
@@ -88,8 +91,13 @@ known_hosts indexé par IP : `ssh-keyscan -H -T 10 <ip_address>`.
 - `unlock_user(unix_user, hostname, admin_id)` — valide POSIX, sam-unlock-user, USER_UNLOCKED (#181)
 
 ### Serveurs
-- `add_server(hostname, ip, env, os_family, db)` — add_to_known_hosts(ip) avant INSERT (#70)
+- `add_server(hostname, ip, ssh_user, ssh_password, env, os_family, ssh_port, admin_id)` — provisionnement atomique : keyscan → SSH → INSERT (#299, #301). SSH password non stocké.
+- `provision_server(hostname, ssh_user, ssh_password, ssh_port, admin_id)` — re-provisionne un serveur existant (#302)
+- `update_server(hostname, ip, env, os_family, ssh_port, admin_id, max_sessions)` — met à jour IP, env, OS, port, max_sessions. Relance keyscan si IP change (#339)
 - `disable_server`, `enable_server` (#88), `delete_server` (#88 — hard + cascade)
+
+### Sessions
+- `check_session_limit(server_id, hostname, session_count, max_sessions)` — alerte WARNING si session_count > max_sessions, anti-spam 24h via audit_log SESSION_LIMIT_EXCEEDED (#360)
 
 ### Administrateurs
 - `add_admin(username, email, password, admin_id, role='operator')` — hash werkzeug, valide role
@@ -117,6 +125,10 @@ Scénarios 2, 3, 5 : **1 seul email CRITIQUE par scan** (#119).
 `warn_expiring_keys()` : lit `expire_warn_days` et `expire_warn_days_2` **depuis la table settings en DB** (#230) — pas depuis ENV.
 Anti-spam : NOT EXISTS EXPIRY_WARNING sur 24h. 1 seul email WARNING groupé par cycle (#119).
 
+`expire_keys()` : clés ACTIVE avec `expires_at < NOW()`. Requête SQL doit sélectionner `s.ip_address` (#114). Statut → EXPIRED, `revoked_automatically=TRUE`.
+
+`purge_old_audit_logs()` : lit `audit_retention_days` depuis settings (défaut 365). DELETE audit_log > N jours. Appelée après `expire_keys()` dans le main cron (#346).
+
 ## Authentification Flask (web.py)
 
 Session : `require_auth` (401 si absent), `require_role(*roles)` (403 si rôle insuffisant).
@@ -132,14 +144,18 @@ Print `[LOGIN_FAILED]` / `[LOGIN_BANNED]` (compatible fail2ban). Configurable vi
 POST /api/auth/login      POST /api/auth/logout     GET /api/auth/me
 
 GET    /api/servers                                  POST /api/servers
-GET    /api/servers/<hostname>                       PUT  /api/servers/<hostname>/disable
+GET    /api/servers/<hostname>                       PUT  /api/servers/<hostname>
+POST   /api/servers/<hostname>/provision             PUT  /api/servers/<hostname>/disable
 PUT    /api/servers/<hostname>/enable                DELETE /api/servers/<hostname>
 POST   /api/servers/<hostname>/scan
+GET    /api/servers/<hostname>/sessions              POST /api/servers/<hostname>/sessions/refresh
+GET    /api/servers/<hostname>/sessions/history
 
 GET  /api/keys                                       GET  /api/keys/get/<fingerprint>
 GET  /api/keys/search?q=                             POST /api/keys/validate/<fingerprint>
 POST /api/keys/revoke/<fingerprint>                  POST /api/keys/assign/<fingerprint>
 POST /api/keys/set-expiry/<fingerprint>              POST /api/keys/remove-expiry/<fingerprint>
+POST /api/keys/bulk-validate                         POST /api/keys/bulk-revoke
 
 GET  /api/access                                     GET  /api/access/<id>
 GET  /api/access/deployed-users                      POST /api/access/grant
@@ -164,10 +180,10 @@ PUT  /api/system/config                              POST /api/system/test-smtp
 ## manage.py — commandes CLI actuelles
 
 ```
-servers list / add / disable / enable / show / scan
+servers list / add / update / disable / enable / show / scan
 keys list / show / validate / revoke / assign / set-expiry / remove-expiry / search
 access list / show / grant / request / approve / reject / revoke / lock-user / unlock-user
-admin list / add / update / disable / enable / delete / change-password
+admin list / add / update / disable / enable / delete / reset-password
 audit list
 system status / report
 ```

--- a/.claude/agents/db-specialist.md
+++ b/.claude/agents/db-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: db-specialist
-description: Agent base de données — Issue 1 (sql/schema.sql) et Issue 5 (app/db.py). Responsable du schéma PostgreSQL 18, des 6 tables, index, contraintes, colonne GENERATED, et du pool de connexions Python.
+description: Agent base de données — Issue 1 (sql/schema.sql) et Issue 5 (app/db.py). Responsable du schéma PostgreSQL 18, des 7 tables, index, contraintes, colonne GENERATED, et du pool de connexions Python.
 tools: Read, Edit, Write, Bash, Glob, Grep
 model: claude-sonnet-4-5
 color: yellow
@@ -12,177 +12,210 @@ color: yellow
 
 Tu es responsable exclusivement de la couche base de données :
 
-- `sql/schema.sql` (Issue 1) — 6 tables, contraintes, index
+- `sql/schema.sql` (Issue 1) — 7 tables, contraintes, index
 - `app/db.py` (Issue 5) — connexion PostgreSQL, pool, helpers
 
 ## PostgreSQL 18 — contraintes strictes
 
 Moteur : `postgresql18` (apk Alpine). Version PostgreSQL 18.
 Jamais de syntaxe incompatible avec PG18.
+Authentification locale : `scram-sha-256` (pg_hba.conf).
 
-## Les 6 tables — schéma complet obligatoire
+## Les 7 tables — schéma complet obligatoire
 
 ### servers
 ```sql
 CREATE TABLE servers (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    hostname    VARCHAR(255) NOT NULL UNIQUE,
-    ip_address  INET NOT NULL,
-    os_family   VARCHAR(50),
-    os_version  VARCHAR(50),
-    environment VARCHAR(20) CHECK (environment IN
-                    ('production','staging','lab')),
-    is_active   BOOLEAN DEFAULT true,
-    added_at    TIMESTAMPTZ DEFAULT now()
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    hostname     VARCHAR(255) NOT NULL UNIQUE,
+    ip_address   INET NOT NULL,
+    ssh_port     INTEGER NOT NULL DEFAULT 22,
+    os_family    VARCHAR(50),
+    os_version   VARCHAR(50),
+    environment  VARCHAR(20) CHECK (environment IN ('production','staging','lab')),
+    is_active    BOOLEAN DEFAULT true,
+    max_sessions INTEGER NOT NULL DEFAULT 2,
+    added_at     TIMESTAMPTZ DEFAULT now()
 );
 ```
+
+Index unique : `servers_ip_unique ON servers(ip_address)` — une IP ne peut appartenir qu'à un seul serveur actif ou désactivé.
 
 ### administrators
 ```sql
 CREATE TABLE administrators (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    username    VARCHAR(100) NOT NULL UNIQUE,
-    email       VARCHAR(255),
-    role        VARCHAR(50) DEFAULT 'sysadmin',
-    is_active   BOOLEAN DEFAULT true,
-    created_at  TIMESTAMPTZ DEFAULT now()
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    username            VARCHAR(100) NOT NULL UNIQUE,
+    email               VARCHAR(255),
+    role                VARCHAR(50) DEFAULT 'sysadmin'
+                            CHECK (role IN ('sysadmin', 'operator', 'viewer')),
+    password_hash       VARCHAR(255),
+    is_active           BOOLEAN DEFAULT true,
+    receive_alerts      BOOLEAN NOT NULL DEFAULT true,
+    created_at          TIMESTAMPTZ DEFAULT now(),
+    password_changed_at TIMESTAMPTZ
 );
 ```
 
 ### ssh_keys
 ```sql
 CREATE TABLE ssh_keys (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    fingerprint     VARCHAR(64) NOT NULL UNIQUE,
-    key_type        VARCHAR(30) NOT NULL CHECK (key_type IN (
-                        'ssh-ed25519',
-                        'ssh-rsa',
-                        'ecdsa-sha2-nistp256'
-                    )),
-    key_size_bits   SMALLINT,
-    public_key      TEXT NOT NULL,
-    comment         VARCHAR(255),
-    owner_id        UUID REFERENCES administrators(id),
-    is_compliant    BOOLEAN GENERATED ALWAYS AS (
-                        key_type = 'ssh-ed25519' OR
-                        (key_type = 'ssh-rsa'
-                         AND key_size_bits >= 4096)
-                    ) STORED,
-    first_seen      TIMESTAMPTZ DEFAULT now(),
-    last_seen       TIMESTAMPTZ DEFAULT now()
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    fingerprint   VARCHAR(64) NOT NULL UNIQUE,
+    key_type      VARCHAR(30) NOT NULL CHECK (key_type IN (
+                      'ssh-ed25519', 'ssh-rsa', 'ecdsa-sha2-nistp256'
+                  )),
+    key_size_bits SMALLINT,
+    public_key    TEXT NOT NULL,
+    comment       VARCHAR(255),
+    owner         VARCHAR(255),           -- free-form, pas de FK
+    is_compliant  BOOLEAN GENERATED ALWAYS AS (
+                      key_type = 'ssh-ed25519'
+                      OR (key_type = 'ssh-rsa' AND key_size_bits >= 4096)
+                  ) STORED,
+    first_seen    TIMESTAMPTZ DEFAULT now(),
+    last_seen     TIMESTAMPTZ DEFAULT now()
 );
 ```
 
 ### key_authorizations
 ```sql
 CREATE TABLE key_authorizations (
-    key_id                   UUID REFERENCES ssh_keys(id),
-    server_id                UUID REFERENCES servers(id),
-    authorized_by            UUID REFERENCES administrators(id),
-    authorized_at            TIMESTAMPTZ DEFAULT now(),
-    expires_at               TIMESTAMPTZ,
-    status                   VARCHAR(20) DEFAULT 'PENDING_REVIEW'
-                                 CHECK (status IN (
-                                     'ACTIVE',
-                                     'REVOKED',
-                                     'PENDING_REVIEW',
-                                     'UNAUTHORIZED',
-                                     'EXPIRED'
-                                 )),
-    revoked_at               TIMESTAMPTZ,
-    revoked_by               UUID REFERENCES administrators(id),
-    revoked_automatically    BOOLEAN DEFAULT false,
+    key_id                UUID NOT NULL REFERENCES ssh_keys(id),
+    server_id             UUID NOT NULL REFERENCES servers(id),
+    unix_user             VARCHAR(100) NOT NULL DEFAULT '',
+    authorized_by         UUID REFERENCES administrators(id) ON DELETE SET NULL,
+    authorized_at         TIMESTAMPTZ DEFAULT now(),
+    expires_at            TIMESTAMPTZ,
+    status                VARCHAR(20) NOT NULL DEFAULT 'PENDING_REVIEW'
+                              CHECK (status IN (
+                                  'ACTIVE','REVOKED','PENDING_REVIEW','UNAUTHORIZED','EXPIRED'
+                              )),
+    revoked_at            TIMESTAMPTZ,
+    revoked_by            UUID REFERENCES administrators(id) ON DELETE SET NULL,
+    revoked_automatically BOOLEAN DEFAULT false,
     revocation_justification TEXT,
-    PRIMARY KEY (key_id, server_id)
+    PRIMARY KEY (key_id, server_id, unix_user)
 );
 ```
+
+**PK composite (key_id, server_id, unix_user)** — la même clé peut être ACTIVE pour `alice` et REVOKED pour `root` sur le même serveur (#185).
 
 ### access_requests
 ```sql
 CREATE TABLE access_requests (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    requested_by    UUID REFERENCES administrators(id),
-    approved_by     UUID REFERENCES administrators(id),
-    key_id          UUID REFERENCES ssh_keys(id),
-    server_id       UUID REFERENCES servers(id),
-    duration_hours  SMALLINT,
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    requested_by         UUID REFERENCES administrators(id) ON DELETE SET NULL,
+    approved_by          UUID REFERENCES administrators(id) ON DELETE SET NULL,
+    key_id               UUID REFERENCES ssh_keys(id),
+    server_id            UUID REFERENCES servers(id),
+    duration_hours       SMALLINT,
     expires_at_requested TIMESTAMPTZ,
-    justification   TEXT NOT NULL,
-    status          VARCHAR(20) DEFAULT 'PENDING'
-                        CHECK (status IN (
-                            'PENDING',
-                            'APPROVED',
-                            'REJECTED',
-                            'EXPIRED'
-                        )),
-    requested_at    TIMESTAMPTZ DEFAULT now(),
-    approved_at     TIMESTAMPTZ,
-    expires_at      TIMESTAMPTZ
+    justification        TEXT NOT NULL,
+    status               VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+                             CHECK (status IN ('PENDING','APPROVED','REJECTED','EXPIRED')),
+    requested_at         TIMESTAMPTZ DEFAULT now(),
+    approved_at          TIMESTAMPTZ,
+    expires_at           TIMESTAMPTZ
 );
 ```
 
 ### audit_log
 ```sql
 CREATE TABLE audit_log (
-    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    action          VARCHAR(50) NOT NULL CHECK (action IN (
-                        'KEY_ADDED',
-                        'KEY_REVOKED',
-                        'KEY_EXPIRED',
-                        'EXPIRY_WARNING',
-                        'REQUEST_APPROVED',
-                        'REQUEST_REJECTED',
-                        'ANOMALY_DETECTED',
-                        'SCAN_COMPLETED',
-                        'SCAN_FAILED',
-                        'SCRIPT_DEPLOYED',
-                        'SERVER_ADDED',
-                        'SERVER_DISABLED',
-                        'ADMIN_ADDED',
-                        'ADMIN_DISABLED'
-                    )),
-    performed_by    UUID REFERENCES administrators(id),
-    target_key      UUID REFERENCES ssh_keys(id),
-    target_server   UUID REFERENCES servers(id),
-    performed_at    TIMESTAMPTZ DEFAULT now(),
-    details         JSONB
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    action       VARCHAR(50) NOT NULL CHECK (action IN (
+                     'KEY_ADDED', 'KEY_REVOKED', 'KEY_EXPIRED', 'EXPIRY_WARNING',
+                     'REQUEST_APPROVED', 'REQUEST_REJECTED',
+                     'ANOMALY_DETECTED', 'SCAN_COMPLETED', 'SCAN_FAILED',
+                     'SCRIPT_DEPLOYED',
+                     'SERVER_ADDED', 'SERVER_DISABLED', 'SERVER_UPDATED',
+                     'ADMIN_ADDED', 'ADMIN_DISABLED', 'ADMIN_ENABLED',
+                     'ADMIN_DELETED', 'ADMIN_UPDATED',
+                     'USER_LOCKED', 'USER_UNLOCKED',
+                     'LOGIN_FAILED', 'LOGIN_BANNED', 'PASSWORD_RESET',
+                     'SERVER_PROVISIONED', 'SESSION_LIMIT_EXCEEDED'
+                 )),
+    performed_by UUID REFERENCES administrators(id) ON DELETE SET NULL,
+    target_key   UUID REFERENCES ssh_keys(id),
+    target_server UUID REFERENCES servers(id),
+    performed_at TIMESTAMPTZ DEFAULT now(),
+    details      JSONB
 );
 ```
+
+Jamais de UPDATE ni DELETE sur `audit_log` — journal immuable.
+`audit_retention_days` (settings) contrôle la purge automatique via `expire.py`.
+
+### settings
+```sql
+CREATE TABLE settings (
+    key   VARCHAR(100) PRIMARY KEY,
+    value TEXT NOT NULL
+);
+```
+
+Valeurs initiales : `scan_interval_hours=4`, `expire_warn_days=7`, `expire_warn_days_2=2`,
+`login_max_attempts=10`, `login_ban_seconds=300`, `audit_retention_days=365`.
+
+### ssh_sessions
+```sql
+CREATE TABLE ssh_sessions (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    server_id    UUID NOT NULL REFERENCES servers(id) ON DELETE CASCADE,
+    unix_user    VARCHAR(100) NOT NULL,
+    tty          VARCHAR(50) NOT NULL,
+    login_ip     INET,
+    login_at     TIMESTAMPTZ NOT NULL,
+    logout_at    TIMESTAMPTZ,
+    is_active    BOOLEAN NOT NULL DEFAULT true,
+    collected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (server_id, unix_user, tty, login_at)
+);
+```
+
+Upsert via `ON CONFLICT (server_id, unix_user, tty, login_at)`.
 
 ## Index obligatoires
 
 ```sql
-CREATE INDEX idx_key_auth_status     ON key_authorizations(status);
-CREATE INDEX idx_key_auth_expires    ON key_authorizations(expires_at) WHERE expires_at IS NOT NULL;
+CREATE INDEX idx_key_auth_status       ON key_authorizations(status);
+CREATE INDEX idx_key_auth_expires      ON key_authorizations(expires_at)
+    WHERE expires_at IS NOT NULL;
 CREATE INDEX idx_audit_log_performed_at ON audit_log(performed_at DESC);
-CREATE INDEX idx_audit_log_action    ON audit_log(action, performed_at DESC);
-CREATE INDEX idx_ssh_keys_compliant  ON ssh_keys(is_compliant);
-CREATE INDEX idx_ssh_keys_fingerprint ON ssh_keys(fingerprint);
+CREATE INDEX idx_audit_log_action      ON audit_log(action, performed_at DESC);
+CREATE INDEX idx_ssh_keys_compliant    ON ssh_keys(is_compliant);
+CREATE INDEX idx_ssh_keys_fingerprint  ON ssh_keys(fingerprint);
+CREATE UNIQUE INDEX servers_ip_unique  ON servers(ip_address);
+CREATE INDEX idx_sessions_server       ON ssh_sessions(server_id, is_active, login_at DESC);
+CREATE INDEX idx_sessions_collected    ON ssh_sessions(collected_at DESC);
 ```
 
 ## db.py — contrat d'interface
 
 Le module `app/db.py` doit exposer :
-- Un pool de connexions (psycopg2)
+- Un pool de connexions `ThreadedConnectionPool(minconn=1, maxconn=10)` (psycopg2)
 - `execute(sql, params)` — INSERT/UPDATE/DELETE sans retour
 - `query(sql, params)` — SELECT multi-lignes → list[dict]
 - `query_one(sql, params)` — SELECT une ligne → dict | None
-- Gestion des transactions (commit/rollback)
-- Connexion via variables d'environnement POSTGRES_*
+- `RealDictCursor` — lignes accessibles par nom de colonne (`row["fingerprint"]`)
+- `@contextmanager` — commit systématique ou rollback sur exception
+- Connexion via variables d'environnement `POSTGRES_*`
 
 ## Règles absolues
 
 1. **Colonne GENERATED** — `is_compliant` est `GENERATED ALWAYS AS ... STORED`. Ne jamais l'écrire manuellement.
 2. **UUID via gen_random_uuid()** — jamais de SERIAL ou BIGSERIAL.
 3. **TIMESTAMPTZ** — jamais TIMESTAMP sans TZ.
-4. **CHECK contraints** — toutes les listes de valeurs sont protégées par CHECK.
+4. **CHECK constraints** — toutes les listes de valeurs sont protégées par CHECK.
 5. **Clés étrangères** — toutes les relations sont déclarées avec REFERENCES.
 6. **Pas de ORM** — psycopg2 direct uniquement, pas de SQLAlchemy.
+7. **unix_user DEFAULT ''** — obligatoire dans toutes les requêtes sur key_authorizations.
 
 ## Tu ne touches jamais à...
 
 - `app/actions.py`, `app/web.py`, `app/manage.py`, `app/collect.py`, `app/expire.py`, `app/alerts.py`, `app/servers.py`, `app/ssh.py`
 - `Dockerfile`, `bootstrap.sh`, `supervisord.conf`, `docker-compose.yml`, `.env.example`
-- `nginx.conf.template`, `msmtp.conf.template`, `crontab`, `provision-host.sh`
+- `nginx.conf.http.template`, `nginx.conf.https.template`, `msmtp.conf.template`, `crontab`, `provision-host.sh`
 - `ui/` — domaine frontend-dev
 - La logique métier (fingerprint, paramiko, Flask routes, etc.)

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -15,7 +15,7 @@ Tu es responsable exclusivement de la couche interface utilisateur :
 - `ui/package.json`, `ui/vite.config.js`, `ui/index.html`
 - `ui/src/main.js`, `ui/src/router/index.js`, `ui/src/App.vue`
 - `ui/src/i18n.js` — configuration vue-i18n v9
-- `ui/src/composables/useAuth.js`, `ui/src/composables/useFormatDate.js`
+- `ui/src/composables/` — useAuth.js, useFormatDate.js, usePagination.js, useSort.js, useTheme.js
 - `ui/src/views/` — toutes les vues
 - `ui/src/components/` — tous les composants
 - `ui/src/locales/` — 5 fichiers JSON (en, fr, es, it, de)
@@ -29,7 +29,7 @@ Référence complète des règles UI : `ui/CLAUDE.md`.
 - **Vite** (bundler)
 - **Node.js 24 LTS** (`node:24-alpine`)
 - **vue-router ^4.3**
-- **vue-i18n ^9.14** — 5 langues : EN/FR/ES/IT/DE
+- **vue-i18n ^9.14** — 5 langues : EN/FR/ES/IT/DE — chargement lazy des locales
 - Le build produit `/ui/dist/` → copié dans `/app/static/`
 
 ## Configuration Vite obligatoire
@@ -45,44 +45,56 @@ server: {
 | Vue | Rôle |
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
-| Dashboard.vue | Tableau serveurs + compteurs + modal ajout serveur (#71) + clé collecteur (#74) |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91) |
+| Dashboard.vue | Tableau serveurs + compteurs + modal ajout serveur (SSH user/password obligatoires, #299) + clé collecteur (#74). Auto-scan après ajout (#332). Validation hostname RFC 1123 (#303). |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91) + bandeau orange si `last_scan_ok === false` (#324). Bouton **Edit** (sysadmin, `EditServerModal`) + bouton **Re-provisionner** (violet, sysadmin, #302). `max_sessions` affiché et configurable via EditServerModal (#360). |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
-| Audit.vue | Historique filtrable |
+| Audit.vue | Historique filtrable + export CSV (#343) |
 | Admins.vue | Gestion admins + modals enable/delete/password + garde-fou self (#116) + toggle alerts (#223) |
-| Settings.vue | scan_interval, expire_warn_days*, login_max_attempts, login_ban_seconds (#236) + test SMTP |
+| Settings.vue | scan_interval_hours, expire_warn_days*, login_max_attempts, login_ban_seconds (#236), audit_retention_days (#346) + test SMTP |
 
 ## Composants (ui/src/components/)
 
 | Composant | Rôle |
 |-----------|------|
-| ServerTable.vue | Tableau serveurs + ligne grisée + badge rouge si désactivé (#91) |
-| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité |
+| ServerTable.vue | Tableau serveurs + ligne grisée + badge rouge si désactivé (#91) + tri colonnes |
+| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité + sélection en masse (bulk validate/revoke, #345) + tri colonnes |
 | KeyActions.vue | Boutons valider/révoquer/expiry |
 | ExpiryPicker.vue | Modes exclusifs heures / date précise |
 | DeployKeyForm.vue | Formulaire déploiement clé SSH |
 | UserLockForm.vue | Verrouillage/déverrouillage compte Unix (#181) |
-| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer |
+| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer + tri colonnes |
+| AdminsTable.vue | Tableau administrateurs + filtre texte + pagination + garde-fou self (#250) + tri colonnes |
+| AuditTable.vue | Tableau audit + filtres serveur/action/date + pagination (#250) + export CSV (#343) + tri colonnes |
+| AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) + export CSV (#343) + tri colonnes |
+| PaginationBar.vue | Pagination réutilisable : sélecteur taille (10/20/40/50/100), indicateur traduit, boutons Précédent/Suivant |
+| SessionsCard.vue | Sessions SSH actives + modal Full History (filtres user/ip/date, pagination, export CSV) — sysadmin/operator (#253) |
+| Spinner.vue | Spinner animé universel — utilisé dans tous les boutons en état de chargement (#337) |
+| EditServerModal.vue | Modal édition serveur (IP, env, OS, port SSH, max_sessions). Props : `modelValue` (v-model), `server`, `allServers`. Émet `saved` après PUT /api/servers/{hostname} (#339, #360) |
 
 ## Composables
 
-- `useAuth.js` — authentification session (login, logout, état connecté, rôle)
+- `useAuth.js` — authentification session (login, logout, `apiFetch` avec détection 401 → redirection /login, #312)
 - `useFormatDate.js` — `formatDate()` et `formatDateOnly()` avec locale navigateur (#228, UTC→local)
+- `usePagination.js` — pagination côté client réutilisable (10 lignes par défaut, reset auto sur filtre)
+- `useSort.js` — tri de colonnes (`sortKey`, `toggleSort`, `sorted`, `sortIndicator`) — utilisé dans KeyTable, ServerTable, AuditTable, DeployedUsersTable, AdminsTable, AnomaliesTable
+- `useTheme.js` — thème sombre/clair (`isDark`, `toggleTheme`, `initializeTheme`) — persistance `localStorage`, défaut dark (#363)
 
 ## Internationalisation — règle absolue
 
 **Toute nouvelle clé de traduction doit être présente dans les 5 fichiers JSON :**
 `locales/en.json`, `fr.json`, `es.json`, `it.json`, `de.json`
 
-Détection automatique de la langue du navigateur via vue-i18n v9.
+Détection automatique de la langue du navigateur via vue-i18n v9. Chargement lazy des locales au changement de langue.
 
 ## Règles UI transversales
 
 - **`button:disabled`** → opacity 45%, cursor not-allowed, grayscale (#107)
 - **Serveurs désactivés** : ligne grisée (ServerTable) + bandeau rouge (ServerDetail) (#91)
 - **Timestamps** : stockés UTC en base, affichés dans le fuseau du navigateur via useFormatDate.js (#228)
-- **RBAC** : les boutons d'action sont masqués ou désactivés selon le rôle (viewer = lecture seule)
+- **RBAC** : les boutons d'action sont masqués (`v-if`, jamais `v-show`) selon le rôle (viewer = lecture seule)
+- **Validation IP** (#271) : `isValidIp()` (format IPv4/IPv6) + `isIpDuplicate()` — actifs ET désactivés
+- **Thème sombre** : par défaut, toggleable via `btn-theme` dans App.vue
 
 ## Routes API consommées
 
@@ -92,14 +104,18 @@ Tu consommes **uniquement** ces routes. Ne jamais appeler autre chose.
 POST /api/auth/login      POST /api/auth/logout     GET /api/auth/me
 
 GET    /api/servers                                  POST /api/servers
-GET    /api/servers/<hostname>                       PUT  /api/servers/<hostname>/disable
+GET    /api/servers/<hostname>                       PUT  /api/servers/<hostname>
+POST   /api/servers/<hostname>/provision             PUT  /api/servers/<hostname>/disable
 PUT    /api/servers/<hostname>/enable                DELETE /api/servers/<hostname>
 POST   /api/servers/<hostname>/scan
+GET    /api/servers/<hostname>/sessions              POST /api/servers/<hostname>/sessions/refresh
+GET    /api/servers/<hostname>/sessions/history
 
 GET  /api/keys                                       GET  /api/keys/get/<fingerprint>
 GET  /api/keys/search?q=                             POST /api/keys/validate/<fingerprint>
 POST /api/keys/revoke/<fingerprint>                  POST /api/keys/assign/<fingerprint>
 POST /api/keys/set-expiry/<fingerprint>              POST /api/keys/remove-expiry/<fingerprint>
+POST /api/keys/bulk-validate                         POST /api/keys/bulk-revoke
 
 GET  /api/access                                     GET  /api/access/<id>
 GET  /api/access/deployed-users                      POST /api/access/grant
@@ -130,6 +146,7 @@ PUT  /api/system/config                              POST /api/system/test-smtp
 5. **Jamais de logique métier dans les composants** — afficher et déléguer à l'API
 6. **Validation côté client** avant tout POST/PUT
 7. **vitest doit passer** avant tout commit
+8. **Spinner.vue** sur tous les boutons avec état de chargement (#337)
 
 ## Tu ne touches jamais à...
 

--- a/.claude/agents/infra-dev.md
+++ b/.claude/agents/infra-dev.md
@@ -1,6 +1,6 @@
 ---
 name: infra-dev
-description: Agent infrastructure — Milestone 1 (Issues 1-4). Responsable du Dockerfile multi-stage, supervisord.conf, bootstrap.sh, docker-compose.yml, nginx.conf.template, msmtp.conf.template, crontab, provision-host.sh et sql/schema.sql.
+description: Agent infrastructure — Milestone 1 (Issues 1-4). Responsable du Dockerfile multi-stage, supervisord.conf, bootstrap.sh, docker-compose.yml, nginx.conf.http.template, nginx.conf.https.template, msmtp.conf.template, crontab, provision-host.sh et sql/schema.sql.
 tools: Read, Edit, Write, Bash, Glob, Grep
 model: claude-sonnet-4-5
 color: cyan
@@ -15,7 +15,7 @@ Tu es responsable exclusivement de la couche infrastructure du projet ssh-access
 - ~~`sql/schema.sql`~~ **Issue 1 déléguée à db-specialist** — tu ne touches pas à ce fichier
 - `Dockerfile` (Issue 2)
 - `supervisord.conf`, `bootstrap.sh` (Issue 3)
-- `docker-compose.yml`, `.env.example`, `nginx.conf.template`, `msmtp.conf.template`, `crontab`, `provision-host.sh` (Issue 4)
+- `docker-compose.yml`, `.env.example`, `nginx.conf.http.template`, `nginx.conf.https.template`, `msmtp.conf.template`, `crontab`, `provision-host.sh` (Issue 4)
 
 ## Stack figée — ne jamais dévier
 
@@ -43,6 +43,8 @@ Paquets pip obligatoires :
 - paramiko
 - psycopg2-binary
 - pyyaml
+- werkzeug
+- waitress
 
 ### Stage build UI
 ```
@@ -56,9 +58,9 @@ FROM node:24-alpine AS ui-builder
    ```
    /data/
        ├── keys/
-       │   ├── collector_key        (chmod 600)
+       │   ├── collector_key        (chmod 600, chown nobody)
        │   ├── collector_key.pub
-       │   └── known_hosts          (chmod 600)
+       │   └── known_hosts          (chmod 644, chown nobody)
        ├── pg/                      (chown postgres:postgres, chmod 700)
        └── config/
            └── servers.yml
@@ -66,20 +68,22 @@ FROM node:24-alpine AS ui-builder
 3. **Détection premier démarrage** — Toujours via l'absence de `/data/pg/PG_VERSION`, jamais autrement.
 4. **Ordre bootstrap strict** — Respecter l'ordre exact :
    1. mkdir -p /data/keys /data/pg /data/config
-   2. chown postgres:postgres /data/pg && chmod 700 /data/pg
+   2. chown postgres:postgres /data/pg && chmod 700 /data/pg  ← AVANT initdb
    3. ssh-keygen -t ed25519 -f /data/keys/collector_key -N "" -C "ssh-access-manager@$(hostname)"
-   4. touch /data/keys/known_hosts && chmod 600 /data/keys/known_hosts
+   4. touch /data/keys/known_hosts && chmod 644 /data/keys/known_hosts
    5. chmod 600 /data/keys/collector_key
-   6. Démarrer PostgreSQL temporairement (socket local uniquement)
-   7. Créer base et utilisateur depuis ENV
-   8. Appliquer /app/sql/schema.sql
-   9. Insérer administrateur initial depuis ENV
-   10. Arrêter PostgreSQL temporaire
-   11. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
-   12. Générer /etc/nginx/nginx.conf depuis nginx.conf.template + ENV
-   13. Afficher collector_key.pub dans les logs
+   6. chown nobody /data/keys/collector_key /data/keys/known_hosts
+   7. Démarrer PostgreSQL temporairement (socket local uniquement)
+   8. Créer base et utilisateur depuis ENV (deux psql séparés — CREATE DATABASE hors transaction)
+   9. Appliquer /app/sql/schema.sql
+   10. Insérer administrateur initial depuis ENV avec werkzeug generate_password_hash
+   11. Arrêter PostgreSQL temporaire
+   12. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
+   13. **Sélectionner nginx.conf.http.template ou nginx.conf.https.template** selon présence de NGINX_TLS_CERT_PATH + NGINX_TLS_KEY_PATH. Générer /etc/nginx/nginx.conf.
+   14. Afficher collector_key.pub dans les logs
 5. **ENTRYPOINT** — Toujours `exec /usr/bin/supervisord -c /etc/supervisord.conf` en dernière instruction de bootstrap.sh.
 6. **supervisord nodaemon=true** — Logs vers /dev/stdout uniquement.
+7. **Flask via Waitress** — `python3 /app/app/web.py` démarre Waitress (jamais le dev server Flask). Utilisateur `nobody`.
 
 ## Variables d'environnement — liste complète
 
@@ -91,8 +95,10 @@ POSTGRES_PASSWORD=changeme
 
 # Nginx
 NGINX_PORT=8080
-NGINX_USER=admin
-NGINX_PASSWORD=changeme
+# TLS optionnel — si les deux sont définis → HTTPS (TLSv1.2/1.3)
+# Un certificat auto-signé est généré si les fichiers n'existent pas
+NGINX_TLS_CERT_PATH=/data/certs/server.crt
+NGINX_TLS_KEY_PATH=/data/certs/server.key
 
 # Flask
 FLASK_SECRET_KEY=changeme
@@ -100,37 +106,53 @@ FLASK_SECRET_KEY=changeme
 # Email
 SMTP_HOST=mail.example.com
 SMTP_PORT=587
-SMTP_USER=alerts@example.com
+SMTP_USERNAME=alerts@example.com   # si vide → auth off dans msmtp
 SMTP_PASSWORD=changeme
 SMTP_FROM=ssh-manager@example.com
-SMTP_TO=admin@example.com
+SMTP_ENCRYPTION=starttls           # none | starttls | tls
+SMTP_TLSVERIFY=1                   # 1 = vérifie certs TLS | vide = off
+SMTP_ENABLED=1                     # 1 = envoi actif | vide = désactivé
 
 # Collector
 SSH_USER=audit-collector
-SCAN_INTERVAL_HOURS=4
-EXPIRE_WARN_DAYS=7
-EXPIRE_WARN_DAYS_2=2
+
+# Admin initial
 ADMIN_USERNAME=admin
 ADMIN_EMAIL=admin@example.com
-TZ=Europe/Paris
+ADMIN_PASSWORD=admin
 ```
+
+**Supprimés** (ne jamais réintroduire) :
+- `NGINX_USER` / `NGINX_PASSWORD` — Basic Auth supprimé (#54)
+- `SCAN_INTERVAL_HOURS`, `EXPIRE_WARN_DAYS`, `EXPIRE_WARN_DAYS_2` — configurables en base via settings
+- `TZ` — UTC en base, conversion navigateur (#228)
 
 ## provision-host.sh — actions obligatoires
 
-1. useradd -r -m -s /bin/bash audit-collector
-2. mkdir /home/audit-collector/.ssh && chmod 700 /home/audit-collector/.ssh
-3. Déployer la clé publique dans authorized_keys (chmod 600)
-4. Créer /etc/sudoers.d/audit-collector (chmod 440)
+Actions : crée l'utilisateur collector, déploie la clé publique (append + chown), crée sudoers dynamique.
 
-Contenu sudoers :
+Sudoers généré avec `printf` ligne par ligne (résistant au CRLF PTY — #159).
+Créé via `install -m 440` (évite ":" dans les args sur RHEL/CentOS — #161).
+
+```bash
+# Invocation
+ssh <user>@<ip> "sudo bash -s '$(podman exec ssh-access-manager cat /data/keys/collector_key.pub)' '${SSH_USER}'" \
+    < <(podman exec ssh-access-manager cat /app/provision-host.sh)
 ```
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/mv /tmp/sam-* /usr/local/bin/
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-revoke
+
+Permissions appliquées (#260) :
+- `chmod 700 /home/${COLLECTOR_USER}` — home non listable
+- Scripts SAM déployés avec `-m 750` (root:root) — non exécutables par non-root
+
+Sudoers (contenu dynamique via `${COLLECTOR_USER}`) — inclut tous les scripts SAM :
+```
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/bin/install -m 750 ...
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-add *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-sessions
 ```
 
 ## Tu ne touches jamais à...

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -51,11 +51,13 @@ Vérifier dans `ssh.py` :
 
 Vérifier dans `bootstrap.sh` :
 ```bash
-chmod 600 /data/keys/collector_key    # Clé privée
-chmod 600 /data/keys/known_hosts      # known_hosts
-chmod 700 /data/pg                    # PGDATA
-chown postgres:postgres /data/pg      # Propriétaire postgres
-chmod 440 /etc/sudoers.d/audit-collector  # sudoers
+chmod 600 /data/keys/collector_key         # Clé privée
+chmod 644 /data/keys/known_hosts           # known_hosts (lisible par nobody)
+chown nobody /data/keys/collector_key      # Propriétaire nobody (user Flask)
+chown nobody /data/keys/known_hosts        # Propriétaire nobody
+chmod 700 /data/pg                         # PGDATA
+chown postgres:postgres /data/pg           # Propriétaire postgres
+chmod 440 /etc/sudoers.d/audit-collector   # sudoers
 ```
 
 ### 6. Flask / Waitress — surface d'attaque
@@ -74,7 +76,7 @@ ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-add *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user *
-${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-sessions
 ```
 Aucune règle `ALL=(ALL) NOPASSWD: ALL` ou équivalent permissif.
@@ -84,7 +86,7 @@ Généré avec `printf` ligne par ligne (résistant au CRLF PTY). Créé via `in
 
 - Toute action sensible doit être tracée dans `audit_log`
 - Les actions de révocation doivent inclure `performed_by` et `details` JSONB
-- Vérifier que `ANOMALY_DETECTED` est bien émis dans les 4 scénarios de révocation
+- Vérifier que `ANOMALY_DETECTED` est bien émis dans les 3 scénarios d'anomalie (scénario 2 : révocation hors système, scénario 3 : clé inconnue, scénario 5 : clé réapparue)
 
 ## Format de rapport
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -28,8 +28,8 @@ Tu effectues des revues de sécurité sur le code du projet ssh-access-manager. 
 ### 2. Scripts distants (Critique)
 
 Vérifier dans `ssh.py` :
-- Les constantes `SAM_COLLECT` et `SAM_REVOKE` sont des strings Python (pas des fichiers)
-- Le déploiement se fait via SFTP dans `/tmp/`, puis `sudo mv` (jamais d'exécution directe depuis /tmp/)
+- Les constantes `SAM_COLLECT`, `SAM_REVOKE`, `SAM_ADD`, `SAM_LOCK_USER`, `SAM_UNLOCK_USER`, `SAM_SESSIONS` sont des **`bytes` Python** (pas des strings ni des fichiers)
+- Le déploiement se fait via SFTP dans le home du collector, puis `sudo /usr/bin/install -m 750 -o root -g root` (jamais `mv` + `chmod` séparés — atomique, #161)
 - `sam-revoke` utilise `mktemp` + `mv` atomique pour réécrire authorized_keys
 - Aucune injection de commande possible dans le fingerprint passé à sam-revoke
 
@@ -58,26 +58,27 @@ chown postgres:postgres /data/pg      # Propriétaire postgres
 chmod 440 /etc/sudoers.d/audit-collector  # sudoers
 ```
 
-### 6. Flask — surface d'attaque
+### 6. Flask / Waitress — surface d'attaque
 
-- Vérifier que l'API Flask écoute sur `127.0.0.1:5000` uniquement (pas `0.0.0.0`)
-- Vérifier que Nginx fait le Basic Auth (jamais dans Flask directement)
-- Vérifier que Flask est lancé avec `user=nobody` dans supervisord.conf
-- Vérifier l'absence de mode debug Flask en production
+- Vérifier que Waitress écoute sur `127.0.0.1:5000` uniquement (pas `0.0.0.0`)
+- **Pas de Basic Auth Nginx** — supprimé (#54). L'authentification est gérée par sessions Flask uniquement.
+- Vérifier que Flask/Waitress est lancé avec `user=nobody` dans supervisord.conf
+- Vérifier l'absence de mode debug Flask en production (jamais `app.run(debug=True)`)
 
 ### 7. Sudoers — principe de moindre privilège
 
-Le fichier `/etc/sudoers.d/audit-collector` doit autoriser **uniquement** :
+Le fichier `/etc/sudoers.d/${COLLECTOR_USER}` (chmod 440) doit autoriser **uniquement** :
 ```
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/mv /tmp/sam-* /usr/local/bin/
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chmod 755 /usr/local/bin/sam-revoke
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-collect
-audit-collector ALL=(root) NOPASSWD: /bin/chown root:root /usr/local/bin/sam-revoke
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/bin/install -m 750 ...
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-collect
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-add *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-sessions
 ```
 Aucune règle `ALL=(ALL) NOPASSWD: ALL` ou équivalent permissif.
+Généré avec `printf` ligne par ligne (résistant au CRLF PTY). Créé via `install -m 440` (évite ":" dans les args — #161).
 
 ### 8. Audit trail — intégrité
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -110,3 +110,16 @@ Produire un rapport structuré :
 ✅ Issue N validée — prête pour commit
 ❌ Issue N — corrections requises avant commit
 ```
+
+## Étape 8 — Revue de sécurité approfondie
+
+Après avoir produit le rapport ci-dessus, déléguer systématiquement au `security-reviewer` :
+
+```
+Utilise l'agent security-reviewer pour effectuer une revue de sécurité approfondie
+sur les fichiers modifiés dans cette issue. Contexte : [résumé des changements].
+```
+
+Le `security-reviewer` produit son propre rapport indépendant. Fusionner les deux verdicts :
+- Si `security-reviewer` lève un problème CRITIQUE ou ÉLEVÉ → verdict global ❌ bloquant
+- Si uniquement MOYEN ou INFO → mentionner dans le rapport mais ne pas bloquer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Projet "ssh-access-manager" — audit et gestion des accès SSH dans un containe
 VAE RNCP41330 "Expert en développement logiciel" Niveau 7 — C.1.6.
 Développeur : Stéphane de Labrusse.
 
-## État du projet — toutes issues fermées (69/69)
+## État du projet — toutes issues fermées (85/85)
 
-Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303, 312, 314, 320, 322, 324, 326, 328, 330, 332, 335, 337, 339) ✅
+Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303, 312, 314, 320, 322, 324, 326, 328, 330, 332, 335, 337, 339, 343, 345, 346, 348, 350, 352, 354, 357, 360, 361, 363, 365, 367, 368, 378, 380) ✅
 
 ## Stack vérifiée et figée
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -506,7 +506,7 @@ Le scénario 3 concerne les clés totalement inconnues.
 ```
 ┌─────────────────────────────────┐
 │  actions.py  (logique métier)   │
-│  552 lignes — source unique     │
+│  1185 lignes — source unique    │
 └───────────────┬─────────────────┘
                 │ importé par
        ┌────────┴────────┐
@@ -514,7 +514,7 @@ Le scénario 3 concerne les clés totalement inconnues.
 ┌──────▼──────┐   ┌──────▼──────┐
 │  web.py     │   │  manage.py  │
 │  (API REST) │   │  (CLI)      │
-│  516 lignes │   │  508 lignes │
+│  1174 lignes│   │  631 lignes │
 └─────────────┘   └─────────────┘
 ```
 
@@ -655,12 +655,15 @@ Les alertes email sont envoyées aux administrateurs dont `receive_alerts=true`
 
 ### Composition API et composables
 
-Vue.js 3 avec `<script setup>` est utilisé systématiquement. Deux composables
+Vue.js 3 avec `<script setup>` est utilisé systématiquement. Cinq composables
 encapsulent la logique partagée :
 
 - **`useAuth.js`** — état d'authentification partagé entre toutes les vues
 - **`useFormatDate.js`** — `formatDate()` et `formatDateOnly()` avec locale du navigateur
   (`toLocaleString(undefined, ...)` — s'adapte automatiquement au fuseau du navigateur)
+- **`usePagination.js`** — pagination côté client réutilisable (reset auto sur filtre)
+- **`useSort.js`** — tri de colonnes réutilisable (`sortKey`, `toggleSort`, `sorted`, `sortIndicator`) — utilisé dans KeyTable, ServerTable, AuditTable, DeployedUsersTable, AdminsTable, AnomaliesTable
+- **`useTheme.js`** — thème sombre/clair avec persistance `localStorage` ; initialise `data-theme` sur `<html>` au chargement ; défaut : dark (#363)
 
 Le composable `useAuth.js` encapsule l'état d'authentification partagé entre toutes les vues :
 
@@ -1159,7 +1162,7 @@ coûteuse en temps).
 | `test_collect.py` | 35 | 4 scénarios détection, RSA parsing |
 | `test_expire.py` | 12 | Anti-spam 24h, expiration auto |
 | `test_alerts.py` | 23 | Niveaux CRITICAL/WARNING/INFO, anti-spam |
-| Vue.js specs | 262 | 18 fichiers : Dashboard (provisionnement, validation hostname), ServerDetail (re-provision), KeyTable, ServerTable, Admins, SessionsCard, et tous composants |
+| Vue.js specs | 325 | 19 fichiers : Dashboard (provisionnement, validation hostname), ServerDetail (re-provision), KeyTable (bulk select), ServerTable, Admins, SessionsCard, useSort, et tous composants |
 
 ---
 
@@ -1369,6 +1372,11 @@ permet de modifier `NGINX_PORT` ou `SMTP_HOST` sans reconstruire l'image — un
 | Provisionnement atomique (provision-first) | Aucun serveur zombie en DB — INSERT uniquement si SSH réussit | SSH obligatoire à l'ajout (pas de déclaration purement déclarative via UI) |
 | SSH password non stocké | Sécurité : credential éphémère, jamais en base ni en audit | Pas de re-connexion automatique — re-provisionnement via bouton UI si nécessaire |
 | `error_code` API + traduction frontend | Messages d'erreur SSH dans la langue du navigateur sans hard-coder les traductions côté serveur | 7 codes à maintenir synchronisés entre backend et fichiers i18n |
+| Waitress WSGI server | Serveur de production thread-safe ; Flask dev server interdit en production | Dépendance supplémentaire (`waitress` dans pip) |
+| Bulk validate/revoke | Réduction du nombre de requêtes HTTP pour les opérations de masse ; transactions atomiques | Limite 200 fingerprints par appel |
+| Rétention audit configurable | `audit_retention_days` (défaut 365) évite la croissance illimitée de `audit_log` | Perte des entrées purgées (irréversible) |
+| Seuil sessions par serveur (`max_sessions`) | Alerte WARNING si sessions SSH actives > seuil ; anti-spam 24h via `audit_log` | Seuil par serveur à maintenir dans l'UI |
+| Thème sombre par défaut | Réduction de la fatigue visuelle pour les opérateurs ; persistance via `localStorage` | CSS variables à synchroniser entre composants |
 
 ---
 
@@ -1385,7 +1393,7 @@ d'ingénierie logicielle niveau 7 :
 - **Idempotence** : sync YAML, keyscan, bootstrap, déploiement de scripts.
 - **Traçabilité complète** : les 4 scénarios de révocation sont distingués par des
   colonnes dédiées et des entrées `audit_log` de types différents.
-- **Qualité mesurée** : couverture ≥ 80 % imposée par CI, 733 tests (471 Python +
-  262 Vue.js), isolation totale.
+- **Qualité mesurée** : couverture ≥ 80 % imposée par CI, 857 tests (532 Python +
+  325 Vue.js), isolation totale.
 - **Déploiement continu** : 5 workflows GitHub Actions (tests, build PR, build main,
   publication semver, nettoyage GHCR).

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -40,8 +40,9 @@ Schéma complet dans sql/schema.sql. Points non-évidents :
 - `ssh_keys.is_compliant` : colonne GENERATED ALWAYS AS — `key_type = 'ssh-ed25519' OR (key_type = 'ssh-rsa' AND key_size_bits >= 4096)`
 - `key_authorizations` PK = **(key_id, server_id, unix_user)** — même clé déployable pour plusieurs users Unix sur même serveur (#185)
 - `key_authorizations.unix_user` DEFAULT '' — champ obligatoire dans toutes les requêtes
-- Table `settings` : lire en DB, jamais depuis ENV. Clés : `scan_interval_hours` (4), `expire_warn_days` (7), `expire_warn_days_2` (2), `login_max_attempts` (10), `login_ban_seconds` (300)
+- Table `settings` : lire en DB, jamais depuis ENV. Clés : `scan_interval_hours` (4), `expire_warn_days` (7), `expire_warn_days_2` (2), `login_max_attempts` (10), `login_ban_seconds` (300), `audit_retention_days` (365)
 - `servers.ip_address` : index unique global (`servers_ip_unique`) — une IP ne peut appartenir qu'à un seul serveur, actif ou désactivé. Désactivation = maintenance temporaire, le serveur peut revenir. Seule la suppression libère l'IP.
+- `servers.max_sessions` : INTEGER DEFAULT 2 — seuil alertes SESSION_LIMIT_EXCEEDED (alerte WARNING par serveur avec anti-spam 24h, #360)
 
 ## Logique métier — fingerprint SHA256
 
@@ -96,6 +97,12 @@ Récupération de clé hôte si absent de known_hosts — `_fetch_host_key(ip, p
 - **Requête SQL doit sélectionner s.ip_address** (#114)
 - sam-revoke sur serveur distant via IP
 - status=EXPIRED, revoked_automatically=TRUE, audit_log KEY_EXPIRED, email INFO
+
+`purge_old_audit_logs()` :
+- Lit `audit_retention_days` depuis settings en DB (défaut 365 jours)
+- DELETE FROM audit_log WHERE performed_at < NOW() - INTERVAL N days
+- Retourne le nombre d'entrées supprimées
+- Appelée par expire.py main() après expire_keys()
 
 ## Les 5 scénarios de révocation / détection
 
@@ -158,6 +165,8 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 
 ### Clés SSH
 - `validate_key(fingerprint, admin_id, unix_user=None, hostname=None)` — sans args : valide toutes PENDING_REVIEW du fingerprint ; avec args : valide uniquement (fingerprint, server, unix_user) (#193)
+- `bulk_validate_keys(fingerprints, admin_id)` — valide en masse une liste de fingerprints PENDING_REVIEW ; retourne `{validated: N, errors: [...]}`
+- `bulk_revoke_keys(fingerprints, reason, admin_id)` — révoque en masse ; retourne `{revoked: N, errors: [...]}`
 - `revoke_key(fingerprint, admin_id, reason, db)` — ACTIVE et PENDING_REVIEW (#85)
 - `handle_disappeared_key`, `handle_unknown_key`, `handle_reappeared_key`
 - `warn_expiring_key`, `assign_key`, `set_key_expiry`, `remove_key_expiry`
@@ -171,7 +180,11 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 ### Serveurs
 - `add_server(hostname, ip, ssh_user, ssh_password, env=None, os_family=None, ssh_port=22, admin_id=None)` — provisionnement atomique : `add_to_known_hosts(ip)` → `ssh.provision_server()` → INSERT servers → audit SERVER_ADDED + SERVER_PROVISIONED. Si le SSH échoue, aucune donnée n'est écrite (#299, #301). Le SSH password n'est jamais stocké.
 - `provision_server(hostname, ip, ssh_user, ssh_password, ssh_port)` — re-provisionne un serveur existant (#302). Même garantie : ssh password non stocké.
+- `update_server(hostname, ip, env, os_family, ssh_port, admin_id, max_sessions)` — met à jour IP, env, OS, port, max_sessions. Si l'IP change, relance ssh-keyscan atomiquement (#339)
 - `disable_server`, `enable_server` (#88), `delete_server` (#88 — hard delete + cascade)
+
+### Sessions
+- `check_session_limit(server_id, hostname, session_count, max_sessions)` — envoie alerte WARNING si session_count > max_sessions, avec anti-spam 24h via audit_log (SESSION_LIMIT_EXCEEDED, #360)
 
 ### Administrateurs
 - `add_admin(username, email, password, admin_id, role='operator')` — email obligatoire, valide role, hash werkzeug
@@ -191,7 +204,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 | POST /api/servers/\*/scan, /api/system/scan | ✓ | ✓ | 403 |
 | GET /api/servers/\*/sessions, /api/servers/\*/sessions/history | ✓ | ✓ | 403 |
 | POST /api/servers/\*/sessions/refresh | ✓ | ✓ | 403 |
-| POST /api/keys/validate, revoke, assign, set-expiry, remove-expiry | ✓ | ✓ | 403 |
+| POST /api/keys/validate, revoke, assign, set-expiry, remove-expiry, bulk-validate, bulk-revoke | ✓ | ✓ | 403 |
 | POST /api/access/grant, deploy, lock-user, unlock-user, request, approve, reject, revoke | ✓ | ✓ | 403 |
 | POST /api/admins | ✓ | 403 | 403 |
 | PUT /api/admins/\* (sauf password) | ✓ | 403 | 403 |
@@ -211,7 +224,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - Couverture minimale actions.py : 80%
 - pytest doit passer avant tout commit
 
-Fichiers : conftest.py, test_db.py (7), test_servers.py (9), test_ssh.py (49), test_actions.py (114), test_collect.py (35), test_expire.py (12), test_alerts.py (23), test_web.py (130), test_manage.py (38), test_rbac.py (54).
+Fichiers : conftest.py, test_db.py (7), test_servers.py (10), test_ssh.py (61), test_actions.py (131), test_collect.py (35), test_expire.py (16), test_alerts.py (23), test_web.py (157), test_manage.py (38), test_rbac.py (54).
 
 Fixtures obligatoires dans conftest.py : `mock_db`, `mock_ssh_client`, `mock_smtp`, `sample_server`, `sample_key`.
 

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -6,19 +6,19 @@
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
 | Dashboard.vue | Tableau serveurs + recherche + compteurs + modal ajout serveur (#71) + clé collecteur (#74). Provisionnement atomique via SSH (#299, #301) : SSH user/password obligatoires, serveur créé uniquement si SSH réussit. Validation hostname RFC 1123 (#303). Layout 2 colonnes. |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Edit** (sysadmin) : ouvre `EditServerModal` pour modifier IP, env, OS, port SSH (#339). Bandeau orange si `last_scan_ok === false` (#324). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Edit** (sysadmin) : ouvre `EditServerModal` pour modifier IP, env, OS, port SSH (#339) ; `max_sessions` configurable via `EditServerModal` (seuil alertes sessions, #360). Bandeau orange si `last_scan_ok === false` (#324). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + colonne unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
 | Audit.vue | Historique filtrable |
 | Admins.vue | Gestion admins + modals enable/delete/password + garde-fou self (#116) + toggle alerts (#223) |
-| Settings.vue | scan_interval_hours, expire_warn_days*, login_max_attempts, login_ban_seconds (#236) + test SMTP |
+| Settings.vue | scan_interval_hours, expire_warn_days*, login_max_attempts, login_ban_seconds (#236), audit_retention_days (#346) + test SMTP |
 
 ## Composants (ui/src/components/)
 
 | Composant | Rôle |
 |-----------|------|
 | ServerTable.vue | Tableau serveurs + ligne grisée + badge rouge si désactivé (#91) |
-| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité |
+| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité + sélection en masse (bulk validate/revoke, #345) |
 | KeyActions.vue | Boutons valider/révoquer/expiry |
 | ExpiryPicker.vue | Modes exclusifs heures / date précise |
 | DeployKeyForm.vue | Formulaire déploiement clé SSH |
@@ -37,6 +37,8 @@
 - `useAuth.js` — authentification session + détection 401 → redirection automatique vers `/login` via `apiFetch` (session expirée — #312)
 - `useFormatDate.js` — `formatDate()` et `formatDateOnly()` avec locale navigateur (#228, UTC→local)
 - `usePagination.js` — pagination côté client réutilisable (10 lignes par défaut, reset auto au changement de filtre)
+- `useSort.js` — tri de colonnes réutilisable (`sortKey`, `toggleSort`, `sorted`, `sortIndicator`) — utilisé dans KeyTable, ServerTable, AuditTable, DeployedUsersTable, AdminsTable, AnomaliesTable
+- `useTheme.js` — thème sombre/clair (`isDark`, `toggleTheme`, `initializeTheme`) — persistance via localStorage, défaut dark (#363)
 
 ## Internationalisation — règle absolue
 
@@ -59,8 +61,8 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 |---------|-------|--------------------|
 | KeyActions.spec.js | 14 | modal confirmation révocation |
 | ExpiryPicker.spec.js | 9 | modes exclusifs heures/date |
-| ServerTable.spec.js | 16 | filtres hostname/IP/env, badges statut |
-| KeyTable.spec.js | 30 | boutons par statut, owner, expires_at, filtres |
+| ServerTable.spec.js | 25 | filtres hostname/IP/env, badges statut |
+| KeyTable.spec.js | 45 | boutons par statut, owner, expires_at, filtres |
 | Admins.spec.js | 31 | modals enable/delete, RBAC, toggle alerts |
 | Settings.spec.js | 18 | validation champs, SMTP test |
 | DeployKeyForm.spec.js | 16 | formulaire déploiement clé SSH |
@@ -69,11 +71,13 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | Anomalies.spec.js | 20 | filtres texte + dropdowns, unix_user, badges |
 | Login.spec.js | 8 | checkbox remember-me, payload remember_me |
 | AdminsTable.spec.js | 13 | filtre texte, pagination, RBAC, garde-fou self, events (#250) |
-| AuditTable.spec.js | 8 | filtres serveur/action/date, pagination, row classes (#250) |
-| AnomaliesTable.spec.js | 13 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
+| AuditTable.spec.js | 10 | filtres serveur/action/date, pagination, row classes (#250) |
+| AnomaliesTable.spec.js | 22 | filtres texte/type/conformité, pagination, RBAC, events (#250) |
 | SessionsCard.spec.js | 17 | sessions actives, modal historique, filtres, pagination, CSV export, RBAC (#253) |
 | Dashboard.spec.js | 8 | champs SSH obligatoires, submit désactivé sans password/hostname invalide, POST avec ssh_user/password/port, port 22 par défaut, fermeture modal, validation RFC 1123 (#299, #303) |
 | PaginationBar.spec.js | 10 | sélecteur taille, navigation pages, désactivation limites |
-| App.spec.js | 6 | sélecteur langue, persistance localStorage |
+| App.spec.js | 8 | SMTP banner, sélecteur langue, persistance localStorage |
+| useSort.spec.js | 21 | tri multi-colonnes, reset, indicateurs |
 
+<!-- 19 fichiers de tests -->
 vitest doit passer avant tout commit.


### PR DESCRIPTION
## Summary

- **CLAUDE.md** : compteur issues 69/69 → 85/85 (ajout #343–#380), `waitress` dans la liste pip
- **app/CLAUDE.md** : `audit_retention_days` dans settings, `servers.max_sessions`, `purge_old_audit_logs()` dans expire.py, `bulk_validate_keys` / `bulk_revoke_keys` / `check_session_limit` / `update_server` dans actions.py, RBAC bulk routes, comptages tests mis à jour (532 Python au total)
- **ui/CLAUDE.md** : composables `useSort.js` et `useTheme.js`, bulk select dans KeyTable, `audit_retention_days` dans Settings, `max_sessions` dans ServerDetail, comptages tests mis à jour (325 Vue.js, 19 fichiers)
- **DESIGN.md** : lignes de code actions.py/web.py/manage.py, totaux tests (857 = 532+325), `usePagination`/`useSort`/`useTheme` dans la liste composables, 5 nouvelles lignes dans le tableau de synthèse (Waitress, bulk ops, rétention audit, max_sessions, dark theme)

## Test plan

- [ ] Relire les 4 fichiers modifiés pour vérifier la cohérence
- [ ] CI verte (pas de code modifié, uniquement de la documentation)