### PR TITLE
docs: fix SAM scripts install permissions 755 → 750 in DESIGN.md example

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -332,7 +332,7 @@ def ensure_scripts(hostname, server_id, ip):
         if remote_hash != _sha256(content):
             tmp_path = f"/home/{SSH_USER}/{os.path.basename(remote_path)}"
             sftp.putfo(io.BytesIO(content), tmp_path)
-            _run(client, f"sudo /usr/bin/install -m 755 -o root -g root {tmp_path} {remote_path}")
+            _run(client, f"sudo /usr/bin/install -m 750 -o root -g root {tmp_path} {remote_path}")
             db.execute("INSERT INTO audit_log ... 'SCRIPT_DEPLOYED' ...")
 ```
 


### PR DESCRIPTION
## Summary

- Corrige l'exemple de code DESIGN.md section 6.5 : `install -m 755` → `install -m 750`
- Incohérence détectée par le `security-reviewer` lors de la revue de la PR #381
- Les scripts SAM doivent être `750` (non exécutables par les non-root) comme documenté partout ailleurs

## Test plan

- [ ] Vérifier que `grep "755" DESIGN.md` ne retourne plus rien dans les exemples SAM