### PR TITLE
feat: root account protection, checkbox fix, and key deployment hardening

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -74,7 +74,7 @@ Tracées dans audit_log (SCRIPT_DEPLOYED).
 | SAM_LOCK_USER | /usr/local/bin/sam-lock-user \<unix_user\> | root, 750 | `usermod -L -s /sbin/nologin` — bloque mdp ET shell (#181) |
 | SAM_UNLOCK_USER | /usr/local/bin/sam-unlock-user \<unix_user\> | root, 750 | `usermod -U -s /bin/bash` (#181) |
 | SAM_SESSIONS | /usr/local/bin/sam-sessions | root, 750 | Collecte sessions SSH actives + historique → stdout : `A\|H\tuser\ttty\tip\trest`. Utilise `utmpdump /var/run/utmp` (ISO 8601, locale-safe), fallback `LANG=C last -F` (#253, #322) |
-| SAM_GRANT_GROUP | /usr/local/bin/sam-grant-group \<unix_user\> \<group\> | root, 750 | Valide groupe (sam-operator\|sam-pkg\|sam-root), `usermod -aG` (#383) |
+| SAM_GRANT_GROUP | /usr/local/bin/sam-grant-group \<unix_user\> \<group\> | root, 750 | Valide groupe (sam-operator\|sam-pkg\|sam-root), `gpasswd -a` — works even when user is logged in (#383) |
 | SAM_REVOKE_GROUP | /usr/local/bin/sam-revoke-group \<unix_user\> \<group\> | root, 750 | Valide groupe, `gpasswd -d ... \|\| true` — idempotent (#383) |
 
 ## Logique métier — known_hosts et connexions SSH
@@ -98,6 +98,7 @@ Récupération de clé hôte si absent de known_hosts — `_fetch_host_key(ip, p
 `expire_keys()` :
 - Clés ACTIVE avec expires_at < NOW()
 - **Requête SQL doit sélectionner s.ip_address** (#114)
+- **Requête SQL exclut `unix_user != 'root'`** — sécurité contre révocation automatique de root
 - sam-revoke sur serveur distant via IP
 - status=EXPIRED, revoked_automatically=TRUE, audit_log KEY_EXPIRED, email INFO
 
@@ -169,14 +170,16 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 ### Clés SSH
 - `validate_key(fingerprint, admin_id, unix_user=None, hostname=None)` — sans args : valide toutes PENDING_REVIEW du fingerprint ; avec args : valide uniquement (fingerprint, server, unix_user) (#193)
 - `bulk_validate_keys(fingerprints, admin_id)` — valide en masse une liste de fingerprints PENDING_REVIEW ; retourne `{validated: N, errors: [...]}`
-- `bulk_revoke_keys(fingerprints, reason, admin_id)` — révoque en masse ; retourne `{revoked: N, errors: [...]}`
-- `revoke_key(fingerprint, admin_id, reason, db)` — ACTIVE et PENDING_REVIEW (#85)
+- `bulk_revoke_keys(fingerprints, reason, admin_id)` — révoque en masse ; retourne `{revoked: N, errors: [...]}` ; les fingerprints liés à root sont automatiquement skippés (UserError catchée → skipped+1)
+- `revoke_key(fingerprint, admin_id, reason, hostname=None, unix_user=None)` — ACTIVE et PENDING_REVIEW (#85) ; refuse si `unix_user == 'root'` (targeted) ou si root a ce fingerprint (global) → UserError
 - `handle_disappeared_key`, `handle_unknown_key`, `handle_reappeared_key`
-- `warn_expiring_key`, `assign_key`, `set_key_expiry`, `remove_key_expiry`
+- `warn_expiring_key`, `assign_key`
+- `set_key_expiry(fingerprint, expires_at, unix_user=None, hostname=None)` — refuse si `unix_user == 'root'` ; global UPDATE exclut `unix_user != 'root'`
+- `remove_key_expiry(fingerprint, unix_user=None, hostname=None)` — refuse si `unix_user == 'root'` ; global UPDATE exclut `unix_user != 'root'`
 
 ### Accès temporaires
 - `grant_access`, `approve_request`, `reject_request`, `revoke_request`
-- `deploy_key(public_key, unix_user, hostname, expires_at, justification, admin_id)` — parse + fingerprint, INSERT ssh_keys, sam-add, key_authorization ACTIVE (#164, #185)
+- `deploy_key(public_key, unix_user, hostname, expires_at, justification, admin_id)` — parse + fingerprint, INSERT ssh_keys, sam-add, key_authorization ACTIVE (#164, #185) ; refuse si `unix_user == 'root'` ; `justification` inclus dans le `details` du `audit_log` KEY_ADDED
 - `lock_user(unix_user, hostname, admin_id)` — valide username POSIX, sam-lock-user, USER_LOCKED (#181)
 - `unlock_user(unix_user, hostname, admin_id)` — valide username POSIX, sam-unlock-user, USER_UNLOCKED (#181)
 
@@ -240,7 +243,7 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - Couverture minimale actions.py : 80%
 - pytest doit passer avant tout commit
 
-Fichiers : conftest.py, test_db.py (7), test_servers.py (10), test_ssh.py (66), test_actions.py (154), test_collect.py (35), test_expire.py (16), test_alerts.py (23), test_web.py (172), test_manage.py (46), test_rbac.py (3).
+Fichiers : conftest.py, test_db.py (7), test_servers.py (10), test_ssh.py (66), test_actions.py (176), test_collect.py (35), test_expire.py (16), test_alerts.py (23), test_web.py (172), test_manage.py (46), test_rbac.py (3).
 
 Fixtures obligatoires dans conftest.py : `mock_db`, `mock_ssh_client`, `mock_smtp`, `sample_server`, `sample_key`.
 

--- a/app/actions.py
+++ b/app/actions.py
@@ -195,6 +195,8 @@ def revoke_key(
 
     if hostname and unix_user:
         # --- Targeted revocation (one user on one server) ---
+        if unix_user == "root":
+            raise UserError("Cannot revoke the root account's SSH key — this would cause permanent loss of server access")
         server = db.query_one(
             "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s",
             (hostname,),
@@ -240,6 +242,19 @@ def revoke_key(
         )
     else:
         # --- Global revocation (all servers, all users) ---
+        root_auth = db.query_one(
+            """
+            SELECT 1 FROM key_authorizations
+            WHERE key_id = %s AND unix_user = 'root'
+              AND status IN ('ACTIVE', 'PENDING_REVIEW')
+            """,
+            (key["id"],),
+        )
+        if root_auth:
+            raise UserError(
+                "Cannot revoke this key globally — it is deployed for the root account. "
+                "Use targeted revocation for specific non-root users."
+            )
         active_auths = db.query(
             """
             SELECT DISTINCT ka.server_id, s.hostname, s.ip_address, s.ssh_port
@@ -495,28 +510,75 @@ def assign_key(fingerprint: str, owner_name: str) -> None:
     )
 
 
-def set_key_expiry(fingerprint: str, expires_at: datetime) -> None:
-    """Set expiration on all ACTIVE authorizations for a key."""
+def set_key_expiry(
+    fingerprint: str,
+    expires_at: datetime,
+    unix_user: str | None = None,
+    hostname: str | None = None,
+) -> None:
+    """Set expiration on ACTIVE authorizations for a key.
+
+    If unix_user and hostname are provided, updates only the specific
+    (key, server, unix_user) authorization. Otherwise, updates all
+    ACTIVE authorizations for the key.
+    """
+    if unix_user == "root":
+        raise UserError("Cannot set an expiry on root's SSH key — this would revoke root access automatically")
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise NotFoundError(f"Key not found: {fingerprint}")
-    db.execute(
-        "UPDATE key_authorizations SET expires_at = %s WHERE key_id = %s AND status = 'ACTIVE'",
-        (expires_at, key["id"]),
-    )
+
+    if unix_user is not None and hostname is not None:
+        server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+        if not server:
+            raise NotFoundError(f"Server not found: {hostname}")
+        db.execute(
+            "UPDATE key_authorizations SET expires_at = %s"
+            " WHERE key_id = %s AND unix_user = %s AND server_id = %s AND status = 'ACTIVE'",
+            (expires_at, key["id"], unix_user, server["id"]),
+        )
+    else:
+        db.execute(
+            "UPDATE key_authorizations SET expires_at = %s"
+            " WHERE key_id = %s AND status = 'ACTIVE' AND unix_user != 'root'",
+            (expires_at, key["id"]),
+        )
 
 
-def remove_key_expiry(fingerprint: str) -> None:
-    """Remove expiration from all ACTIVE authorizations for a key."""
+def remove_key_expiry(
+    fingerprint: str,
+    unix_user: str | None = None,
+    hostname: str | None = None,
+) -> None:
+    """Remove expiration from ACTIVE authorizations for a key.
+
+    If unix_user and hostname are provided, updates only the specific
+    (key, server, unix_user) authorization. Otherwise, updates all
+    ACTIVE authorizations for the key (root excluded).
+    """
+    if unix_user == "root":
+        raise UserError("Cannot modify the expiry of the root account's SSH key")
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
         raise NotFoundError(f"Key not found: {fingerprint}")
-    db.execute(
-        "UPDATE key_authorizations SET expires_at = NULL WHERE key_id = %s AND status = 'ACTIVE'",
-        (key["id"],),
-    )
+
+    if unix_user is not None and hostname is not None:
+        server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+        if not server:
+            raise NotFoundError(f"Server not found: {hostname}")
+        db.execute(
+            "UPDATE key_authorizations SET expires_at = NULL"
+            " WHERE key_id = %s AND unix_user = %s AND server_id = %s AND status = 'ACTIVE'",
+            (key["id"], unix_user, server["id"]),
+        )
+    else:
+        db.execute(
+            "UPDATE key_authorizations SET expires_at = NULL"
+            " WHERE key_id = %s AND status = 'ACTIVE' AND unix_user != 'root'",
+            (key["id"],),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -580,6 +642,15 @@ def _get_current_group(unix_user: str, hostname: str) -> str | None:
     return row["sam_group"] if row else None
 
 
+def _has_active_session(unix_user: str, server_id) -> bool:
+    """Return True if unix_user has an active SSH session on this server (from last scan)."""
+    row = db.query_one(
+        "SELECT 1 FROM ssh_sessions WHERE server_id = %s AND unix_user = %s AND is_active = true LIMIT 1",
+        (server_id, unix_user),
+    )
+    return row is not None
+
+
 def deploy_key(
     public_key: str,
     unix_user: str,
@@ -593,6 +664,8 @@ def deploy_key(
     Register public key in ssh_keys (if not exists), deploy via sam-add,
     create key_authorization ACTIVE with optional expiry.
     """
+    if unix_user == "root":
+        raise UserError("Cannot deploy a key for the root account")
     if not _UNIX_USER_RE.match(unix_user):
         raise UserError(
             f"Invalid Unix username: '{unix_user}' "
@@ -675,7 +748,7 @@ def deploy_key(
             admin_id,
             key["id"],
             server["id"],
-            json.dumps({"unix_user": unix_user, "fingerprint": fingerprint, "hostname": hostname, "sam_group": sam_group}),
+            json.dumps({"unix_user": unix_user, "fingerprint": fingerprint, "hostname": hostname, "sam_group": sam_group, "justification": justification}),
         ),
     )
     return {
@@ -690,6 +763,8 @@ def deploy_key(
 
 def grant_group(unix_user: str, hostname: str, group: str, admin_id: str) -> dict:
     """Assign a SAM sudo group to a unix_user on a server."""
+    if unix_user == "root":
+        raise UserError("Cannot assign a SAM group to the root account")
     if group not in VALID_SAM_GROUPS:
         raise UserError(f"Invalid SAM group: '{group}'. Must be one of: {', '.join(VALID_SAM_GROUPS)}")
     server = db.query_one(
@@ -698,13 +773,15 @@ def grant_group(unix_user: str, hostname: str, group: str, admin_id: str) -> dic
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
-    active = db.query_one(
+    if _has_active_session(unix_user, server["id"]):
+        raise UserError(f"User '{unix_user}' has an active session on {hostname} — group change blocked to avoid interrupting ongoing operations")
+    row = db.query_one(
         "SELECT 1 FROM key_authorizations WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (server["id"], unix_user),
     )
-    if not active:
-        raise UserError(f"No active key deployment for user '{unix_user}' on {hostname}")
-    ssh.grant_group_on_server(hostname, unix_user, group, server["ip_address"], port=server["ssh_port"])
+    if not row:
+        raise UserError(f"No active key deployment for {unix_user} on {hostname}")
+    actual_groups = ssh.grant_group_on_server(hostname, unix_user, group, server["ip_address"], port=server["ssh_port"])
     db.execute(
         "UPDATE key_authorizations SET sam_group = %s WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (group, server["id"], unix_user),
@@ -714,43 +791,50 @@ def grant_group(unix_user: str, hostname: str, group: str, admin_id: str) -> dic
         INSERT INTO audit_log (action, performed_by, target_server, details)
         VALUES ('GROUP_GRANTED', %s, %s, %s::jsonb)
         """,
-        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "group": group, "hostname": hostname})),
+        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "hostname": hostname, "sam_group": group})),
     )
-    return {"unix_user": unix_user, "hostname": hostname, "sam_group": group}
+    return {"unix_user": unix_user, "hostname": hostname, "sam_group": group, "actual_groups": actual_groups}
 
 
 def revoke_group(unix_user: str, hostname: str, admin_id: str) -> dict:
-    """Remove the SAM sudo group from a unix_user on a server."""
+    """Remove SAM sudo group from unix_user on a server. Works even if no group is currently set (force-strips server)."""
+    if unix_user == "root":
+        raise UserError("Cannot modify the SAM group of the root account")
     server = db.query_one(
         "SELECT id, ip_address, ssh_port FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,),
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
+    if _has_active_session(unix_user, server["id"]):
+        raise UserError(f"User '{unix_user}' has an active session on {hostname} — group change blocked to avoid interrupting ongoing operations")
     row = db.query_one(
-        "SELECT sam_group FROM key_authorizations WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE' AND sam_group IS NOT NULL",
+        "SELECT sam_group FROM key_authorizations WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (server["id"], unix_user),
     )
     if not row:
-        raise UserError(f"User '{unix_user}' on {hostname} has no SAM group assigned")
+        raise UserError(f"No active key deployment for {unix_user} on {hostname}")
     current_group = row["sam_group"]
-    ssh.revoke_group_on_server(hostname, unix_user, current_group, server["ip_address"], port=server["ssh_port"])
-    db.execute(
-        "UPDATE key_authorizations SET sam_group = NULL WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
-        (server["id"], unix_user),
-    )
-    db.execute(
-        """
-        INSERT INTO audit_log (action, performed_by, target_server, details)
-        VALUES ('GROUP_REVOKED', %s, %s, %s::jsonb)
-        """,
-        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "group": current_group, "hostname": hostname})),
-    )
-    return {"unix_user": unix_user, "hostname": hostname, "sam_group": None}
+    actual_groups = ssh.revoke_group_on_server(hostname, unix_user, current_group, server["ip_address"], port=server["ssh_port"])
+    if current_group is not None:
+        db.execute(
+            "UPDATE key_authorizations SET sam_group = NULL WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
+            (server["id"], unix_user),
+        )
+        db.execute(
+            """
+            INSERT INTO audit_log (action, performed_by, target_server, details)
+            VALUES ('GROUP_REVOKED', %s, %s, %s::jsonb)
+            """,
+            (admin_id, server["id"], json.dumps({"unix_user": unix_user, "hostname": hostname, "sam_group": current_group})),
+        )
+    return {"unix_user": unix_user, "hostname": hostname, "sam_group": None, "actual_groups": actual_groups}
 
 
 def change_group(unix_user: str, hostname: str, new_group: str, admin_id: str) -> dict:
-    """Change the SAM sudo group of a unix_user on a server."""
+    """Change SAM sudo group for unix_user on a server. Re-applies even if same group."""
+    if unix_user == "root":
+        raise UserError("Cannot modify the SAM group of the root account")
     if new_group not in VALID_SAM_GROUPS:
         raise UserError(f"Invalid SAM group: '{new_group}'. Must be one of: {', '.join(VALID_SAM_GROUPS)}")
     server = db.query_one(
@@ -759,18 +843,18 @@ def change_group(unix_user: str, hostname: str, new_group: str, admin_id: str) -
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
+    if _has_active_session(unix_user, server["id"]):
+        raise UserError(f"User '{unix_user}' has an active session on {hostname} — group change blocked to avoid interrupting ongoing operations")
     row = db.query_one(
         "SELECT sam_group FROM key_authorizations WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (server["id"], unix_user),
     )
     if not row:
-        raise UserError(f"No active key deployment for user '{unix_user}' on {hostname}")
+        raise UserError(f"No active key deployment for {unix_user} on {hostname}")
     old_group = row["sam_group"]
-    if old_group == new_group:
-        return {"unix_user": unix_user, "hostname": hostname, "sam_group": new_group}
-    if old_group:
+    if old_group and old_group != new_group:
         ssh.revoke_group_on_server(hostname, unix_user, old_group, server["ip_address"], port=server["ssh_port"])
-    ssh.grant_group_on_server(hostname, unix_user, new_group, server["ip_address"], port=server["ssh_port"])
+    actual_groups = ssh.grant_group_on_server(hostname, unix_user, new_group, server["ip_address"], port=server["ssh_port"])
     db.execute(
         "UPDATE key_authorizations SET sam_group = %s WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (new_group, server["id"], unix_user),
@@ -780,11 +864,9 @@ def change_group(unix_user: str, hostname: str, new_group: str, admin_id: str) -
         INSERT INTO audit_log (action, performed_by, target_server, details)
         VALUES ('GROUP_CHANGED', %s, %s, %s::jsonb)
         """,
-        (admin_id, server["id"], json.dumps({
-            "unix_user": unix_user, "old_group": old_group, "new_group": new_group, "hostname": hostname,
-        })),
+        (admin_id, server["id"], json.dumps({"unix_user": unix_user, "hostname": hostname, "old_group": old_group, "new_group": new_group})),
     )
-    return {"unix_user": unix_user, "hostname": hostname, "sam_group": new_group}
+    return {"unix_user": unix_user, "hostname": hostname, "sam_group": new_group, "actual_groups": actual_groups}
 
 
 def approve_request(request_id: str, admin_id: str) -> None:
@@ -1266,6 +1348,8 @@ def delete_admin(username: str, admin_id: str | None = None) -> None:
 
 def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     """Lock a Unix user account on a remote server."""
+    if unix_user == "root":
+        raise UserError("Cannot lock the root account")
     if unix_user == ssh.SSH_USER:
         raise UserError(f"Cannot lock the collector account '{ssh.SSH_USER}'")
     if not _UNIX_USER_RE.match(unix_user):
@@ -1288,6 +1372,8 @@ def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
 
 def unlock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     """Unlock a Unix user account on a remote server."""
+    if unix_user == "root":
+        raise UserError("Cannot unlock the root account")
     if unix_user == ssh.SSH_USER:
         raise UserError(f"Cannot unlock the collector account '{ssh.SSH_USER}'")
     if not _UNIX_USER_RE.match(unix_user):

--- a/app/expire.py
+++ b/app/expire.py
@@ -70,6 +70,7 @@ def expire_keys() -> int:
         WHERE ka.status = 'ACTIVE'
           AND ka.expires_at IS NOT NULL
           AND ka.expires_at <= now()
+          AND ka.unix_user != 'root'
         """,
         (),
     )

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -158,14 +158,14 @@ if ! id "$TARGET_USER" >/dev/null 2>&1; then
     useradd -m -s /bin/bash "$TARGET_USER"
     TMPPASS=$(openssl rand -base64 12 | tr -d '\\n')
     printf '%s:%s\\n' "$TARGET_USER" "$TMPPASS" | chpasswd
-    usermod -aG sam-users "$TARGET_USER" 2>/dev/null || true
+    gpasswd -a "$TARGET_USER" sam-users 2>/dev/null || true
 fi
 
 for grp in sam-operator sam-pkg sam-root; do
     getent group "$grp" >/dev/null 2>&1 && gpasswd -d "$TARGET_USER" "$grp" 2>/dev/null || true
 done
 if [ -n "$TARGET_GROUP" ]; then
-    usermod -aG "$TARGET_GROUP" "$TARGET_USER"
+    gpasswd -a "$TARGET_USER" "$TARGET_GROUP"
 fi
 
 home=$(getent passwd "$TARGET_USER" | cut -d: -f6)
@@ -311,28 +311,46 @@ case "$GROUP" in
     sam-operator|sam-pkg|sam-root) ;;
     *) echo "Error: group must be sam-operator, sam-pkg or sam-root" >&2; exit 1 ;;
 esac
-usermod -aG "$GROUP" "$USERNAME"
+gpasswd -a "$USERNAME" "$GROUP"
+printf 'GROUPS:%s\\n' "$(id -Gn "$USERNAME" 2>/dev/null || echo '')"
 """
 
 SAM_REVOKE_GROUP = b"""#!/bin/sh
-# sam-revoke-group <unix_user> <group> - remove unix_user from a sam-* group
+# sam-revoke-group <unix_user> [group]
+# If group given: remove from that group only.
+# If no group: remove from all sam-* groups (sync to none).
 set -e
 USERNAME="$1"
-GROUP="$2"
-if [ -z "$USERNAME" ] || [ -z "$GROUP" ]; then
-    echo "Usage: sam-revoke-group <unix_user> <group>" >&2
+GROUP="${2:-}"
+if [ -z "$USERNAME" ]; then
+    echo "Usage: sam-revoke-group <unix_user> [group]" >&2
     exit 1
 fi
-case "$GROUP" in
-    sam-operator|sam-pkg|sam-root) ;;
-    *) echo "Error: group must be sam-operator, sam-pkg or sam-root" >&2; exit 1 ;;
-esac
-gpasswd -d "$USERNAME" "$GROUP" 2>/dev/null || true
+if [ -n "$GROUP" ]; then
+    case "$GROUP" in
+        sam-operator|sam-pkg|sam-root) ;;
+        *) echo "Error: group must be sam-operator, sam-pkg or sam-root" >&2; exit 1 ;;
+    esac
+    gpasswd -d "$USERNAME" "$GROUP" 2>/dev/null || true
+else
+    for grp in sam-operator sam-pkg sam-root; do
+        getent group "$grp" >/dev/null 2>&1 && gpasswd -d "$USERNAME" "$grp" 2>/dev/null || true
+    done
+fi
+printf 'GROUPS:%s\\n' "$(id -Gn "$USERNAME" 2>/dev/null || echo '')"
 """
 
 
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def _parse_groups_output(out: str) -> list[str]:
+    """Parse GROUPS: line from SAM script output and return list of groups."""
+    for line in out.splitlines():
+        if line.startswith("GROUPS:"):
+            return line[7:].split()
+    return []
 
 
 def _connect(ip: str, port: int = 22) -> paramiko.SSHClient:
@@ -487,30 +505,32 @@ def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22
         client.close()
 
 
-def grant_group_on_server(hostname: str, unix_user: str, group: str, ip: str, port: int = 22) -> None:
-    """Run sam-grant-group on the remote host to add unix_user to a sam-* group."""
+def grant_group_on_server(hostname: str, unix_user: str, group: str, ip: str, port: int = 22) -> list[str]:
+    """Run sam-grant-group on the remote host. Returns actual groups of unix_user after change."""
     client = _connect(ip, port)
     try:
-        _, err, rc = _run(
+        out, err, rc = _run(
             client,
             f"sudo {SAM_GRANT_GROUP_PATH} {shlex.quote(unix_user)} {shlex.quote(group)}",
         )
         if rc != 0:
             raise SSHError(f"sam-grant-group failed on {hostname} (rc={rc}): {err}")
+        return _parse_groups_output(out)
     finally:
         client.close()
 
 
-def revoke_group_on_server(hostname: str, unix_user: str, group: str, ip: str, port: int = 22) -> None:
-    """Run sam-revoke-group on the remote host to remove unix_user from a sam-* group."""
+def revoke_group_on_server(hostname: str, unix_user: str, group: str | None, ip: str, port: int = 22) -> list[str]:
+    """Run sam-revoke-group on the remote host. group=None strips all sam-* groups. Returns actual groups."""
+    cmd = f"sudo {SAM_REVOKE_GROUP_PATH} {shlex.quote(unix_user)}"
+    if group:
+        cmd += f" {shlex.quote(group)}"
     client = _connect(ip, port)
     try:
-        _, err, rc = _run(
-            client,
-            f"sudo {SAM_REVOKE_GROUP_PATH} {shlex.quote(unix_user)} {shlex.quote(group)}",
-        )
+        out, err, rc = _run(client, cmd)
         if rc != 0:
             raise SSHError(f"sam-revoke-group failed on {hostname} (rc={rc}): {err}")
+        return _parse_groups_output(out)
     finally:
         client.close()
 

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -59,7 +59,7 @@ def test_actions_validate_key_raises_if_no_pending(sample_key):
 def test_actions_revoke_key_scenario1_calls_sam_revoke(sample_key):
     auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
-        mock_db.query_one.return_value = {"id": KEY_ID}
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, None]  # key found, no root auth
         mock_db.query.return_value = [auth]
         actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "test reason")
         mock_ssh.revoke_on_server.assert_called_once_with(
@@ -70,7 +70,7 @@ def test_actions_revoke_key_scenario1_calls_sam_revoke(sample_key):
 def test_actions_revoke_key_scenario1_sets_revoked_by_admin(sample_key):
     auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
-        mock_db.query_one.return_value = {"id": KEY_ID}
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, None]
         mock_db.query.return_value = [auth]
         actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "test reason")
         update_call = mock_db.execute.call_args_list[0]
@@ -81,7 +81,7 @@ def test_actions_revoke_key_scenario1_sets_revoked_by_admin(sample_key):
 def test_actions_revoke_key_scenario1_logs_key_revoked(sample_key):
     auth = {"server_id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
-        mock_db.query_one.return_value = {"id": KEY_ID}
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, None]
         mock_db.query.return_value = [auth]
         actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "test reason")
         audit_call = mock_db.execute.call_args_list[1]
@@ -282,12 +282,41 @@ def test_actions_assign_key_raises_if_key_not_found():
 # set_key_expiry / remove_key_expiry
 # ---------------------------------------------------------------------------
 
+def test_actions_set_key_expiry_root_raises():
+    with pytest.raises(UserError, match="Cannot set an expiry on root"):
+        actions.set_key_expiry("SHA256:abc", datetime.now(), unix_user="root", hostname="server")
+
+
 def test_actions_set_key_expiry_updates_active_auths(sample_key):
+    """set_key_expiry without unix_user/hostname updates all ACTIVE auths."""
     expires_at = _future()
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": KEY_ID}
         actions.set_key_expiry(sample_key["fingerprint"], expires_at)
-        assert expires_at in mock_db.execute.call_args[0][1]
+        sql = mock_db.execute.call_args[0][0]
+        params = mock_db.execute.call_args[0][1]
+        assert "UPDATE key_authorizations" in sql
+        assert "status = 'ACTIVE'" in sql
+        assert "unix_user != 'root'" in sql
+        assert expires_at in params
+
+
+def test_actions_set_key_expiry_scoped_to_unix_user(sample_key, sample_server):
+    """set_key_expiry with unix_user and hostname updates only that specific auth."""
+    expires_at = _future()
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            {"id": SERVER_ID},
+        ]
+        actions.set_key_expiry(
+            sample_key["fingerprint"], expires_at, unix_user="alice", hostname=sample_server["hostname"]
+        )
+        sql = mock_db.execute.call_args[0][0]
+        params = mock_db.execute.call_args[0][1]
+        assert "UPDATE key_authorizations" in sql
+        assert "WHERE key_id = %s AND unix_user = %s AND server_id = %s AND status = 'ACTIVE'" in sql
+        assert params == (expires_at, KEY_ID, "alice", SERVER_ID)
 
 
 def test_actions_set_key_expiry_raises_if_key_not_found(sample_key):
@@ -297,11 +326,88 @@ def test_actions_set_key_expiry_raises_if_key_not_found(sample_key):
             actions.set_key_expiry(sample_key["fingerprint"], _future())
 
 
+def test_actions_set_key_expiry_raises_if_server_not_found(sample_key):
+    """set_key_expiry raises NotFoundError if hostname doesn't exist."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            None,
+        ]
+        with pytest.raises(UserError, match="Server not found"):
+            actions.set_key_expiry(sample_key["fingerprint"], _future(), unix_user="alice", hostname="ghost")
+
+
 def test_actions_remove_key_expiry_sets_null(sample_key):
+    """remove_key_expiry without unix_user/hostname updates all ACTIVE auths."""
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {"id": KEY_ID}
         actions.remove_key_expiry(sample_key["fingerprint"])
-        assert "NULL" in mock_db.execute.call_args[0][0]
+        sql = mock_db.execute.call_args[0][0]
+        assert "NULL" in sql
+        assert "status = 'ACTIVE'" in sql
+        assert "unix_user != 'root'" in sql
+
+
+def test_actions_remove_key_expiry_scoped_to_unix_user(sample_key, sample_server):
+    """remove_key_expiry with unix_user and hostname updates only that specific auth."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            {"id": SERVER_ID},
+        ]
+        actions.remove_key_expiry(
+            sample_key["fingerprint"], unix_user="bob", hostname=sample_server["hostname"]
+        )
+        sql = mock_db.execute.call_args[0][0]
+        params = mock_db.execute.call_args[0][1]
+        assert "UPDATE key_authorizations" in sql
+        assert "expires_at = NULL" in sql
+        assert "WHERE key_id = %s AND unix_user = %s AND server_id = %s AND status = 'ACTIVE'" in sql
+        assert params == (KEY_ID, "bob", SERVER_ID)
+
+
+def test_actions_remove_key_expiry_raises_if_server_not_found(sample_key):
+    """remove_key_expiry raises NotFoundError if hostname doesn't exist."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": KEY_ID},
+            None,
+        ]
+        with pytest.raises(UserError, match="Server not found"):
+            actions.remove_key_expiry(sample_key["fingerprint"], unix_user="alice", hostname="ghost")
+
+
+def test_actions_set_key_expiry_global_excludes_root(sample_key):
+    """set_key_expiry global UPDATE must exclude unix_user = 'root'."""
+    from datetime import datetime, timezone
+    expires = datetime.now(tz=timezone.utc)
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": KEY_ID}
+        actions.set_key_expiry(sample_key["fingerprint"], expires)
+        sql = mock_db.execute.call_args[0][0]
+        assert "unix_user != 'root'" in sql
+
+
+def test_actions_set_key_expiry_root_targeted_raises(sample_key):
+    """set_key_expiry with unix_user=root must raise UserError."""
+    from datetime import datetime, timezone
+    with pytest.raises(UserError, match="root"):
+        actions.set_key_expiry(sample_key["fingerprint"], datetime.now(tz=timezone.utc), unix_user="root")
+
+
+def test_actions_remove_key_expiry_root_targeted_raises(sample_key):
+    """remove_key_expiry with unix_user=root must raise UserError."""
+    with pytest.raises(UserError, match="root"):
+        actions.remove_key_expiry(sample_key["fingerprint"], unix_user="root")
+
+
+def test_actions_remove_key_expiry_global_excludes_root(sample_key):
+    """remove_key_expiry global UPDATE must exclude unix_user = 'root'."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": KEY_ID}
+        actions.remove_key_expiry(sample_key["fingerprint"])
+        sql = mock_db.execute.call_args[0][0]
+        assert "unix_user != 'root'" in sql
 
 
 # ---------------------------------------------------------------------------
@@ -881,6 +987,40 @@ def test_actions_revoke_key_rejects_invalid_fingerprint_format():
         actions.revoke_key("INVALID:abc", ADMIN_ID, "test")
 
 
+def test_actions_revoke_key_targeted_root_raises():
+    """Targeted revoke with unix_user=root must be rejected."""
+    fp = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": "key-uuid"}
+        with pytest.raises(UserError, match="root"):
+            actions.revoke_key(fp, ADMIN_ID, "test", hostname="server-01", unix_user="root")
+
+
+def test_actions_revoke_key_global_blocks_when_root_has_key():
+    """Global revoke must be rejected if root has this key deployed."""
+    fp = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": "key-uuid"},   # ssh_keys lookup
+            {"1": 1},             # root_auth check → root has this key
+        ]
+        with pytest.raises(UserError, match="root"):
+            actions.revoke_key(fp, ADMIN_ID, "test")
+
+
+def test_actions_revoke_key_global_proceeds_when_no_root_auth():
+    """Global revoke proceeds normally when root does not have this key."""
+    fp = "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_db.query_one.side_effect = [
+            {"id": "key-uuid"},   # ssh_keys lookup
+            None,                 # root_auth check → root does NOT have this key
+        ]
+        mock_db.query.return_value = []
+        actions.revoke_key(fp, ADMIN_ID, "test")
+        mock_db.query.assert_called_once()
+
+
 def test_actions_assign_key_rejects_invalid_fingerprint_format():
     with pytest.raises(UserError, match="Invalid fingerprint format"):
         actions.assign_key("sha256:lowercase", "alice")
@@ -962,6 +1102,16 @@ def test_actions_unlock_user_ssh_user_raises():
         mock_ssh.SSH_USER = "audit-collector"
         with pytest.raises(UserError, match="Cannot unlock the collector account"):
             actions.unlock_user("audit-collector", "server-test-01", ADMIN_ID)
+
+
+def test_actions_lock_user_root_raises():
+    with pytest.raises(UserError, match="Cannot lock the root account"):
+        actions.lock_user("root", "server-test-01", ADMIN_ID)
+
+
+def test_actions_unlock_user_root_raises():
+    with pytest.raises(UserError, match="Cannot unlock the root account"):
+        actions.unlock_user("root", "server-test-01", ADMIN_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -1510,6 +1660,28 @@ def test_actions_deploy_key_invalid_sam_group_raises(sample_server, sample_key):
             )
 
 
+def test_actions_deploy_key_justification_stored_in_audit_log(sample_server, sample_key):
+    """deploy_key must include justification in the KEY_ADDED audit_log details."""
+    with patch("actions.db") as mock_db, patch("actions.ssh"):
+        mock_db.query_one.side_effect = [
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            {"id": sample_key["id"]},
+        ]
+        actions.deploy_key(
+            public_key=sample_key["public_key"],
+            unix_user="alice",
+            hostname=sample_server["hostname"],
+            expires_at=None,
+            justification="Security audit Q2",
+            admin_id=ADMIN_ID,
+        )
+        audit_call = mock_db.execute.call_args_list[-1]
+        assert "KEY_ADDED" in audit_call[0][0]
+        import json
+        details = json.loads(audit_call[0][1][-1])
+        assert details["justification"] == "Security audit Q2"
+
+
 def test_actions_deploy_key_no_sam_group_passes_none_to_add_key(sample_server, sample_key):
     """deploy_key with no group passes sam_group=None — sam-add strips all SAM groups."""
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
@@ -1539,8 +1711,10 @@ def test_actions_deploy_key_no_sam_group_passes_none_to_add_key(sample_server, s
 
 def test_actions_grant_group_success(sample_server):
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"id": "ka-id"},
         ]
         result = actions.grant_group("alice", sample_server["hostname"], "sam-operator", ADMIN_ID)
@@ -1550,6 +1724,11 @@ def test_actions_grant_group_success(sample_server):
             sample_server["hostname"], "alice", "sam-operator",
             sample_server["ip_address"], port=22,
         )
+
+
+def test_actions_grant_group_root_raises():
+    with pytest.raises(UserError, match="Cannot assign a SAM group to the root account"):
+        actions.grant_group("root", "server", "sam-pkg", ADMIN_ID)
 
 
 def test_actions_grant_group_invalid_group_raises():
@@ -1568,16 +1747,19 @@ def test_actions_grant_group_no_active_deployment_raises(sample_server):
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
-            None,
+            None,  # no active session
+            None,  # no key_authorization
         ]
         with pytest.raises(UserError, match="No active key deployment"):
             actions.grant_group("alice", sample_server["hostname"], "sam-root", ADMIN_ID)
 
 
 def test_actions_grant_group_logs_group_granted(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"id": "ka-id"},
         ]
         actions.grant_group("alice", sample_server["hostname"], "sam-pkg", ADMIN_ID)
@@ -1586,13 +1768,29 @@ def test_actions_grant_group_logs_group_granted(sample_server):
 
 
 # ---------------------------------------------------------------------------
+# grant_group — active session blocking
+# ---------------------------------------------------------------------------
+
+def test_actions_grant_group_active_session_blocks(sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            {"unix_user": "alice"},  # active session found
+        ]
+        with pytest.raises(UserError, match="active session"):
+            actions.grant_group("alice", sample_server["hostname"], "sam-operator", ADMIN_ID)
+
+
+# ---------------------------------------------------------------------------
 # revoke_group
 # ---------------------------------------------------------------------------
 
 def test_actions_revoke_group_success(sample_server):
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.revoke_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": "sam-operator"},
         ]
         result = actions.revoke_group("alice", sample_server["hostname"], ADMIN_ID)
@@ -1603,6 +1801,11 @@ def test_actions_revoke_group_success(sample_server):
         )
 
 
+def test_actions_revoke_group_root_raises():
+    with pytest.raises(UserError, match="Cannot modify the SAM group of the root account"):
+        actions.revoke_group("root", "server", ADMIN_ID)
+
+
 def test_actions_revoke_group_server_not_found_raises():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None
@@ -1610,20 +1813,23 @@ def test_actions_revoke_group_server_not_found_raises():
             actions.revoke_group("alice", "unknown-server", ADMIN_ID)
 
 
-def test_actions_revoke_group_no_group_raises(sample_server):
+def test_actions_revoke_group_no_deployment_raises(sample_server):
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
-            None,
+            None,  # no active session
+            None,  # no key_authorization at all
         ]
-        with pytest.raises(UserError, match="no SAM group assigned"):
+        with pytest.raises(UserError, match="No active key deployment"):
             actions.revoke_group("alice", sample_server["hostname"], ADMIN_ID)
 
 
 def test_actions_revoke_group_logs_group_revoked(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.revoke_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": "sam-root"},
         ]
         actions.revoke_group("alice", sample_server["hostname"], ADMIN_ID)
@@ -1631,14 +1837,49 @@ def test_actions_revoke_group_logs_group_revoked(sample_server):
         assert "GROUP_REVOKED" in audit_call[0][0]
 
 
+def test_actions_revoke_group_active_session_blocks(sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            {"unix_user": "alice"},  # active session found
+        ]
+        with pytest.raises(UserError, match="active session"):
+            actions.revoke_group("alice", sample_server["hostname"], ADMIN_ID)
+
+
+def test_actions_revoke_group_no_group_in_db_still_strips_server(sample_server):
+    """revoke_group with sam_group=None in DB should still run strip command on server."""
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.revoke_group_on_server.return_value = ["sam-users"]
+        mock_db.query_one.side_effect = [
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
+            {"sam_group": None},  # no group in DB
+        ]
+        result = actions.revoke_group("alice", sample_server["hostname"], ADMIN_ID)
+        assert result["sam_group"] is None
+        mock_ssh.revoke_group_on_server.assert_called_once_with(
+            sample_server["hostname"], "alice", None,
+            sample_server["ip_address"], port=22,
+        )
+
+
 # ---------------------------------------------------------------------------
 # change_group
 # ---------------------------------------------------------------------------
 
+def test_actions_change_group_root_raises():
+    with pytest.raises(UserError, match="Cannot modify the SAM group of the root account"):
+        actions.change_group("root", "server", "sam-pkg", ADMIN_ID)
+
+
 def test_actions_change_group_success(sample_server):
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = []
+        mock_ssh.revoke_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": "sam-operator"},
         ]
         result = actions.change_group("alice", sample_server["hostname"], "sam-pkg", ADMIN_ID)
@@ -1647,22 +1888,26 @@ def test_actions_change_group_success(sample_server):
         mock_ssh.grant_group_on_server.assert_called_once()
 
 
-def test_actions_change_group_noop_when_same(sample_server):
+def test_actions_change_group_reapplies_when_same(sample_server):
+    """change_group should re-apply even when group is identical (force sync)."""
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = ["sam-users", "sam-pkg"]
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": "sam-pkg"},
         ]
         result = actions.change_group("alice", sample_server["hostname"], "sam-pkg", ADMIN_ID)
         assert result["sam_group"] == "sam-pkg"
-        mock_ssh.revoke_group_on_server.assert_not_called()
-        mock_ssh.grant_group_on_server.assert_not_called()
+        mock_ssh.grant_group_on_server.assert_called_once()
 
 
 def test_actions_change_group_from_none_does_not_revoke(sample_server):
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": None},
         ]
         actions.change_group("alice", sample_server["hostname"], "sam-root", ADMIN_ID)
@@ -1686,18 +1931,32 @@ def test_actions_change_group_no_deployment_raises(sample_server):
     with patch("actions.db") as mock_db:
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
-            None,
+            None,  # no active session
+            None,  # no key_authorization
         ]
         with pytest.raises(UserError, match="No active key deployment"):
             actions.change_group("alice", sample_server["hostname"], "sam-operator", ADMIN_ID)
 
 
 def test_actions_change_group_logs_group_changed(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.grant_group_on_server.return_value = []
+        mock_ssh.revoke_group_on_server.return_value = []
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            None,  # no active session
             {"sam_group": "sam-operator"},
         ]
         actions.change_group("alice", sample_server["hostname"], "sam-pkg", ADMIN_ID)
         audit_call = mock_db.execute.call_args_list[-1]
         assert "GROUP_CHANGED" in audit_call[0][0]
+
+
+def test_actions_change_group_active_session_blocks(sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [
+            {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
+            {"unix_user": "alice"},  # active session found
+        ]
+        with pytest.raises(UserError, match="active session"):
+            actions.change_group("alice", sample_server["hostname"], "sam-operator", ADMIN_ID)

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -179,6 +179,17 @@ def test_expire_expire_keys_scenario4_sends_critical_on_revoke_failure():
         assert count == 0
 
 
+def test_expire_expire_keys_excludes_root_unix_user():
+    """expire_keys SQL must exclude unix_user = 'root' to protect server access."""
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh"), \
+         patch("expire.alerts"):
+        mock_db.query.return_value = []
+        expire.expire_keys()
+        sql = mock_db.query.call_args[0][0]
+        assert "unix_user != 'root'" in sql
+
+
 def test_expire_expire_keys_returns_zero_when_no_expired_keys():
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -1111,44 +1111,78 @@ def test_ssh_sam_revoke_group_is_bytes():
 # grant_group_on_server / revoke_group_on_server
 # ---------------------------------------------------------------------------
 
+def test_ssh_parse_groups_output():
+    """_parse_groups_output parses GROUPS: line correctly."""
+    assert ssh._parse_groups_output("GROUPS:sam-users sam-operator") == ["sam-users", "sam-operator"]
+    assert ssh._parse_groups_output("GROUPS:") == []
+    assert ssh._parse_groups_output("other output\nGROUPS:sam-root\nmore output") == ["sam-root"]
+    assert ssh._parse_groups_output("no groups line") == []
+
+
 def test_ssh_grant_group_on_server_calls_sam_grant_group():
-    """grant_group_on_server runs sam-grant-group with correct args."""
+    """grant_group_on_server runs sam-grant-group with correct args and returns groups."""
     from unittest.mock import MagicMock, patch
 
     with patch("ssh._connect") as mock_connect:
         client = MagicMock()
         mock_connect.return_value = client
         stdout = MagicMock()
-        stdout.read.return_value = b""
+        stdout.read.return_value = b"GROUPS:sam-users sam-operator\n"
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
+        result = ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-grant-group" in cmd
         assert "alice" in cmd
         assert "sam-operator" in cmd
+        assert result == ["sam-users", "sam-operator"]
 
 
 def test_ssh_revoke_group_on_server_calls_sam_revoke_group():
-    """revoke_group_on_server runs sam-revoke-group with correct args."""
+    """revoke_group_on_server runs sam-revoke-group with correct args and returns groups."""
     from unittest.mock import MagicMock, patch
 
     with patch("ssh._connect") as mock_connect:
         client = MagicMock()
         mock_connect.return_value = client
         stdout = MagicMock()
-        stdout.read.return_value = b""
+        stdout.read.return_value = b"GROUPS:sam-users\n"
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        ssh.revoke_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
+        result = ssh.revoke_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-revoke-group" in cmd
         assert "alice" in cmd
         assert "sam-operator" in cmd
+        assert result == ["sam-users"]
+
+
+def test_ssh_revoke_group_on_server_with_none_strips_all():
+    """revoke_group_on_server with group=None strips all SAM groups."""
+    from unittest.mock import MagicMock, patch
+
+    with patch("ssh._connect") as mock_connect:
+        client = MagicMock()
+        mock_connect.return_value = client
+        stdout = MagicMock()
+        stdout.read.return_value = b"GROUPS:sam-users\n"
+        stdout.channel.recv_exit_status.return_value = 0
+        client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
+
+        result = ssh.revoke_group_on_server("web-01", "alice", None, "192.168.1.10")
+
+        cmd = client.exec_command.call_args[0][0]
+        assert "sam-revoke-group" in cmd
+        assert "alice" in cmd
+        # Should NOT have a group argument when group=None
+        assert "sam-operator" not in cmd
+        assert "sam-pkg" not in cmd
+        assert "sam-root" not in cmd
+        assert result == ["sam-users"]
 
 
 def test_ssh_grant_group_on_server_raises_on_failure():

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -299,6 +299,68 @@ def test_web_set_expiry_duration_hours_not_integer_returns_400(auth_client):
         assert "must be an integer" in resp.json["error"] or "error" in resp.json
 
 
+def test_web_set_expiry_scoped_to_unix_user_and_hostname(auth_client):
+    """set-expiry with unix_user and hostname passes them to actions."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/set-expiry/{FINGERPRINT}",
+            json={"hours": 24, "unix_user": "alice", "hostname": "server-01"},
+        )
+        assert resp.status_code == 200
+        mock_actions.set_key_expiry.assert_called_once()
+        call_args = mock_actions.set_key_expiry.call_args
+        assert call_args[0][0] == FINGERPRINT
+        assert call_args[1]["unix_user"] == "alice"
+        assert call_args[1]["hostname"] == "server-01"
+
+
+def test_web_remove_expiry_scoped_to_unix_user_and_hostname(auth_client):
+    """remove-expiry with unix_user and hostname passes them to actions."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/remove-expiry/{FINGERPRINT}",
+            json={"unix_user": "bob", "hostname": "server-02"},
+        )
+        assert resp.status_code == 200
+        mock_actions.remove_key_expiry.assert_called_once()
+        call_args = mock_actions.remove_key_expiry.call_args
+        assert call_args[0][0] == FINGERPRINT
+        assert call_args[1]["unix_user"] == "bob"
+        assert call_args[1]["hostname"] == "server-02"
+
+
+def test_web_set_expiry_without_scoping_params(auth_client):
+    """set-expiry without unix_user/hostname calls actions with None."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/set-expiry/{FINGERPRINT}",
+            json={"hours": 48},
+        )
+        assert resp.status_code == 200
+        mock_actions.set_key_expiry.assert_called_once()
+        call_args = mock_actions.set_key_expiry.call_args
+        assert call_args[1]["unix_user"] is None
+        assert call_args[1]["hostname"] is None
+
+
+def test_web_remove_expiry_without_scoping_params(auth_client):
+    """remove-expiry without unix_user/hostname calls actions with None."""
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        resp = auth_client.post(
+            f"/api/keys/remove-expiry/{FINGERPRINT}",
+            json={},
+        )
+        assert resp.status_code == 200
+        mock_actions.remove_key_expiry.assert_called_once()
+        call_args = mock_actions.remove_key_expiry.call_args
+        assert call_args[1]["unix_user"] is None
+        assert call_args[1]["hostname"] is None
+
+
 # ---------------------------------------------------------------------------
 # GET /api/servers
 # ---------------------------------------------------------------------------
@@ -1710,6 +1772,28 @@ def test_web_login_max_attempts_triggers_ban(client):
     assert resp.status_code == 401
     assert entry is not None
     assert entry["banned_until"] > 0
+
+
+def test_web_get_client_ip_prefers_x_real_ip(client):
+    """X-Real-IP (set by Nginx, not spoofable) takes priority over X-Forwarded-For."""
+    with client.application.test_request_context(
+        headers={"X-Real-IP": "203.0.113.5", "X-Forwarded-For": "1.2.3.4, 5.6.7.8"}
+    ):
+        assert web._get_client_ip() == "203.0.113.5"
+
+
+def test_web_get_client_ip_fallback_rightmost_forwarded(client):
+    """Without X-Real-IP, take the rightmost X-Forwarded-For entry (most trustworthy)."""
+    with client.application.test_request_context(
+        headers={"X-Forwarded-For": "1.1.1.1, 203.0.113.5"}
+    ):
+        assert web._get_client_ip() == "203.0.113.5"
+
+
+def test_web_get_client_ip_fallback_remote_addr(client):
+    """Without any proxy headers, use remote_addr."""
+    with client.application.test_request_context("/", environ_base={"REMOTE_ADDR": "10.0.0.1"}):
+        assert web._get_client_ip() == "10.0.0.1"
 
 
 def test_web_config_update_login_max_attempts(auth_client):

--- a/app/web.py
+++ b/app/web.py
@@ -30,9 +30,14 @@ _login_lock = threading.Lock()
 
 
 def _get_client_ip() -> str:
+    # X-Real-IP is set by Nginx to $remote_addr — not spoofable by the client
+    real_ip = request.headers.get("X-Real-IP", "").strip()
+    if real_ip:
+        return real_ip
+    # Fallback: take the rightmost entry of X-Forwarded-For (most trustworthy in a proxy chain)
     forwarded = request.headers.get("X-Forwarded-For", "")
     if forwarded:
-        return forwarded.split(",")[0].strip()
+        return forwarded.split(",")[-1].strip()
     return request.remote_addr or "unknown"
 
 
@@ -105,6 +110,13 @@ if not _flask_secret or _flask_secret == "changeme":
         "FLASK_SECRET_KEY must be set to a strong secret (not 'changeme')"
     )
 app.secret_key = _flask_secret
+_tls_enabled = bool(
+    os.environ.get("NGINX_TLS_CERT_PATH", "").strip()
+    and os.environ.get("NGINX_TLS_KEY_PATH", "").strip()
+)
+app.config["SESSION_COOKIE_SECURE"] = _tls_enabled
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_HTTPONLY"] = True
 
 
 @app.errorhandler(UserError)
@@ -616,13 +628,20 @@ def set_key_expiry(fingerprint):
         expires_at = datetime.now(tz=timezone.utc) + timedelta(hours=int(data["hours"]))
     if not expires_at:
         return jsonify({"error": "hours or date required"}), 400
-    actions.set_key_expiry(fingerprint, expires_at)
+    unix_user = data.get("unix_user") or None
+    hostname = data.get("hostname") or None
+    actions.set_key_expiry(fingerprint, expires_at, unix_user=unix_user, hostname=hostname)
     return jsonify({"status": "expiry set", "expires_at": expires_at.isoformat()})
+
+
 @app.route("/api/keys/remove-expiry/<path:fingerprint>", methods=["POST"])
 @require_auth
 @require_role("sysadmin", "operator")
 def remove_key_expiry(fingerprint):
-    actions.remove_key_expiry(fingerprint)
+    data = request.get_json() or {}
+    unix_user = data.get("unix_user") or None
+    hostname = data.get("hostname") or None
+    actions.remove_key_expiry(fingerprint, unix_user=unix_user, hostname=hostname)
     return jsonify({"status": "expiry removed"})
 @app.route("/api/keys/bulk-validate", methods=["POST"])
 @require_auth
@@ -871,7 +890,11 @@ def list_deployed_users():
                      AND al.action IN ('USER_LOCKED', 'USER_UNLOCKED')
                    ORDER BY al.performed_at DESC
                    LIMIT 1
-               ) AS lock_status
+               ) AS lock_status,
+               EXISTS(
+                   SELECT 1 FROM ssh_sessions ss
+                   WHERE ss.server_id = s.id AND ss.unix_user = ka.unix_user AND ss.is_active = true
+               ) AS has_active_session
         FROM key_authorizations ka
         JOIN ssh_keys sk ON sk.id = ka.key_id
         JOIN servers s ON ka.server_id = s.id

--- a/ui/CLAUDE.md
+++ b/ui/CLAUDE.md
@@ -6,7 +6,7 @@
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
 | Dashboard.vue | Tableau serveurs + recherche + compteurs + modal ajout serveur (#71) + clé collecteur (#74). Provisionnement atomique via SSH (#299, #301) : SSH user/password obligatoires, serveur créé uniquement si SSH réussit. Validation hostname RFC 1123 (#303). Layout 2 colonnes. |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Edit** (sysadmin) : ouvre `EditServerModal` pour modifier IP, env, OS, port SSH (#339) ; `max_sessions` configurable via `EditServerModal` (seuil alertes sessions, #360). Bandeau orange si `last_scan_ok === false` (#324). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91). Bouton **Edit** (sysadmin) : ouvre `EditServerModal` pour modifier IP, env, OS, port SSH (#339) ; `max_sessions` configurable via `EditServerModal` (seuil alertes sessions, #360). Bandeau orange si `last_scan_ok === false` (#324). Bouton **Re-provisionner** (violet, sysadmin + serveur actif) : modal SSH credentials, spinner, traduction error_code (#302). `bulkRevokeHasRoot` vérifie les clés composées (`\|root`) — évite faux positif quand un non-root partage le même fingerprint que root. Fingerprints dédupliqués uniquement au moment de l'appel API. |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + colonne unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
 | Audit.vue | Historique filtrable |
@@ -18,12 +18,12 @@
 | Composant | Rôle |
 |-----------|------|
 | ServerTable.vue | Tableau serveurs + ligne grisée + badge rouge si désactivé (#91) |
-| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité + sélection en masse (bulk validate/revoke, #345) |
+| KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité + sélection en masse (bulk validate/revoke, #345) ; lignes root visuellement grisées (`.row-root`), badge "protected", Revoke et Expiry désactivés pour root, root exclu de `isSelectable` (pas de checkbox) ; sélection utilise clés composées `fingerprint\|unix_user` (fix bug multi-user même fingerprint) ; `bulk-revoke` émet clés composées brutes |
 | KeyActions.vue | Boutons valider/révoquer/expiry |
 | ExpiryPicker.vue | Modes exclusifs heures / date précise |
-| DeployKeyForm.vue | Formulaire déploiement clé SSH |
+| DeployKeyForm.vue | Formulaire déploiement clé SSH ; refuse `unix_user = 'root'` avec message d'erreur dédié |
 | UserLockForm.vue | Verrouillage/déverrouillage compte Unix (#181) |
-| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer |
+| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer ; lignes root visuellement grisées (`.row-root`), badge "protected", tooltips sur boutons désactivés via `<span class="btn-tooltip-wrapper">` (fix navigateur : buttons disabled ne reçoivent pas les événements souris) |
 | AdminsTable.vue | Tableau administrateurs + filtre texte + pagination + garde-fou self (#250) |
 | AuditTable.vue | Tableau audit + filtres serveur/action/date + pagination (#250) |
 | AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) |
@@ -62,12 +62,13 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | KeyActions.spec.js | 14 | modal confirmation révocation |
 | ExpiryPicker.spec.js | 9 | modes exclusifs heures/date |
 | ServerTable.spec.js | 25 | filtres hostname/IP/env, badges statut |
-| KeyTable.spec.js | 45 | boutons par statut, owner, expires_at, filtres |
+| KeyTable.spec.js | 49 | boutons par statut, owner, expires_at, filtres, protection root (grisage, badge, sélection exclue) |
 | Admins.spec.js | 31 | modals enable/delete, RBAC, toggle alerts |
 | Settings.spec.js | 18 | validation champs, SMTP test |
 | DeployKeyForm.spec.js | 16 | formulaire déploiement clé SSH |
 | UserLockForm.spec.js | 10 | lock/unlock compte Unix |
-| DeployedUsersTable.spec.js | 15 | filtres, RBAC operator/viewer, lien serveur, colonne IP |
+| DeployedUsersTable.spec.js | 21 | filtres, RBAC operator/viewer, lien serveur, colonne IP, protection root (grisage, badge, tooltips) |
+| ServerDetail.spec.js | 7 | root warnings + expiry scoping |
 | Anomalies.spec.js | 20 | filtres texte + dropdowns, unix_user, badges |
 | Login.spec.js | 8 | checkbox remember-me, payload remember_me |
 | AdminsTable.spec.js | 13 | filtre texte, pagination, RBAC, garde-fou self, events (#250) |
@@ -79,5 +80,5 @@ Détection automatique de la langue du navigateur via vue-i18n v9 (i18n.js).
 | App.spec.js | 8 | SMTP banner, sélecteur langue, persistance localStorage |
 | useSort.spec.js | 21 | tri multi-colonnes, reset, indicateurs |
 
-<!-- 19 fichiers de tests -->
+<!-- 20 fichiers de tests -->
 vitest doit passer avant tout commit.

--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -39,7 +39,11 @@
         <span v-if="unixUser && isRootUser" class="field-error" data-testid="error-root-user">
           {{ $t('deployKey.error_root_user') }}
         </span>
-        <span v-else-if="unixUser && !unixUserValid" class="field-error" data-testid="error-unix-user">
+        <span
+          v-else-if="unixUser && !unixUserValid"
+          class="field-error"
+          data-testid="error-unix-user"
+        >
           {{ $t('deployKey.error_unix_user') }}
         </span>
       </div>

--- a/ui/src/components/DeployKeyForm.vue
+++ b/ui/src/components/DeployKeyForm.vue
@@ -36,7 +36,10 @@
           :placeholder="$t('deployKey.unixUserPlaceholder')"
           data-testid="input-unix-user"
         />
-        <span v-if="unixUser && !unixUserValid" class="field-error" data-testid="error-unix-user">
+        <span v-if="unixUser && isRootUser" class="field-error" data-testid="error-root-user">
+          {{ $t('deployKey.error_root_user') }}
+        </span>
+        <span v-else-if="unixUser && !unixUserValid" class="field-error" data-testid="error-unix-user">
           {{ $t('deployKey.error_unix_user') }}
         </span>
       </div>
@@ -203,6 +206,7 @@ const minDate = computed(() => {
 })
 
 const unixUserValid = computed(() => /^[a-z_][a-z0-9_-]{0,31}$/.test(unixUser.value))
+const isRootUser = computed(() => unixUser.value.trim() === 'root')
 
 const durationError = computed(() => {
   if (mode.value === 'unlimited') return ''
@@ -225,6 +229,7 @@ const durationValid = computed(() => {
 const isValid = computed(
   () =>
     unixUserValid.value &&
+    !isRootUser.value &&
     publicKey.value.trim() !== '' &&
     server.value.trim() !== '' &&
     durationValid.value &&

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -151,13 +151,23 @@
               <span
                 v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
                 class="btn-tooltip-wrapper"
-                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : user.has_active_session ? $t('deployedUsers.active_session_tooltip') : undefined"
+                :title="
+                  user.unix_user === 'root'
+                    ? $t('deployedUsers.root_user_tooltip')
+                    : user.has_active_session
+                      ? $t('deployedUsers.active_session_tooltip')
+                      : undefined
+                "
               >
                 <button
                   type="button"
                   class="btn-danger btn-sm"
                   :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
-                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.has_active_session || user.unix_user === 'root'"
+                  :disabled="
+                    actionInProgress[`${user.unix_user}-${user.hostname}`] ||
+                    user.has_active_session ||
+                    user.unix_user === 'root'
+                  "
                   @click="!user.has_active_session && user.unix_user !== 'root' && lockUser(user)"
                 >
                   {{ $t('userLock.btnLock') }}
@@ -166,13 +176,18 @@
               <span
                 v-else
                 class="btn-tooltip-wrapper"
-                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : undefined"
+                :title="
+                  user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : undefined
+                "
               >
                 <button
                   type="button"
                   class="btn-success btn-sm"
                   :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
-                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.unix_user === 'root'"
+                  :disabled="
+                    actionInProgress[`${user.unix_user}-${user.hostname}`] ||
+                    user.unix_user === 'root'
+                  "
                   @click="user.unix_user !== 'root' && unlockUser(user)"
                 >
                   {{ $t('userLock.btnUnlock') }}
@@ -180,14 +195,26 @@
               </span>
               <span
                 class="btn-tooltip-wrapper"
-                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : user.has_active_session ? $t('deployedUsers.active_session_tooltip') : undefined"
+                :title="
+                  user.unix_user === 'root'
+                    ? $t('deployedUsers.root_user_tooltip')
+                    : user.has_active_session
+                      ? $t('deployedUsers.active_session_tooltip')
+                      : undefined
+                "
               >
                 <button
                   type="button"
                   class="btn-group btn-sm"
                   :data-testid="`btn-group-${user.unix_user}-${user.hostname}`"
-                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.has_active_session || user.unix_user === 'root'"
-                  @click="!user.has_active_session && user.unix_user !== 'root' && openGroupModal(user)"
+                  :disabled="
+                    actionInProgress[`${user.unix_user}-${user.hostname}`] ||
+                    user.has_active_session ||
+                    user.unix_user === 'root'
+                  "
+                  @click="
+                    !user.has_active_session && user.unix_user !== 'root' && openGroupModal(user)
+                  "
                 >
                   {{ $t('deployedUsers.btn_group') }}
                 </button>
@@ -395,9 +422,11 @@ async function loadUsers() {
         uniqueServers.map((hostname) =>
           apiFetch(`/api/servers/${hostname}/sessions/refresh`, { method: 'POST' })
         )
-      ).then(() => _fetchUsers().catch(() => {})).finally(() => {
-        refreshingSessions.value = false
-      })
+      )
+        .then(() => _fetchUsers().catch(() => {}))
+        .finally(() => {
+          refreshingSessions.value = false
+        })
     }
   } catch (e) {
     loadError.value = e.message
@@ -512,9 +541,9 @@ async function submitGroupChange() {
 
     const result = await res.json()
     const key = `${user.unix_user}-${user.hostname}`
-    const serverGroups = (result.actual_groups || [])
-      .filter((g) => g.startsWith('sam-'))
-      .join(', ') || t('deployedUsers.group_none')
+    const serverGroups =
+      (result.actual_groups || []).filter((g) => g.startsWith('sam-')).join(', ') ||
+      t('deployedUsers.group_none')
     successMessages.value[key] = t('deployedUsers.group_success_verified', {
       user: user.unix_user,
       server: user.hostname,
@@ -595,8 +624,12 @@ async function submitGroupChange() {
 }
 
 @keyframes progress-sweep {
-  0%   { left: -40%; }
-  100% { left: 100%; }
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
 }
 
 .alert-error {

--- a/ui/src/components/DeployedUsersTable.vue
+++ b/ui/src/components/DeployedUsersTable.vue
@@ -28,6 +28,14 @@
         </select>
       </div>
 
+      <div
+        class="table-progress-bar"
+        :class="{ active: refreshingSessions }"
+        :title="refreshingSessions ? $t('deployedUsers.refreshing_sessions') : undefined"
+        data-testid="sessions-refreshing"
+        aria-hidden="true"
+      />
+
       <table data-testid="table-deployed-users">
         <thead>
           <tr>
@@ -87,8 +95,16 @@
             v-for="user in paginatedItems"
             :key="`${user.unix_user}-${user.hostname}`"
             :data-testid="`row-${user.unix_user}-${user.hostname}`"
+            :class="{ 'row-root': user.unix_user === 'root' }"
           >
-            <td>{{ user.unix_user }}</td>
+            <td>
+              <span class="unix-user-cell">
+                {{ user.unix_user }}
+                <span v-if="user.unix_user === 'root'" class="badge-root-protected">
+                  {{ $t('deployedUsers.root_protected_badge') }}
+                </span>
+              </span>
+            </td>
             <td>
               <RouterLink :to="`/servers/${user.hostname}`" class="server-link">{{
                 user.hostname
@@ -132,35 +148,57 @@
               >
             </td>
             <td v-if="currentRole !== 'viewer'" class="actions">
-              <button
+              <span
                 v-if="lockStates[`${user.unix_user}-${user.hostname}`] !== 'USER_LOCKED'"
-                type="button"
-                class="btn-danger btn-sm"
-                :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
-                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                @click="lockUser(user)"
+                class="btn-tooltip-wrapper"
+                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : user.has_active_session ? $t('deployedUsers.active_session_tooltip') : undefined"
               >
-                {{ $t('userLock.btnLock') }}
-              </button>
-              <button
+                <button
+                  type="button"
+                  class="btn-danger btn-sm"
+                  :data-testid="`btn-lock-${user.unix_user}-${user.hostname}`"
+                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.has_active_session || user.unix_user === 'root'"
+                  @click="!user.has_active_session && user.unix_user !== 'root' && lockUser(user)"
+                >
+                  {{ $t('userLock.btnLock') }}
+                </button>
+              </span>
+              <span
                 v-else
-                type="button"
-                class="btn-success btn-sm"
-                :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
-                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                @click="unlockUser(user)"
+                class="btn-tooltip-wrapper"
+                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : undefined"
               >
-                {{ $t('userLock.btnUnlock') }}
-              </button>
-              <button
-                type="button"
-                class="btn-group btn-sm"
-                :data-testid="`btn-group-${user.unix_user}-${user.hostname}`"
-                :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`]"
-                @click="openGroupModal(user)"
+                <button
+                  type="button"
+                  class="btn-success btn-sm"
+                  :data-testid="`btn-unlock-${user.unix_user}-${user.hostname}`"
+                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.unix_user === 'root'"
+                  @click="user.unix_user !== 'root' && unlockUser(user)"
+                >
+                  {{ $t('userLock.btnUnlock') }}
+                </button>
+              </span>
+              <span
+                class="btn-tooltip-wrapper"
+                :title="user.unix_user === 'root' ? $t('deployedUsers.root_user_tooltip') : user.has_active_session ? $t('deployedUsers.active_session_tooltip') : undefined"
               >
-                {{ $t('deployedUsers.btn_group') }}
-              </button>
+                <button
+                  type="button"
+                  class="btn-group btn-sm"
+                  :data-testid="`btn-group-${user.unix_user}-${user.hostname}`"
+                  :disabled="actionInProgress[`${user.unix_user}-${user.hostname}`] || user.has_active_session || user.unix_user === 'root'"
+                  @click="!user.has_active_session && user.unix_user !== 'root' && openGroupModal(user)"
+                >
+                  {{ $t('deployedUsers.btn_group') }}
+                </button>
+              </span>
+              <span
+                v-if="user.has_active_session"
+                class="badge badge-session"
+                :data-testid="`session-${user.unix_user}-${user.hostname}`"
+              >
+                {{ $t('deployedUsers.active_session_badge') }}
+              </span>
               <div
                 v-if="successMessages[`${user.unix_user}-${user.hostname}`]"
                 class="inline-success"
@@ -281,6 +319,7 @@ const currentRole = computed(() => admin.value?.role || 'viewer')
 
 const users = ref([])
 const loading = ref(false)
+const refreshingSessions = ref(false)
 const loadError = ref('')
 const actionInProgress = ref({})
 const successMessages = ref({})
@@ -326,20 +365,40 @@ onMounted(async () => {
 
 defineExpose({ refresh: loadUsers })
 
+async function _fetchUsers() {
+  const res = await apiFetch('/api/access/deployed-users')
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error(data.error || `HTTP ${res.status}`)
+  }
+  const data = await res.json()
+  users.value = data
+  data.forEach((u) => {
+    const key = `${u.unix_user}-${u.hostname}`
+    lockStates.value[key] = u.lock_status || 'USER_UNLOCKED'
+  })
+  return data
+}
+
 async function loadUsers() {
   loading.value = true
   loadError.value = ''
   try {
-    const res = await apiFetch('/api/access/deployed-users')
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}))
-      throw new Error(data.error || `HTTP ${res.status}`)
+    const data = await _fetchUsers()
+
+    // Refresh sessions in background for all servers (sysadmin/operator only),
+    // then silently reload to get fresh has_active_session values.
+    if (currentRole.value !== 'viewer' && data.length > 0) {
+      refreshingSessions.value = true
+      const uniqueServers = [...new Set(data.map((u) => u.hostname))]
+      Promise.allSettled(
+        uniqueServers.map((hostname) =>
+          apiFetch(`/api/servers/${hostname}/sessions/refresh`, { method: 'POST' })
+        )
+      ).then(() => _fetchUsers().catch(() => {})).finally(() => {
+        refreshingSessions.value = false
+      })
     }
-    users.value = await res.json()
-    users.value.forEach((u) => {
-      const key = `${u.unix_user}-${u.hostname}`
-      lockStates.value[key] = u.lock_status || 'USER_UNLOCKED'
-    })
   } catch (e) {
     loadError.value = e.message
   } finally {
@@ -420,11 +479,6 @@ async function submitGroupChange() {
   const currentGroup = user.sam_group || ''
   const newGroup = groupModalNewValue.value
 
-  if (currentGroup === newGroup) {
-    closeGroupModal()
-    return
-  }
-
   groupModalSubmitting.value = true
   groupModalError.value = ''
 
@@ -435,7 +489,7 @@ async function submitGroupChange() {
       hostname: user.hostname,
     }
 
-    if (newGroup === '' && currentGroup !== '') {
+    if (newGroup === '') {
       endpoint = '/api/access/revoke-group'
     } else if (currentGroup === '' && newGroup !== '') {
       endpoint = '/api/access/grant-group'
@@ -456,10 +510,15 @@ async function submitGroupChange() {
       throw new Error(data.error || `HTTP ${res.status}`)
     }
 
+    const result = await res.json()
     const key = `${user.unix_user}-${user.hostname}`
-    successMessages.value[key] = t('deployedUsers.group_success', {
+    const serverGroups = (result.actual_groups || [])
+      .filter((g) => g.startsWith('sam-'))
+      .join(', ') || t('deployedUsers.group_none')
+    successMessages.value[key] = t('deployedUsers.group_success_verified', {
       user: user.unix_user,
       server: user.hostname,
+      groups: serverGroups,
     })
     setTimeout(() => {
       successMessages.value[key] = ''
@@ -510,6 +569,36 @@ async function submitGroupChange() {
   padding: 1rem;
 }
 
+.table-progress-bar {
+  height: 3px;
+  background: transparent;
+  border-radius: 2px 2px 0 0;
+  overflow: hidden;
+  margin-bottom: -3px;
+  position: relative;
+}
+
+.table-progress-bar.active {
+  background: color-mix(in srgb, #0d6efd 20%, transparent);
+}
+
+.table-progress-bar.active::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -40%;
+  width: 40%;
+  height: 100%;
+  background: #0d6efd;
+  border-radius: 2px;
+  animation: progress-sweep 1.4s ease-in-out infinite;
+}
+
+@keyframes progress-sweep {
+  0%   { left: -40%; }
+  100% { left: 100%; }
+}
+
 .alert-error {
   background: #f8d7da;
   color: #721c24;
@@ -546,6 +635,34 @@ td {
   flex-wrap: wrap;
 }
 
+.btn-tooltip-wrapper {
+  display: inline-flex;
+}
+
+.row-root {
+  opacity: 0.65;
+  background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
+}
+
+.unix-user-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.badge-root-protected {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  background: #6c757d;
+  color: #fff;
+  vertical-align: middle;
+}
+
 .badge {
   display: inline-block;
   padding: 0.2rem 0.5rem;
@@ -579,6 +696,11 @@ td {
 .badge-root {
   background: #f8d7da;
   color: #721c24;
+}
+
+.badge-session {
+  background: #fff3cd;
+  color: #664d03;
 }
 
 .btn-sm {

--- a/ui/src/components/KeyTable.vue
+++ b/ui/src/components/KeyTable.vue
@@ -120,13 +120,17 @@
             {{ $t('key_table.no_results') }}
           </td>
         </tr>
-        <tr v-for="k in paginatedItems" :key="k.fingerprint + '|' + (k.unix_user || '')">
+        <tr
+          v-for="k in paginatedItems"
+          :key="k.fingerprint + '|' + (k.unix_user || '')"
+          :class="{ 'row-root': k.unix_user === 'root' }"
+        >
           <td v-if="currentRole !== 'viewer'" class="td-check">
             <input
               v-if="isSelectable(k)"
               type="checkbox"
-              :checked="selected.has(k.fingerprint)"
-              @change="toggleSelect(k.fingerprint)"
+              :checked="selected.has(k.fingerprint + '|' + (k.unix_user || ''))"
+              @change="toggleSelect(k.fingerprint + '|' + (k.unix_user || ''))"
             />
           </td>
           <td>
@@ -139,7 +143,12 @@
             <code>{{ k.fingerprint }}</code>
           </td>
           <td>
-            <code v-if="k.unix_user">{{ k.unix_user }}</code>
+            <span v-if="k.unix_user" class="unix-user-cell">
+              <code>{{ k.unix_user }}</code>
+              <span v-if="k.unix_user === 'root'" class="badge-root-protected">
+                {{ $t('key_table.root_protected_badge') }}
+              </span>
+            </span>
             <span v-else>—</span>
           </td>
           <td>{{ k.comment || '—' }}</td>
@@ -160,18 +169,28 @@
               >
                 {{ $t('key_table.btn_validate') }}
               </button>
-              <button
+              <span
                 v-if="
                   (k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW') &&
                   props.currentRole !== 'viewer'
                 "
-                class="btn-danger"
-                :disabled="props.scanOk === false"
-                :title="props.scanOk === false ? $t('key_table.revoke_unavailable') : undefined"
-                @click="$emit('revoke', k)"
+                class="btn-tooltip-wrapper"
+                :title="
+                  k.unix_user === 'root'
+                    ? $t('key_table.root_revoke_tooltip')
+                    : props.scanOk === false
+                      ? $t('key_table.revoke_unavailable')
+                      : undefined
+                "
               >
-                {{ $t('key_table.btn_revoke') }}
-              </button>
+                <button
+                  class="btn-danger"
+                  :disabled="props.scanOk === false || k.unix_user === 'root'"
+                  @click="k.unix_user !== 'root' && $emit('revoke', k)"
+                >
+                  {{ $t('key_table.btn_revoke') }}
+                </button>
+              </span>
               <button
                 v-if="!k.owner && k.status === 'ACTIVE' && props.currentRole !== 'viewer'"
                 class="btn-primary"
@@ -179,17 +198,23 @@
               >
                 {{ $t('key_table.btn_assign') }}
               </button>
-              <button
+              <span
                 v-if="k.status === 'ACTIVE' && props.currentRole !== 'viewer'"
-                class="btn-warning"
-                @click="$emit('set-expiry', k)"
+                class="btn-tooltip-wrapper"
+                :title="k.unix_user === 'root' ? $t('key_table.root_expiry_tooltip') : undefined"
               >
-                {{ $t('key_table.btn_expiry') }}
-              </button>
+                <button
+                  class="btn-warning"
+                  :disabled="k.unix_user === 'root'"
+                  @click="k.unix_user !== 'root' && $emit('set-expiry', k)"
+                >
+                  {{ $t('key_table.btn_expiry') }}
+                </button>
+              </span>
               <button
                 v-if="k.status === 'ACTIVE' && k.expires_at && props.currentRole !== 'viewer'"
                 class="btn-unlimited"
-                @click="$emit('remove-expiry', k.fingerprint)"
+                @click="$emit('remove-expiry', k)"
               >
                 {{ $t('key_table.btn_unlimited') }}
               </button>
@@ -265,11 +290,11 @@ watch(filteredKeys, () => {
 })
 
 function isSelectable(k) {
-  return k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW'
+  return (k.status === 'ACTIVE' || k.status === 'PENDING_REVIEW') && k.unix_user !== 'root'
 }
 
 const selectableOnPage = computed(() =>
-  paginatedItems.value.filter(isSelectable).map((k) => k.fingerprint)
+  paginatedItems.value.filter(isSelectable).map((k) => k.fingerprint + '|' + (k.unix_user || ''))
 )
 
 const allSelectableChecked = computed(
@@ -300,7 +325,8 @@ function toggleSelectAll(e) {
 }
 
 function emitBulkValidate() {
-  emit('bulk-validate', [...selected.value])
+  const fingerprints = [...new Set([...selected.value].map((key) => key.split('|')[0]))]
+  emit('bulk-validate', fingerprints)
   selected.value = new Set()
 }
 
@@ -462,6 +488,33 @@ function exportCsv() {
   flex-wrap: nowrap;
   gap: 0.3rem;
   white-space: nowrap;
+}
+.btn-tooltip-wrapper {
+  display: inline-flex;
+}
+
+.row-root {
+  opacity: 0.65;
+  background: color-mix(in srgb, var(--bg-secondary) 60%, transparent);
+}
+
+.unix-user-cell {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.badge-root-protected {
+  display: inline-block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  background: #6c757d;
+  color: #fff;
+  vertical-align: middle;
 }
 .actions button {
   padding: 0.2rem 0.45rem;

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -164,7 +164,8 @@
     "reprovision_password_optional_hint": "Leer lassen, wenn der Collector-Schlüssel bereits manuell bereitgestellt wurde (ssh-copy-id oder provision-host.sh).",
     "bulk_revoke_modal_title": "Ausgewählte Schlüssel widerrufen",
     "bulk_validated": "Schlüssel validiert: {validated}, übersprungen: {skipped}",
-    "bulk_revoked": "Schlüssel widerrufen: {revoked}, übersprungen: {skipped}"
+    "bulk_revoked": "Schlüssel widerrufen: {revoked}, übersprungen: {skipped}",
+    "root_revoke_warning": "Das Widerrufen des SSH-Schlüssels des Benutzers <strong>root</strong> kann zum dauerhaften Verlust des Fernzugriffs auf diesen Server führen."
   },
   "key_table": {
     "col_status": "Status",
@@ -195,7 +196,10 @@
     "bulk_selected": "{n} Schlüssel ausgewählt",
     "bulk_validate": "Auswahl validieren",
     "bulk_revoke": "Auswahl widerrufen",
-    "bulk_clear": "Auswahl aufheben"
+    "bulk_clear": "Auswahl aufheben",
+    "root_expiry_tooltip": "Ablaufzeit für root nicht setzbar — automatischer Widerruf würde dauerhaften Zugriffsverlust verursachen",
+    "root_revoke_tooltip": "Root-Konto geschützt — Widerruf deaktiviert, um Zugriffsverlust auf den Server zu verhindern",
+    "root_protected_badge": "geschützt"
   },
   "access": {
     "title": "Temporärer Zugriff",
@@ -387,6 +391,7 @@
     "unixUser": "Unix-Benutzer",
     "unixUserPlaceholder": "z.B. alice",
     "error_unix_user": "Ungültiger Unix-Benutzername (nur Kleinbuchstaben, Ziffern, _ und -, max. 32 Zeichen)",
+    "error_root_user": "Ein Schlüssel für das Root-Konto kann nicht bereitgestellt werden",
     "publicKey": "Öffentlicher Schlüssel",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Zielserver",
@@ -445,7 +450,12 @@
     "group_confirm": "Anwenden",
     "group_cancel": "Abbrechen",
     "group_success": "Gruppe für '{user}' auf {server} aktualisiert",
-    "group_error": "Gruppenänderung fehlgeschlagen: {error}"
+    "group_error": "Gruppenänderung fehlgeschlagen: {error}",
+    "active_session_tooltip": "Benutzer hat eine aktive Sitzung — Gruppenänderung blockiert",
+    "active_session_badge": "Aktive Sitzung",
+    "group_success_verified": "Gruppe für {user} auf {server} aktualisiert — Server bestätigt: {groups}",
+    "root_user_tooltip": "Der root-Benutzer kann weder gesperrt noch seine Gruppe geändert werden",
+    "root_protected_badge": "geschützt"
   },
   "pagination": {
     "rowsPerPage": "Zeilen pro Seite",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -164,7 +164,8 @@
     "reprovision_password_optional_hint": "Leave empty if the collector key was already deployed manually (ssh-copy-id or provision-host.sh).",
     "bulk_revoke_modal_title": "Revoke selected keys",
     "bulk_validated": "Keys validated: {validated}, skipped: {skipped}",
-    "bulk_revoked": "Keys revoked: {revoked}, skipped: {skipped}"
+    "bulk_revoked": "Keys revoked: {revoked}, skipped: {skipped}",
+    "root_revoke_warning": "Revoking the SSH key of user <strong>root</strong> may result in permanent loss of remote access to this server."
   },
   "key_table": {
     "col_status": "Status",
@@ -195,7 +196,10 @@
     "bulk_selected": "{n} key(s) selected",
     "bulk_validate": "Validate selected",
     "bulk_revoke": "Revoke selected",
-    "bulk_clear": "Clear selection"
+    "bulk_clear": "Clear selection",
+    "root_expiry_tooltip": "Cannot set expiry on root — automatic revocation would cause permanent loss of server access",
+    "root_revoke_tooltip": "Root account is protected — revocation is disabled to prevent loss of server access",
+    "root_protected_badge": "protected"
   },
   "access": {
     "title": "Temporary Access",
@@ -387,6 +391,7 @@
     "unixUser": "Unix Username",
     "unixUserPlaceholder": "e.g. alice",
     "error_unix_user": "Invalid Unix username (lowercase, digits, _ and - only, max 32 chars)",
+    "error_root_user": "Cannot deploy a key for the root account",
     "publicKey": "Public Key",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Target Server",
@@ -445,7 +450,13 @@
     "group_confirm": "Apply",
     "group_cancel": "Cancel",
     "group_success": "Group updated for '{user}' on {server}",
-    "group_error": "Group change failed: {error}"
+    "group_error": "Group change failed: {error}",
+    "active_session_tooltip": "User has an active session — group change blocked",
+    "active_session_badge": "Active session",
+    "refreshing_sessions": "Refreshing sessions…",
+    "group_success_verified": "Group updated for {user} on {server} — server confirms: {groups}",
+    "root_user_tooltip": "Root user cannot be locked or have its group changed",
+    "root_protected_badge": "protected"
   },
   "pagination": {
     "rowsPerPage": "Rows per page",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -164,7 +164,8 @@
     "reprovision_password_optional_hint": "Dejar vacío si la clave del colector ya fue desplegada manualmente (ssh-copy-id o provision-host.sh).",
     "bulk_revoke_modal_title": "Revocar claves seleccionadas",
     "bulk_validated": "Claves validadas: {validated}, omitidas: {skipped}",
-    "bulk_revoked": "Claves revocadas: {revoked}, omitidas: {skipped}"
+    "bulk_revoked": "Claves revocadas: {revoked}, omitidas: {skipped}",
+    "root_revoke_warning": "Revocar la clave SSH del usuario <strong>root</strong> puede resultar en la pérdida permanente del acceso remoto a este servidor."
   },
   "key_table": {
     "col_status": "Estado",
@@ -195,7 +196,10 @@
     "bulk_selected": "{n} clave(s) seleccionada(s)",
     "bulk_validate": "Validar selección",
     "bulk_revoke": "Revocar selección",
-    "bulk_clear": "Borrar selección"
+    "bulk_clear": "Borrar selección",
+    "root_expiry_tooltip": "No se puede fijar expiración para root — la revocación automática causaría pérdida permanente de acceso",
+    "root_revoke_tooltip": "Cuenta root protegida — la revocación está desactivada para evitar pérdida de acceso al servidor",
+    "root_protected_badge": "protegido"
   },
   "access": {
     "title": "Acceso temporal",
@@ -387,6 +391,7 @@
     "unixUser": "Usuario Unix",
     "unixUserPlaceholder": "ej: alice",
     "error_unix_user": "Nombre de usuario Unix inválido (minúsculas, dígitos, _ y - únicamente, máx. 32 caracteres)",
+    "error_root_user": "No se puede desplegar una clave para la cuenta root",
     "publicKey": "Clave pública",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Servidor destino",
@@ -445,7 +450,12 @@
     "group_confirm": "Aplicar",
     "group_cancel": "Cancelar",
     "group_success": "Grupo actualizado para '{user}' en {server}",
-    "group_error": "Error al cambiar grupo: {error}"
+    "group_error": "Error al cambiar grupo: {error}",
+    "active_session_tooltip": "El usuario tiene una sesión activa — cambio de grupo bloqueado",
+    "active_session_badge": "Sesión activa",
+    "group_success_verified": "Grupo actualizado para {user} en {server} — servidor confirma: {groups}",
+    "root_user_tooltip": "El usuario root no puede bloquearse ni cambiar de grupo",
+    "root_protected_badge": "protegido"
   },
   "pagination": {
     "rowsPerPage": "Filas por página",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -164,7 +164,8 @@
     "reprovision_password_optional_hint": "Laisser vide si la clé collecteur a déjà été déployée manuellement (ssh-copy-id ou provision-host.sh).",
     "bulk_revoke_modal_title": "Révoquer les clés sélectionnées",
     "bulk_validated": "Clés validées : {validated}, ignorées : {skipped}",
-    "bulk_revoked": "Clés révoquées : {revoked}, ignorées : {skipped}"
+    "bulk_revoked": "Clés révoquées : {revoked}, ignorées : {skipped}",
+    "root_revoke_warning": "Révoquer la clé SSH de l'utilisateur <strong>root</strong> peut entraîner une perte définitive d'accès distant à ce serveur."
   },
   "key_table": {
     "col_status": "Statut",
@@ -195,7 +196,10 @@
     "bulk_selected": "{n} clé(s) sélectionnée(s)",
     "bulk_validate": "Valider la sélection",
     "bulk_revoke": "Révoquer la sélection",
-    "bulk_clear": "Effacer la sélection"
+    "bulk_clear": "Effacer la sélection",
+    "root_expiry_tooltip": "Impossible de définir une expiration pour root — la révocation automatique causerait une perte définitive d'accès",
+    "root_revoke_tooltip": "Compte root protégé — la révocation est désactivée pour éviter toute perte d'accès au serveur",
+    "root_protected_badge": "protégé"
   },
   "access": {
     "title": "Accès temporaires",
@@ -387,6 +391,7 @@
     "unixUser": "Utilisateur Unix",
     "unixUserPlaceholder": "ex: alice",
     "error_unix_user": "Nom d'utilisateur Unix invalide (minuscules, chiffres, _ et - uniquement, max 32 caractères)",
+    "error_root_user": "Impossible de déployer une clé pour le compte root",
     "publicKey": "Clé publique",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Serveur cible",
@@ -445,7 +450,12 @@
     "group_confirm": "Appliquer",
     "group_cancel": "Annuler",
     "group_success": "Groupe mis à jour pour '{user}' sur {server}",
-    "group_error": "Échec du changement de groupe : {error}"
+    "group_error": "Échec du changement de groupe : {error}",
+    "active_session_tooltip": "L'utilisateur a une session active — changement de groupe bloqué",
+    "active_session_badge": "Session active",
+    "group_success_verified": "Groupe mis à jour pour {user} sur {server} — serveur confirme : {groups}",
+    "root_user_tooltip": "L'utilisateur root ne peut pas être verrouillé ni changer de groupe",
+    "root_protected_badge": "protégé"
   },
   "pagination": {
     "rowsPerPage": "Lignes par page",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -164,7 +164,8 @@
     "reprovision_password_optional_hint": "Lasciare vuoto se la chiave del collettore è già stata distribuita manualmente (ssh-copy-id o provision-host.sh).",
     "bulk_revoke_modal_title": "Revocare le chiavi selezionate",
     "bulk_validated": "Chiavi validate: {validated}, saltate: {skipped}",
-    "bulk_revoked": "Chiavi revocate: {revoked}, saltate: {skipped}"
+    "bulk_revoked": "Chiavi revocate: {revoked}, saltate: {skipped}",
+    "root_revoke_warning": "La revoca della chiave SSH dell'utente <strong>root</strong> può causare la perdita permanente dell'accesso remoto a questo server."
   },
   "key_table": {
     "col_status": "Stato",
@@ -195,7 +196,10 @@
     "bulk_selected": "{n} chiave/i selezionata/e",
     "bulk_validate": "Valida selezionati",
     "bulk_revoke": "Revoca selezionati",
-    "bulk_clear": "Annulla selezione"
+    "bulk_clear": "Annulla selezione",
+    "root_expiry_tooltip": "Impossibile impostare scadenza per root — la revoca automatica causerebbe la perdita permanente dell'accesso",
+    "root_revoke_tooltip": "Account root protetto — la revoca è disabilitata per evitare la perdita di accesso al server",
+    "root_protected_badge": "protetto"
   },
   "access": {
     "title": "Accesso temporaneo",
@@ -387,6 +391,7 @@
     "unixUser": "Utente Unix",
     "unixUserPlaceholder": "es: alice",
     "error_unix_user": "Nome utente Unix non valido (solo minuscole, cifre, _ e -, max 32 caratteri)",
+    "error_root_user": "Impossibile distribuire una chiave per l'account root",
     "publicKey": "Chiave pubblica",
     "publicKeyPlaceholder": "ssh-ed25519 AAAA...",
     "server": "Server di destinazione",
@@ -445,7 +450,12 @@
     "group_confirm": "Applica",
     "group_cancel": "Annulla",
     "group_success": "Gruppo aggiornato per '{user}' su {server}",
-    "group_error": "Modifica gruppo fallita: {error}"
+    "group_error": "Modifica gruppo fallita: {error}",
+    "active_session_tooltip": "L'utente ha una sessione attiva — modifica gruppo bloccata",
+    "active_session_badge": "Sessione attiva",
+    "group_success_verified": "Gruppo aggiornato per {user} su {server} — il server conferma: {groups}",
+    "root_user_tooltip": "L'utente root non può essere bloccato né cambiare gruppo",
+    "root_protected_badge": "protetto"
   },
   "pagination": {
     "rowsPerPage": "Righe per pagina",

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -149,6 +149,11 @@
           </button>
         </div>
         <p>{{ $t('key_table.bulk_selected', { n: bulkRevokeFingerprints.length }) }}</p>
+        <div
+          v-if="bulkRevokeHasRoot"
+          class="root-warning"
+          v-html="$t('server_detail.root_revoke_warning')"
+        ></div>
         <label for="bulk-revoke-reason"
           >{{ $t('server_detail.revoke_reason_label') }}
           <span class="required">{{ $t('common.required') }}</span></label
@@ -190,6 +195,11 @@
           {{ $t('server_detail.revoke_user_label') }}
           <strong>{{ revokeTarget.unix_user }}</strong>
         </p>
+        <div
+          v-if="revokeTarget.unix_user === 'root'"
+          class="root-warning"
+          v-html="$t('server_detail.root_revoke_warning')"
+        ></div>
         <label
           >{{ $t('server_detail.revoke_reason_label') }}
           <span class="required">{{ $t('common.required') }}</span></label
@@ -408,6 +418,10 @@ const revokeTarget = ref(null)
 const revokeReason = ref('')
 const bulkRevokeFingerprints = ref(null)
 const bulkRevokeReason = ref('')
+const bulkRevokeHasRoot = computed(() => {
+  if (!bulkRevokeFingerprints.value) return false
+  return bulkRevokeFingerprints.value.some((key) => key.endsWith('|root'))
+})
 const assignTarget = ref(null)
 const assignUsername = ref('')
 const expiryTarget = ref(null)
@@ -561,7 +575,7 @@ async function confirmBulkRevoke() {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      fingerprints: bulkRevokeFingerprints.value,
+      fingerprints: [...new Set(bulkRevokeFingerprints.value.map((key) => key.split('|')[0]))],
       reason: bulkRevokeReason.value,
     }),
   })
@@ -599,8 +613,13 @@ function openExpiry(key) {
 }
 
 async function confirmExpiry() {
-  const body =
+  const base =
     expiryMode.value === 'hours' ? { hours: expiryHours.value } : { date: expiryDate.value }
+  const body = {
+    ...base,
+    unix_user: expiryTarget.value.unix_user || undefined,
+    hostname,
+  }
   await apiAction(
     `/api/keys/set-expiry/${efp(expiryTarget.value.fingerprint)}`,
     body,
@@ -610,10 +629,10 @@ async function confirmExpiry() {
   expiryTarget.value = null
 }
 
-async function removeExpiry(fingerprint) {
+async function removeExpiry(key) {
   await apiAction(
-    `/api/keys/remove-expiry/${efp(fingerprint)}`,
-    null,
+    `/api/keys/remove-expiry/${efp(key.fingerprint)}`,
+    { unix_user: key.unix_user || undefined, hostname },
     'POST',
     t('server_detail.expiry_removed')
   )
@@ -756,6 +775,15 @@ dd {
   font-size: 0.85rem;
   color: var(--text-secondary);
   margin: 0 0 0.75rem;
+}
+
+.root-warning {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+  border-radius: 4px;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.85rem;
 }
 
 .empty {

--- a/ui/tests/DeployedUsersTable.spec.js
+++ b/ui/tests/DeployedUsersTable.spec.js
@@ -338,4 +338,140 @@ describe('DeployedUsersTable', () => {
     const hasActions = headers.some((h) => h.text().toUpperCase().includes('ACTION'))
     expect(hasActions).toBe(false)
   })
+
+  it('disables group button and shows badge when user has active session', async () => {
+    const usersWithSession = [{ ...MOCK_USERS[0], has_active_session: true }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(usersWithSession) }))
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    const groupBtn = w.find('[data-testid="btn-group-alice-prod-01"]')
+    expect(groupBtn.attributes('disabled')).toBeDefined()
+    expect(groupBtn.element.parentElement.title).toContain('active session')
+
+    const badge = w.find('[data-testid="session-alice-prod-01"]')
+    expect(badge.exists()).toBe(true)
+    expect(badge.text()).toBe('Active session')
+  })
+
+  it('does not show session badge when has_active_session is false', async () => {
+    const usersNoSession = [{ ...MOCK_USERS[0], has_active_session: false }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(usersNoSession) }))
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    expect(w.find('[data-testid="session-alice-prod-01"]').exists()).toBe(false)
+  })
+
+  it('sends API request even when currentGroup === newGroup', async () => {
+    const usersWithGroup = [{ ...MOCK_USERS[0], sam_group: 'sam-operator' }]
+
+    let capturedEndpoint = null
+
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url === '/api/access/deployed-users') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(usersWithGroup),
+        })
+      }
+      if (url === '/api/access/change-group') {
+        capturedEndpoint = url
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              actual_groups: ['sam-operator'],
+            }),
+        })
+      }
+    })
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    await w.find('[data-testid="btn-group-alice-prod-01"]').trigger('click')
+    await flushPromises()
+
+    expect(w.find('[data-testid="group-modal"]').exists()).toBe(true)
+
+    await w.find('[data-testid="group-modal-confirm"]').trigger('click')
+    await flushPromises()
+
+    expect(capturedEndpoint).toBe('/api/access/change-group')
+  })
+
+  it('shows verification result with actual_groups in success message', async () => {
+    vi.stubGlobal('fetch', (url, opts) => {
+      if (url === '/api/access/deployed-users') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(MOCK_USERS),
+        })
+      }
+      if (url === '/api/access/grant-group') {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              unix_user: 'alice',
+              hostname: 'prod-01',
+              actual_groups: ['sam-operator', 'sam-pkg'],
+            }),
+        })
+      }
+    })
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    await w.find('[data-testid="btn-group-alice-prod-01"]').trigger('click')
+    await flushPromises()
+
+    const select = w.find('[data-testid="group-modal-select"]')
+    await select.setValue('sam-operator')
+    await w.find('[data-testid="group-modal-confirm"]').trigger('click')
+    await flushPromises()
+
+    const success = w.find('[data-testid="success-alice-prod-01"]')
+    expect(success.exists()).toBe(true)
+    expect(success.text()).toContain('alice')
+    expect(success.text()).toContain('prod-01')
+    expect(success.text()).toContain('sam-operator')
+    expect(success.text()).toContain('sam-pkg')
+  })
+
+  it('disables lock and group buttons for root user', async () => {
+    const rootUser = [{ unix_user: 'root', hostname: 'prod-01', ip_address: '10.0.0.1', expires_at: null, has_active_session: false }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(rootUser) }))
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    const lockBtn = w.find('[data-testid="btn-lock-root-prod-01"]')
+    expect(lockBtn.attributes('disabled')).toBeDefined()
+    expect(lockBtn.element.parentElement.title).toBeTruthy()
+
+    const groupBtn = w.find('[data-testid="btn-group-root-prod-01"]')
+    expect(groupBtn.attributes('disabled')).toBeDefined()
+    expect(groupBtn.element.parentElement.title).toBeTruthy()
+  })
+
+  it('does not disable lock and group buttons for non-root users', async () => {
+    const normalUser = [{ unix_user: 'alice', hostname: 'prod-01', ip_address: '10.0.0.1', expires_at: null, has_active_session: false }]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(normalUser) }))
+
+    const w = mount(DeployedUsersTable, mountOpts)
+    await flushPromises()
+
+    const lockBtn = w.find('[data-testid="btn-lock-alice-prod-01"]')
+    expect(lockBtn.attributes('disabled')).toBeUndefined()
+
+    const groupBtn = w.find('[data-testid="btn-group-alice-prod-01"]')
+    expect(groupBtn.attributes('disabled')).toBeUndefined()
+  })
 })

--- a/ui/tests/KeyTable.spec.js
+++ b/ui/tests/KeyTable.spec.js
@@ -141,11 +141,25 @@ describe('KeyTable', () => {
     expect(w.emitted('set-expiry')).toBeTruthy()
   })
 
-  it('emits remove-expiry with fingerprint', async () => {
-    const w = mountTable([makeKey({ status: 'ACTIVE', expires_at: '2099-01-01T00:00:00' })])
+  it('disables Expiry button for root unix_user', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'root' })])
+    const btn = w.find('.btn-warning')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.element.parentElement.title).toBeTruthy()
+  })
+
+  it('does not disable Expiry button for non-root unix_user', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'alice' })])
+    const btn = w.find('.btn-warning')
+    expect(btn.attributes('disabled')).toBeUndefined()
+  })
+
+  it('emits remove-expiry with full key object', async () => {
+    const key = makeKey({ status: 'ACTIVE', expires_at: '2099-01-01T00:00:00', unix_user: 'alice' })
+    const w = mountTable([key])
     await w.find('.btn-unlimited').trigger('click')
     expect(w.emitted('remove-expiry')).toBeTruthy()
-    expect(w.emitted('remove-expiry')[0][0]).toBe(FP)
+    expect(w.emitted('remove-expiry')[0][0]).toMatchObject({ fingerprint: FP, unix_user: 'alice' })
   })
 
   it('emits assign with fingerprint', async () => {
@@ -240,7 +254,7 @@ describe('KeyTable', () => {
     const revokeBtn = w.findAll('button').find((b) => b.text() === 'Revoke')
     expect(revokeBtn).toBeDefined()
     expect(revokeBtn.attributes('disabled')).toBeDefined()
-    expect(revokeBtn.attributes('title')).toContain('Cannot revoke')
+    expect(revokeBtn.element.parentElement.title).toContain('Cannot revoke')
   })
 
   it('keeps revoke button enabled when scanOk is true', () => {
@@ -350,13 +364,14 @@ describe('KeyTable', () => {
     expect(w.emitted('bulk-validate')[0][0]).toContain(FP)
   })
 
-  it('emits bulk-revoke with fingerprints', async () => {
+  it('emits bulk-revoke with compound keys (fingerprint|unix_user)', async () => {
     const key = makeKey({ status: 'ACTIVE' })
     const w = mountTable([key])
     await w.find('tbody input[type="checkbox"]').setChecked(true)
     await w.find('[data-testid="bulk-revoke-btn"]').trigger('click')
     expect(w.emitted('bulk-revoke')).toBeTruthy()
-    expect(w.emitted('bulk-revoke')[0][0]).toContain(FP)
+    const emitted = w.emitted('bulk-revoke')[0][0]
+    expect(emitted.some((k) => k.startsWith(FP))).toBe(true)
   })
 
   it('select-all checks all selectable rows on page', async () => {
@@ -372,5 +387,30 @@ describe('KeyTable', () => {
   it('REVOKED rows are not selectable', async () => {
     const w = mountTable([makeKey({ status: 'REVOKED' })])
     expect(w.find('tbody input[type="checkbox"]').exists()).toBe(false)
+  })
+
+  // --- Root protection ---
+
+  it('root ACTIVE row is not selectable (no checkbox)', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'root' })])
+    expect(w.find('tbody input[type="checkbox"]').exists()).toBe(false)
+  })
+
+  it('root ACTIVE row has Revoke button disabled', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'root' })])
+    const btn = w.find('.btn-danger')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.element.parentElement.title).toBeTruthy()
+  })
+
+  it('root row shows protected badge', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'root' })])
+    expect(w.find('.badge-root-protected').exists()).toBe(true)
+  })
+
+  it('root row has row-root class', () => {
+    const w = mountTable([makeKey({ status: 'ACTIVE', unix_user: 'root' })])
+    const rows = w.findAll('tbody tr').filter((r) => r.find('code').exists())
+    expect(rows[0].classes()).toContain('row-root')
   })
 })

--- a/ui/tests/ServerDetail.spec.js
+++ b/ui/tests/ServerDetail.spec.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import en from '../src/locales/en.json'
+import ServerDetail from '../src/views/ServerDetail.vue'
+
+vi.mock('../src/composables/useAuth.js', () => ({
+  useAuth: () => ({
+    admin: { value: { username: 'admin', role: 'sysadmin' } },
+    logout: vi.fn(),
+  }),
+  apiFetch: async (url, options = {}) => global.fetch(url, options),
+}))
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+const MOCK_SERVER = {
+  hostname: 'test-server',
+  ip_address: '10.0.0.1',
+  ssh_port: 22,
+  environment: 'production',
+  os_family: 'debian',
+  os_version: '12',
+  is_active: true,
+  added_at: '2024-01-01T00:00:00Z',
+  last_scan_ok: true,
+  last_scan_error: null,
+  max_sessions: 2,
+}
+
+const MOCK_KEYS = [
+  {
+    fingerprint: 'SHA256:aaa',
+    unix_user: 'root',
+    status: 'ACTIVE',
+    key_type: 'ssh-ed25519',
+    owner_name: 'Root Key',
+    expires_at: null,
+    added_at: '2024-01-01T00:00:00Z',
+    hostname: 'test-server',
+  },
+  {
+    fingerprint: 'SHA256:bbb',
+    unix_user: 'alice',
+    status: 'ACTIVE',
+    key_type: 'ssh-ed25519',
+    owner_name: 'Alice',
+    expires_at: null,
+    added_at: '2024-01-01T00:00:00Z',
+    hostname: 'test-server',
+  },
+]
+
+function createMockRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/servers/:hostname', component: ServerDetail }],
+  })
+}
+
+function setupFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SERVER) })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+  )
+}
+
+beforeEach(() => {
+  setupFetch()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+async function mountServerDetail() {
+  const router = createMockRouter()
+  await router.push('/servers/test-server')
+  const w = mount(ServerDetail, { global: { plugins: [i18n, router] } })
+  await flushPromises()
+  return w
+}
+
+describe('ServerDetail — root revoke warning', () => {
+  it('shows root warning in single revoke modal when unix_user is root', async () => {
+    const w = await mountServerDetail()
+    w.vm.revokeTarget = MOCK_KEYS[0]
+    await w.vm.$nextTick()
+    expect(w.find('.root-warning').exists()).toBe(true)
+  })
+
+  it('does not show root warning in single revoke modal for non-root user', async () => {
+    const w = await mountServerDetail()
+    w.vm.revokeTarget = MOCK_KEYS[1]
+    await w.vm.$nextTick()
+    expect(w.find('.root-warning').exists()).toBe(false)
+  })
+
+  it('shows root warning in bulk revoke modal when selection contains a root key', async () => {
+    const w = await mountServerDetail()
+    w.vm.bulkRevokeFingerprints = ['SHA256:aaa|root', 'SHA256:bbb|alice']
+    await w.vm.$nextTick()
+    expect(w.find('.root-warning').exists()).toBe(true)
+  })
+
+  it('does not show root warning in bulk revoke modal when no root key selected', async () => {
+    const w = await mountServerDetail()
+    w.vm.bulkRevokeFingerprints = ['SHA256:bbb|alice']
+    await w.vm.$nextTick()
+    expect(w.find('.root-warning').exists()).toBe(false)
+  })
+
+  it('does not show root warning when only a key sharing fingerprint with root is selected (not root itself)', async () => {
+    const w = await mountServerDetail()
+    w.vm.bulkRevokeFingerprints = ['SHA256:aaa|helene']
+    await w.vm.$nextTick()
+    expect(w.find('.root-warning').exists()).toBe(false)
+  })
+})
+
+describe('ServerDetail — expiry scoped to unix_user + hostname', () => {
+  it('sends unix_user and hostname in set-expiry request', async () => {
+    const fetchSpy = vi.fn((url, opts) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys') && !url.includes('set-expiry')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SERVER) })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    w.vm.expiryTarget = MOCK_KEYS[1]
+    w.vm.expiryMode = 'hours'
+    w.vm.expiryHours = 2
+    await w.vm.confirmExpiry()
+    await flushPromises()
+
+    const expiryCall = fetchSpy.mock.calls.find((c) => c[0].includes('set-expiry'))
+    expect(expiryCall).toBeDefined()
+    const body = JSON.parse(expiryCall[1].body)
+    expect(body.unix_user).toBe('alice')
+    expect(body.hostname).toBe('test-server')
+  })
+
+  it('sends unix_user and hostname in remove-expiry request', async () => {
+    const fetchSpy = vi.fn((url, opts) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys') && !url.includes('remove-expiry')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_SERVER) })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    await w.vm.removeExpiry(MOCK_KEYS[1])
+    await flushPromises()
+
+    const removeCall = fetchSpy.mock.calls.find((c) => c[0].includes('remove-expiry'))
+    expect(removeCall).toBeDefined()
+    const body = JSON.parse(removeCall[1].body)
+    expect(body.unix_user).toBe('alice')
+    expect(body.hostname).toBe('test-server')
+  })
+})


### PR DESCRIPTION
Closes #386

## Summary

- **Protection root — défense en profondeur** : `revoke_key`, `set_key_expiry`, `remove_key_expiry`, `deploy_key` refusent explicitement `unix_user == 'root'` (UserError 400) ; `expire_keys()` exclut root en SQL ; `bulk_revoke_keys` skip les fingerprints root automatiquement
- **UI root cohérente** : lignes root grisées + badge "protected" dans KeyTable et DeployedUsersTable ; boutons Revoke/Expiry/Lock/Group désactivés avec tooltip via `<span>` wrapper (fix navigateur — `disabled` buttons ne reçoivent pas les événements souris)
- **Fix checkbox sélection** : sélection utilise des clés composées `fingerprint|unix_user` — cocher helene ne sélectionnait plus root si même fingerprint partagé ; `bulkRevokeHasRoot` vérifie `|root` dans les clés composées (supprime le faux positif)
- **Justification de déploiement** : `deploy_key` stocke maintenant la justification dans le `details` du `audit_log` KEY_ADDED — visible dans la page Audit
- **Sessions Flask** : `SESSION_COOKIE_SECURE`, `SameSite=Lax`, `HttpOnly` ; `_get_client_ip()` préfère `X-Real-IP` (non-spoofable)

## Test plan

- [ ] Backend : `python -m pytest app/tests/ -q` → 615 passed
- [ ] Frontend : `npm run test` (dans `ui/`) → 344 passed
- [ ] Vérifier que la ligne root est grisée + badge "protected" dans la page serveur (SSH Keys)
- [ ] Vérifier que la ligne root est grisée + badge "protected" dans la page Access (Deployed Users)
- [ ] Vérifier que cocher la checkbox de helene (même fingerprint que root) n'affiche pas le warning root dans la modal bulk revoke
- [ ] Vérifier que `curl -X POST /api/keys/revoke/<fp> -d '{"unix_user":"root",...}'` retourne 400
- [ ] Vérifier que la justification apparaît dans la page Audit après un déploiement de clé

🤖 Generated with [Claude Code](https://claude.com/claude-code)