### PR TITLE
docs: update README, DESIGN, CLAUDE and agents post-#383/#384/#386

### DIFF
--- a/.claude/agents/backend-dev.md
+++ b/.claude/agents/backend-dev.md
@@ -57,16 +57,18 @@ known_hosts : `/data/keys/known_hosts`. Clé privée : `/data/keys/collector_key
 **Connexions SSH via ip_address uniquement** — pas le hostname (non résolvable depuis le container, #80, #84).
 known_hosts indexé par IP : `ssh-keyscan -H -T 10 <ip_address>`.
 
-### Scripts distants — 6 constantes Python `bytes` dans ssh.py
+### Scripts distants — 8 constantes Python `bytes` dans ssh.py
 
 | Constante | Path distant | Action |
 |-----------|-------------|--------|
 | SAM_COLLECT | /usr/local/bin/sam-collect (root, 750) | Lit toutes les authorized_keys → stdout : `unix_user\tkey_type key_b64 [comment]` |
 | SAM_REVOKE | /usr/local/bin/sam-revoke \<fp_hex\> (root, 750) | Révoque par fingerprint SHA256 hex. Atomique mktemp+mv. Préserve ownership (#104) |
-| SAM_ADD | /usr/local/bin/sam-add \<unix_user\> \<pubkey\> (root, 750) | Crée user Unix + authorized_keys idempotent (#164) |
+| SAM_ADD | /usr/local/bin/sam-add \<unix_user\> \<pubkey\> (root, 750) | Crée user Unix + authorized_keys idempotent (#164). À la création : mot de passe temporaire (`openssl rand -base64 12`), `chpasswd`, `~/README_first_login.txt` (chmod 600), `~/.profile` invoque `passwd` au premier login. `usermod -aG sam-users` — l'authentification SSH par mot de passe est interdite (bloc sshd `Match Group sam-users`). Pas de `chage -d 0` (#383) |
 | SAM_LOCK_USER | /usr/local/bin/sam-lock-user \<unix_user\> (root, 750) | `usermod -L -s /sbin/nologin` (#181) |
 | SAM_UNLOCK_USER | /usr/local/bin/sam-unlock-user \<unix_user\> (root, 750) | `usermod -U -s /bin/bash` (#181) |
 | SAM_SESSIONS | /usr/local/bin/sam-sessions (root, 750) | Collecte sessions SSH actives + historique → stdout : `A\|H\tuser\ttty\tip\trest`. `utmpdump /var/run/utmp` + fallback `LANG=C last -F` (#253, #322) |
+| SAM_GRANT_GROUP | /usr/local/bin/sam-grant-group \<unix_user\> \<group\> (root, 750) | Valide groupe (sam-operator\|sam-pkg\|sam-root), `gpasswd -a` — fonctionne même quand l'utilisateur est connecté (#383) |
+| SAM_REVOKE_GROUP | /usr/local/bin/sam-revoke-group \<unix_user\> \<group\> (root, 750) | Valide groupe, `gpasswd -d ... \|\| true` — idempotent (#383) |
 
 ### ensure_scripts()
 
@@ -86,9 +88,17 @@ known_hosts indexé par IP : `ssh-keyscan -H -T 10 <ip_address>`.
 
 ### Accès temporaires
 - `grant_access`, `approve_request`, `reject_request`, `revoke_request`
-- `deploy_key(public_key, unix_user, hostname, expires_at, justification, admin_id)` — parse + fingerprint, INSERT ssh_keys, sam-add, key_authorization ACTIVE (#164, #185)
+- `deploy_key(public_key, unix_user, hostname, expires_at, justification, admin_id, sam_group=None)` — parse + fingerprint, INSERT ssh_keys, sam-add, key_authorization ACTIVE (#164, #185). Si `sam_group` fourni : valide contre `VALID_SAM_GROUPS` + appelle `ssh.grant_group_on_server()`. **Refuse `unix_user == 'root'`** (#386). Révoque l'éventuel groupe précédent lors d'un redéploiement.
 - `lock_user(unix_user, hostname, admin_id)` — valide POSIX, sam-lock-user, USER_LOCKED (#181)
 - `unlock_user(unix_user, hostname, admin_id)` — valide POSIX, sam-unlock-user, USER_UNLOCKED (#181)
+
+### Groupes SAM sudo (#383, #384)
+- `VALID_SAM_GROUPS = ("sam-operator", "sam-pkg", "sam-root")` — constante partagée
+- `_get_current_group(unix_user, hostname) -> str | None` — helper interne
+- `grant_group(unix_user, hostname, group, admin_id)` — vérifie déploiement actif, sam-grant-group, UPDATE BDD, log GROUP_GRANTED
+- `revoke_group(unix_user, hostname, admin_id)` — récupère groupe actuel, sam-revoke-group, nullifie BDD, log GROUP_REVOKED
+- `change_group(unix_user, hostname, new_group, admin_id)` — noop si même groupe, sinon revoke + grant, log GROUP_CHANGED
+- **Protection root** : toute fonction de cette section refuse `unix_user == 'root'`
 
 ### Serveurs
 - `add_server(hostname, ip, ssh_user, ssh_password, env, os_family, ssh_port, admin_id)` — provisionnement atomique : keyscan → SSH → INSERT (#299, #301). SSH password non stocké.
@@ -163,6 +173,8 @@ POST /api/access/request                             POST /api/access/deploy
 POST /api/access/lock-user                           POST /api/access/unlock-user
 POST /api/access/<id>/approve                        POST /api/access/<id>/reject
 POST /api/access/<id>/revoke
+POST /api/access/grant-group                         POST /api/access/revoke-group
+PUT  /api/access/change-group
 
 GET    /api/admins                                   GET  /api/admins/me
 POST   /api/admins                                   PUT  /api/admins/<username>
@@ -182,7 +194,7 @@ PUT  /api/system/config                              POST /api/system/test-smtp
 ```
 servers list / add / update / disable / enable / show / scan
 keys list / show / validate / revoke / assign / set-expiry / remove-expiry / search
-access list / show / grant / request / approve / reject / revoke / lock-user / unlock-user
+access list / show / grant / request / approve / reject / revoke / lock-user / unlock-user / grant-group / revoke-group / change-group
 admin list / add / update / disable / enable / delete / reset-password
 audit list
 system status / report

--- a/.claude/agents/db-specialist.md
+++ b/.claude/agents/db-specialist.md
@@ -95,11 +95,17 @@ CREATE TABLE key_authorizations (
     revoked_by            UUID REFERENCES administrators(id) ON DELETE SET NULL,
     revoked_automatically BOOLEAN DEFAULT false,
     revocation_justification TEXT,
+    sam_group             VARCHAR(20)
+                              CHECK (sam_group IS NULL OR sam_group IN (
+                                  'sam-operator', 'sam-pkg', 'sam-root'
+                              )),
     PRIMARY KEY (key_id, server_id, unix_user)
 );
 ```
 
 **PK composite (key_id, server_id, unix_user)** — la même clé peut être ACTIVE pour `alice` et REVOKED pour `root` sur le même serveur (#185).
+
+**Colonne `sam_group`** (audit v4, #383) — NULL ou groupe sudo SAM assigné à l'utilisateur Unix. Migrations gérées par `bootstrap.sh` avec le superuser `postgres` (la contrainte CHECK ajoutée en v4 nécessite ALTER TABLE).
 
 ### access_requests
 ```sql
@@ -134,7 +140,8 @@ CREATE TABLE audit_log (
                      'ADMIN_DELETED', 'ADMIN_UPDATED',
                      'USER_LOCKED', 'USER_UNLOCKED',
                      'LOGIN_FAILED', 'LOGIN_BANNED', 'PASSWORD_RESET',
-                     'SERVER_PROVISIONED', 'SESSION_LIMIT_EXCEEDED'
+                     'SERVER_PROVISIONED', 'SESSION_LIMIT_EXCEEDED',
+                     'GROUP_GRANTED', 'GROUP_REVOKED', 'GROUP_CHANGED'
                  )),
     performed_by UUID REFERENCES administrators(id) ON DELETE SET NULL,
     target_key   UUID REFERENCES ssh_keys(id),

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -61,9 +61,9 @@ server: {
 | KeyTable.vue | Tableau clés + filtres texte + dropdown statut (#189) + bouton Illimité (#93) + tooltip non-conformité + sélection en masse (bulk validate/revoke, #345) + tri colonnes |
 | KeyActions.vue | Boutons valider/révoquer/expiry |
 | ExpiryPicker.vue | Modes exclusifs heures / date précise |
-| DeployKeyForm.vue | Formulaire déploiement clé SSH |
+| DeployKeyForm.vue | Formulaire déploiement clé SSH — champ optionnel **SAM group** (sam-operator/sam-pkg/sam-root) ; option sam-root masquée si rôle ≠ sysadmin ; refuse `unix_user='root'` côté client (#383, #384, #386) |
 | UserLockForm.vue | Verrouillage/déverrouillage compte Unix (#181) |
-| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer + tri colonnes |
+| DeployedUsersTable.vue | Utilisateurs Unix déployés + filtres + RBAC operator/viewer + tri colonnes + colonne **SAM group** avec actions Promote/Change/Revoke (RBAC : sam-root = sysadmin uniquement). Refuse `unix_user='root'` (#383, #384, #386) |
 | AdminsTable.vue | Tableau administrateurs + filtre texte + pagination + garde-fou self (#250) + tri colonnes |
 | AuditTable.vue | Tableau audit + filtres serveur/action/date + pagination (#250) + export CSV (#343) + tri colonnes |
 | AnomaliesTable.vue | Tableau anomalies + filtres texte/type/serveur/conformité + pagination (#250) + export CSV (#343) + tri colonnes |
@@ -123,6 +123,8 @@ POST /api/access/request                             POST /api/access/deploy
 POST /api/access/lock-user                           POST /api/access/unlock-user
 POST /api/access/<id>/approve                        POST /api/access/<id>/reject
 POST /api/access/<id>/revoke
+POST /api/access/grant-group                         POST /api/access/revoke-group
+PUT  /api/access/change-group
 
 GET    /api/admins                                   GET  /api/admins/me
 POST   /api/admins                                   PUT  /api/admins/<username>

--- a/.claude/agents/infra-dev.md
+++ b/.claude/agents/infra-dev.md
@@ -153,7 +153,27 @@ ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-add *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-sessions
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-grant-group *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke-group *
 ```
+
+## SAM sudo groups + sshd Match Group sam-users (#383, #384)
+
+`provision-host.sh` doit également :
+
+1. **Créer 4 groupes Unix** s'ils n'existent pas : `sam-operator`, `sam-pkg`, `sam-root`, `sam-users` (via `getent group ... || groupadd ...`)
+2. **Installer 3 fichiers sudoers SAM** dans `/etc/sudoers.d/` (chmod 440, validation `visudo -c` avant move) :
+   - `sam-operator` : commandes opérateur (systemctl, journalctl, etc.), `PASSWD:` obligatoire
+   - `sam-pkg` : gestion paquets (dnf, apt), `PASSWD:` obligatoire
+   - `sam-root` : `(ALL) PASSWD: ALL`, réservé `sysadmin`
+   - Tous : `Defaults:%sam-* secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"` pour résoudre `runagent`/`api-cli`
+   - **Helper `_bin()`** dans le script : retourne le path absolu d'une commande (cherche dans `/usr/local/bin`, `/usr/sbin`, etc.) — utilisé pour générer les règles
+3. **Installer `/etc/ssh/sshd_config.d/sam-users.conf`** avec `Match Group sam-users` → `PasswordAuthentication no`, `KbdInteractiveAuthentication no` (puis `systemctl reload sshd` ou équivalent)
+
+**Invariants** :
+- Jamais `NOPASSWD:` pour les groupes SAM (différent d'`audit-collector` qui doit rester NOPASSWD)
+- Toujours `visudo -c <fichier-temp>` avant `install -m 440` ; si validation KO → erreur, pas d'installation
+- Le script est idempotent : peut être rejoué sans risque (créations conditionnelles, `install` qui écrase)
 
 ## Tu ne touches jamais à...
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -28,10 +28,13 @@ Tu effectues des revues de sécurité sur le code du projet ssh-access-manager. 
 ### 2. Scripts distants (Critique)
 
 Vérifier dans `ssh.py` :
-- Les constantes `SAM_COLLECT`, `SAM_REVOKE`, `SAM_ADD`, `SAM_LOCK_USER`, `SAM_UNLOCK_USER`, `SAM_SESSIONS` sont des **`bytes` Python** (pas des strings ni des fichiers)
+- Les constantes `SAM_COLLECT`, `SAM_REVOKE`, `SAM_ADD`, `SAM_LOCK_USER`, `SAM_UNLOCK_USER`, `SAM_SESSIONS`, `SAM_GRANT_GROUP`, `SAM_REVOKE_GROUP` sont des **`bytes` Python** (pas des strings ni des fichiers)
 - Le déploiement se fait via SFTP dans le home du collector, puis `sudo /usr/bin/install -m 750 -o root -g root` (jamais `mv` + `chmod` séparés — atomique, #161)
 - `sam-revoke` utilise `mktemp` + `mv` atomique pour réécrire authorized_keys
 - Aucune injection de commande possible dans le fingerprint passé à sam-revoke
+- `sam-add` : mot de passe temporaire généré par `openssl rand -base64 12` (12 octets entropie ≈ 96 bits), set par `chpasswd` (jamais `passwd --stdin` ou `echo | passwd`). `~/README_first_login.txt` doit être `chmod 600` + `chown <user>:<user>`. **Pas de `passwd -d`** (créerait un compte sans mot de passe et bypass PAM nullok pour sudo)
+- `sam-grant-group` / `sam-revoke-group` : valident le groupe en argument contre une whitelist (`sam-operator|sam-pkg|sam-root`) avant toute action `gpasswd`
+- L'utilisateur créé par `sam-add` est **toujours** ajouté au groupe `sam-users` (via `usermod -aG sam-users`)
 
 ### 3. Injection et OWASP Top 10
 
@@ -78,15 +81,35 @@ ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-add *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-lock-user *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-unlock-user *
 ${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-sessions
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-grant-group *
+${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-revoke-group *
 ```
 Aucune règle `ALL=(ALL) NOPASSWD: ALL` ou équivalent permissif.
 Généré avec `printf` ligne par ligne (résistant au CRLF PTY). Créé via `install -m 440` (évite ":" dans les args — #161).
+
+Pour les **règles sudoers des groupes SAM** (`sam-operator`, `sam-pkg`, `sam-root`, #383, #384) :
+- **`PASSWD:` obligatoire** — jamais `NOPASSWD:` (différent d'audit-collector). Toute occurrence `NOPASSWD:` dans un fichier `/etc/sudoers.d/sam-*` est une vulnérabilité CRITIQUE.
+- **`visudo -c <fichier-temp>` avant `install -m 440`** — une règle invalide ne doit jamais être installée.
+- `secure_path` explicite incluant `/usr/local/bin` pour résoudre `runagent`/`api-cli`.
+- Bloc `Match Group sam-users` dans `/etc/ssh/sshd_config.d/` avec `PasswordAuthentication no` + `KbdInteractiveAuthentication no` — les utilisateurs SAM ne peuvent **jamais** se connecter en SSH par mot de passe.
 
 ### 8. Audit trail — intégrité
 
 - Toute action sensible doit être tracée dans `audit_log`
 - Les actions de révocation doivent inclure `performed_by` et `details` JSONB
 - Vérifier que `ANOMALY_DETECTED` est bien émis dans les 3 scénarios d'anomalie (scénario 2 : révocation hors système, scénario 3 : clé inconnue, scénario 5 : clé réapparue)
+- Les actions SAM groups (`GROUP_GRANTED`, `GROUP_REVOKED`, `GROUP_CHANGED`) doivent être tracées avec `performed_by`, `target_server` et `details` incluant `unix_user` + `group`
+
+### 9. Protection du compte root (#386)
+
+Vérifier que les fonctions suivantes refusent toujours `unix_user == 'root'` (lèvent `UserError`) :
+- `actions.deploy_key()`
+- `actions.revoke_key()` (targeted ou global)
+- `actions.set_key_expiry()` / `actions.remove_key_expiry()` (targeted ou global)
+- `actions.grant_group()` / `actions.revoke_group()` / `actions.change_group()`
+- `actions.bulk_revoke_keys()` skippe automatiquement les fingerprints liés à root
+
+Vérifier que `expire_keys()` exclut `unix_user != 'root'` dans la requête SQL — sécurité contre toute révocation automatique du compte root.
 
 ## Format de rapport
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ Projet "ssh-access-manager" — audit et gestion des accès SSH dans un containe
 VAE RNCP41330 "Expert en développement logiciel" Niveau 7 — C.1.6.
 Développeur : Stéphane de Labrusse.
 
-## État du projet — toutes issues fermées (85/85)
+## État du projet — toutes issues fermées (88/88)
 
-Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303, 312, 314, 320, 322, 324, 326, 328, 330, 332, 335, 337, 339, 343, 345, 346, 348, 350, 352, 354, 357, 360, 361, 363, 365, 367, 368, 378, 380) ✅
+Milestone 1–4 + issues supplémentaires (25, 51–54, 61–62, 70–71, 73–74, 80, 82, 86, 88–89, 108, 110, 112, 114, 116, 119, 127, 129, 133, 137, 139–140, 143, 145–148, 181, 183, 185, 222, 223, 228, 230, 236, 239, 253, 257, 259, 260, 299, 301, 302, 303, 312, 314, 320, 322, 324, 326, 328, 330, 332, 335, 337, 339, 343, 345, 346, 348, 350, 352, 354, 357, 360, 361, 363, 365, 367, 368, 378, 380, 383, 384, 386) ✅
 
 ## Stack vérifiée et figée
 
@@ -34,6 +34,14 @@ Volume unique /data/ :
 - config/servers.yml — liste déclarative des serveurs
 
 Nginx : `/api/` → proxy Flask, `/` → /app/static (SPA). Pas de Basic Auth (supprimé — #54).
+
+## Modèle SAM sudo groups (#383, #384)
+
+Trois groupes Unix dédiés sont créés par `provision-host.sh` sur chaque serveur géré : `sam-operator`, `sam-pkg`, `sam-root`. Les règles sudoers SAM associées (chmod 440, validées avec `visudo -c`) exigent `PASSWD:` (jamais NOPASSWD) et fixent `secure_path` incluant `/usr/local/bin`.
+
+Un quatrième groupe `sam-users` regroupe tous les utilisateurs Unix créés via `sam-add`. Le bloc sshd `Match Group sam-users` interdit l'authentification par mot de passe — ces utilisateurs ne peuvent se connecter qu'avec leur clé SSH publique. À la création, `sam-add` génère un mot de passe temporaire (`openssl rand -base64 12`), le set via `chpasswd`, écrit `~/README_first_login.txt` (chmod 600) et `~/.profile` invoque `passwd` automatiquement au premier login pour forcer le changement.
+
+Le compte `root` est protégé : non-déployable, non-révocable, non-promotable en groupe SAM. La colonne `key_authorizations.sam_group` (VARCHAR(20), CHECK IN sam-operator/sam-pkg/sam-root, audit v4) trace le groupe assigné. Routes : `POST /api/access/grant-group`, `POST /api/access/revoke-group`, `PUT /api/access/change-group`. La promotion en `sam-root` est réservée au rôle `sysadmin`.
 
 ## Modules Python — responsabilités
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -359,6 +359,64 @@ fi
 
 Le `mktemp` + `mv` est atomique au niveau du système de fichiers. La comparaison se fait par fingerprint SHA256 via `ssh-keygen -l -E sha256` (pas par regex sur la clé brute). Le `chown` préserve le propriétaire du répertoire parent avant le remplacement.
 
+### 6.6 Modèle SAM sudo groups (issues #383, #384)
+
+Trois groupes Unix prédéfinis sont créés sur chaque serveur par `provision-host.sh` pour structurer les privilèges sudo des utilisateurs déployés via `sam-add` :
+
+| Groupe | Périmètre sudo | Rôle minimal requis |
+|---|---|---|
+| `sam-operator` | Commandes d'exploitation (systemctl, journalctl, etc.) | operator |
+| `sam-pkg` | Gestion paquets (dnf, apt) | operator |
+| `sam-root` | Accès root équivalent | sysadmin uniquement |
+
+**Invariants sécurité** :
+
+- Toutes les règles sudoers SAM utilisent `PASSWD:` — **jamais `NOPASSWD:`** (contrairement à `audit-collector` qui reste `NOPASSWD` car SAM authentifie via la clé). L'utilisateur doit saisir son mot de passe personnel (défini au premier login) pour `sudo`.
+- `secure_path` est explicitement défini pour inclure `/usr/local/bin` afin que les outils NS8 (`runagent`, `api-cli`) soient résolvables.
+- Chaque fichier sudoers est **validé par `visudo -c` avant installation** : une règle invalide est rejetée sans casser la config sudo existante.
+- Le compte `root` est **non-promotable** : `actions.deploy_key()`, `grant_group()` et `change_group()` lèvent `UserError` si `unix_user == 'root'` ou si une entrée audit `unix_user='root'` correspond au fingerprint visé.
+
+Le cycle de vie est tracé par la colonne `key_authorizations.sam_group` (VARCHAR(20) nullable, contrainte `CHECK IN ('sam-operator','sam-pkg','sam-root')`, schéma audit v4) et par les événements `audit_log` `GROUP_GRANTED` / `GROUP_REVOKED` / `GROUP_CHANGED`. Les scripts distants `sam-grant-group <user> <group>` (`gpasswd -a`) et `sam-revoke-group <user> <group>` (`gpasswd -d ... || true`, idempotent) appliquent les changements à chaud — fonctionne même quand l'utilisateur est connecté en SSH.
+
+Routes Flask correspondantes :
+- `POST /api/access/grant-group` — operator pour sam-operator/sam-pkg, sysadmin pour sam-root
+- `POST /api/access/revoke-group` — operator sauf si le groupe actuel est sam-root (sysadmin requis)
+- `PUT /api/access/change-group` — sysadmin requis si sam-root est l'ancien **ou** le nouveau groupe
+
+### 6.7 Premier login d'un utilisateur SAM et blocage du mot de passe SSH
+
+Les utilisateurs Unix créés par `sam-add` ne doivent **jamais** pouvoir se connecter en SSH par mot de passe. Deux mécanismes l'empêchent :
+
+1. Tous les comptes créés par `sam-add` sont ajoutés au groupe `sam-users` (via `usermod -aG sam-users`).
+2. `provision-host.sh` installe dans `/etc/ssh/sshd_config.d/` un bloc `Match Group sam-users` avec `PasswordAuthentication no` et `KbdInteractiveAuthentication no`.
+
+Conséquence : seule la clé SSH publique déployée permet la connexion. Le mot de passe Unix sert uniquement à `sudo` (règles SAM `PASSWD:`).
+
+Pour activer la saisie d'un mot de passe personnel sans bloquer la première lecture du README, `sam-add` à la création applique cette séquence :
+
+```sh
+# Génération d'un mot de passe temporaire 12 caractères base64
+temp_pw=$(openssl rand -base64 12)
+echo "${unix_user}:${temp_pw}" | chpasswd
+
+# Écriture du README dans le home utilisateur (chmod 600)
+cat > "/home/${unix_user}/README_first_login.txt" <<EOF
+Temporary password: ${temp_pw}
+You will be asked to change it on next login.
+EOF
+chown ${unix_user}:${unix_user} "/home/${unix_user}/README_first_login.txt"
+chmod 600 "/home/${unix_user}/README_first_login.txt"
+
+# ~/.profile affiche le README puis force passwd au premier login interactif
+# (pas de chage -d 0 — bloquerait la lecture du README avant le shell)
+```
+
+Au premier login interactif (TTY), `~/.profile` affiche le contenu du README, supprime le fichier, puis invoque `passwd` pour que l'utilisateur définisse son propre mot de passe. Ce flux est testé dans `app/tests/test_ssh.py` (vérification du contenu de la constante `SAM_ADD`).
+
+### 6.8 Détection d'anomalies au niveau serveur (has_anomalies)
+
+La route `GET /api/servers` expose désormais un champ booléen `has_anomalies` par serveur (calculé via une jointure SQL sur `ssh_keys.status IN ('PENDING_REVIEW') OR key_authorizations.revoked_automatically = TRUE` sur les 24 dernières heures). Le Dashboard utilise ce champ pour afficher un compteur Alertes sans avoir à charger toutes les clés.
+
 ---
 
 ## 7. Politique de conformité ANSSI (BP-099)

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ sudo -l -U audit-collector
 
 La sortie doit inclure les commandes SAM (`/usr/local/bin/sam-*`) sans demande de mot de passe (`NOPASSWD`).
 
+`provision-host.sh` installe également les règles sudoers dédiées aux groupes SAM (`sam-operator`, `sam-pkg`, `sam-root`) — voir section [SAM sudo groups](#workflow--sam-sudo-groups). Toutes ces règles sont validées par `visudo -c` avant installation et exigent `PASSWD:` (jamais NOPASSWD pour les utilisateurs SAM). Le bloc sshd `Match Group sam-users` est aussi posé pour interdire l'authentification par mot de passe aux utilisateurs créés via `sam-add`.
+
 ---
 
 ## Workflow — Traitement des clés PENDING_REVIEW
@@ -343,24 +345,46 @@ Pour donner accès à un utilisateur sur un serveur depuis l'interface :
 **Via l'interface web** : Accès → section **Déployer une clé SSH**.
 
 Le formulaire demande :
-- **Utilisateur Unix** — nom du compte à créer sur le serveur cible (créé s'il n'existe pas)
+- **Utilisateur Unix** — nom du compte à créer sur le serveur cible (créé s'il n'existe pas). Le compte `root` est interdit (#386).
 - **Clé publique** — le contenu de la clé `ssh-ed25519` ou `ssh-rsa` (format authorized_keys)
 - **Serveur cible** — dropdown des serveurs actifs
+- **Groupe SAM** — *optionnel* : `sam-operator`, `sam-pkg` ou `sam-root` (réservé `sysadmin`). Voir section [SAM sudo groups](#workflow--sam-sudo-groups).
 - **Durée** — heures / date précise / illimité
 - **Justification** — obligatoire
 
 À la soumission, `sam-add` est exécuté sur le serveur distant via SSH :
-1. Crée l'utilisateur Unix s'il n'existe pas
-2. Ajoute la clé dans `~/.ssh/authorized_keys`
-3. Enregistre la clé dans la base avec statut `ACTIVE` et l'expiration choisie
+1. Crée l'utilisateur Unix s'il n'existe pas (avec `usermod -aG sam-users` — interdit l'authentification SSH par mot de passe)
+2. Si le compte est créé : génère un mot de passe temporaire, le set via `chpasswd`, écrit `~/README_first_login.txt`, et configure `~/.profile` pour invoquer `passwd` au premier login interactif
+3. Ajoute la clé dans `~/.ssh/authorized_keys`
+4. Si un Groupe SAM est sélectionné : `sam-grant-group` ajoute l'utilisateur au groupe choisi
+5. Enregistre la clé dans la base avec statut `ACTIVE`, l'expiration choisie, et le `sam_group` éventuel
 
-> **Privilèges sudo du nouvel utilisateur** : `sam-add` crée le compte Unix mais ne lui attribue aucun privilège sudo. C'est à l'administrateur système de décider. Pour donner les droits sudo :
-> ```bash
-> # Debian/Ubuntu
-> usermod -aG sudo alice
-> # RHEL/CentOS/Rocky
-> usermod -aG wheel alice
-> ```
+### Premier login d'un utilisateur SAM
+
+Lors du premier login SSH (par clé), l'utilisateur voit le contenu de `~/README_first_login.txt` (mot de passe temporaire) affiché par `~/.profile`, puis `passwd` est invoqué automatiquement pour le forcer à choisir un mot de passe personnel. Ce mot de passe est requis pour `sudo` (les règles sudoers SAM exigent `PASSWD:`). L'authentification SSH par mot de passe reste **interdite** par le bloc sshd `Match Group sam-users` — seule la clé permet de se connecter.
+
+---
+
+## Workflow — SAM sudo groups
+
+Trois groupes Unix prédéfinis sont créés par `provision-host.sh` sur chaque serveur géré : `sam-operator`, `sam-pkg`, `sam-root`. Chaque groupe a un jeu de règles sudoers dédié (validé par `visudo -c`, exigeant `PASSWD:`, avec `secure_path` incluant `/usr/local/bin` pour trouver les binaires NS8 type `runagent` / `api-cli`).
+
+| Groupe | Périmètre sudo |
+|---|---|
+| `sam-operator` | Commandes opérateur (systemctl, journalctl, etc.) |
+| `sam-pkg` | Gestion paquets (dnf/apt) |
+| `sam-root` | Accès root équivalent — réservé `sysadmin` |
+
+**Assignation du groupe** :
+- À la création de la clé : champ Groupe SAM du formulaire « Déployer une clé SSH »
+- Après création : actions **Promouvoir / Changer / Révoquer le groupe** depuis la vue Accès (rôles autorisés : `operator` pour sam-operator/sam-pkg, `sysadmin` uniquement pour sam-root)
+
+**Cycle de vie** :
+- Promotion : `POST /api/access/grant-group`
+- Changement : `PUT /api/access/change-group` (révoque l'ancien, assigne le nouveau)
+- Révocation : `POST /api/access/revoke-group` (l'utilisateur Unix reste actif, seul le groupe SAM est retiré)
+
+Tracé en base dans `key_authorizations.sam_group` (audit v4) et dans `audit_log` (`GROUP_GRANTED`, `GROUP_REVOKED`, `GROUP_CHANGED`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -367,13 +367,53 @@ Lors du premier login SSH (par clé), l'utilisateur voit le contenu de `~/README
 
 ## Workflow — SAM sudo groups
 
-Trois groupes Unix prédéfinis sont créés par `provision-host.sh` sur chaque serveur géré : `sam-operator`, `sam-pkg`, `sam-root`. Chaque groupe a un jeu de règles sudoers dédié (validé par `visudo -c`, exigeant `PASSWD:`, avec `secure_path` incluant `/usr/local/bin` pour trouver les binaires NS8 type `runagent` / `api-cli`).
+Trois groupes Unix prédéfinis sont créés par `provision-host.sh` sur chaque serveur géré : `sam-operator`, `sam-pkg`, `sam-root`. Chaque groupe a un jeu de règles sudoers dédié (validé par `visudo -c` avant installation, exigeant `PASSWD:` — jamais `NOPASSWD:`, avec `secure_path` explicite incluant `/usr/local/bin` pour résoudre les binaires NS8 type `runagent` / `api-cli`).
 
-| Groupe | Périmètre sudo |
+### `sam-operator` — exploitation et diagnostic
+
+Cible : opérateurs qui doivent superviser et redémarrer des services sans pouvoir installer de paquets ni accéder à des données sensibles. Règles sudoers installées dans `/etc/sudoers.d/sam-operator` :
+
+| Catégorie | Commandes autorisées (en tant que `root`, `PASSWD:`) |
 |---|---|
-| `sam-operator` | Commandes opérateur (systemctl, journalctl, etc.) |
-| `sam-pkg` | Gestion paquets (dnf/apt) |
-| `sam-root` | Accès root équivalent — réservé `sysadmin` |
+| Services systemd | `systemctl restart`, `systemctl reload`, `systemctl status`, `systemctl start` |
+| Journaux | `journalctl -u`, `journalctl -f`, `journalctl -n`, `journalctl --since`, `journalctl -b`, `journalctl -e` |
+| Réseau / processus | `ss -tlnp`, `lsof`, `lsof -i` |
+| Diagnostic noyau | `dmesg` |
+| Disque | `du -sh /var/* /opt/* /home/*` |
+| Outils NS8 (si présents) | `runagent`, `api-cli` |
+
+### `sam-pkg` — exploitation + gestion paquets
+
+Cible : utilisateurs qui doivent en plus installer ou mettre à jour des paquets. Hérite **de toutes les commandes `sam-operator`** et ajoute la gestion paquets adaptée à la distribution détectée par `provision-host.sh`. Règles sudoers dans `/etc/sudoers.d/sam-pkg` :
+
+| Catégorie | Commandes autorisées (en plus de sam-operator) |
+|---|---|
+| Debian / Ubuntu | `apt install`, `apt upgrade` |
+| RHEL / Rocky / Alma | `dnf install`, `dnf upgrade` (ou `yum install`, `yum update`) |
+| SUSE | `zypper install`, `zypper update` |
+| Alpine | `apk add`, `apk upgrade` |
+| Arch | `pacman -S`, `pacman -Syu`, `pacman -Sy` |
+| Modules NS8 (si présents) | `add-module`, `remove-module` |
+
+### `sam-root` — équivalent root
+
+Cible : administrateurs ayant besoin d'un accès root complet. Règles sudoers dans `/etc/sudoers.d/sam-root` :
+
+```
+%sam-root ALL=(ALL) ALL
+```
+
+Le mot de passe personnel reste exigé (`PASSWD:` implicite — il n'y a pas de `NOPASSWD`). L'attribution du groupe `sam-root` est réservée au rôle `sysadmin` côté API SAM (voir matrice RBAC dans `app/CLAUDE.md`).
+
+### Vérifier la configuration sur un serveur
+
+```bash
+# Sur le serveur géré
+sudo -l -U alice                   # liste les commandes autorisées pour alice
+getent group sam-operator sam-pkg sam-root sam-users
+cat /etc/sudoers.d/sam-operator
+visudo -c                          # valide tous les fichiers /etc/sudoers.d/
+```
 
 **Assignation du groupe** :
 - À la création de la clé : champ Groupe SAM du formulaire « Déployer une clé SSH »


### PR DESCRIPTION
## Summary

- README.md : ajoute le workflow SAM sudo groups, la section « Premier login d'un utilisateur SAM », corrige le conseil obsolète `usermod -aG sudo`, documente les règles sudoers SAM et le bloc `Match Group sam-users` dans la section Prérequis sudo.
- DESIGN.md : nouvelles sous-sections 6.6 (modèle SAM sudo groups), 6.7 (premier login + bloc sshd), 6.8 (`has_anomalies` dans `/api/servers`).
- CLAUDE.md (racine) : ajoute #383, #384, #386 à la liste des issues fermées (88/88) et une section haute niveau sur le modèle SAM groups entre architecture et modules Python.
- 5 agents `.claude/agents/*.md` mis à jour pour refléter leur périmètre post-#383/#384/#386 (schéma v4, nouvelles routes, sudoers SAM, sélecteur UI, invariants sécurité).

## Test plan

- [x] `grep` confirme que `sam-operator`, `sam-pkg`, `sam-root`, `sam_group`, `has_anomalies`, `sam-users`, `README_first_login`, `GROUP_GRANTED` sont désormais présents dans README.md, DESIGN.md, CLAUDE.md et les agents pertinents.
- [x] Aucune modification de code applicatif — uniquement de la documentation.
- [x] Conseil obsolète `usermod -aG sudo` retiré du README.

Closes #388