### PR TITLE
refactor(security): scope api-cli to sam-pkg only

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,9 @@ Cible : opérateurs qui doivent superviser et redémarrer des services sans pouv
 | Réseau / processus | `ss -tlnp`, `lsof`, `lsof -i` |
 | Diagnostic noyau | `dmesg` |
 | Disque | `du -sh /var/* /opt/* /home/*` |
-| Outils NS8 (si présents) | `runagent`, `api-cli` |
+| Outils NS8 (si présents) | `runagent` |
+
+`api-cli` est **volontairement absent** de `sam-operator` : cet outil de gestion NS8 dépasse le périmètre d'exploitation et reste réservé à `sam-pkg` (#394).
 
 ### `sam-pkg` — exploitation + gestion paquets
 
@@ -436,6 +438,7 @@ Cible : utilisateurs qui doivent en plus installer ou mettre à jour des paquets
 | Alpine | `apk add`, `apk upgrade` |
 | Arch | `pacman -S`, `pacman -Syu`, `pacman -Sy` |
 | Modules NS8 (si présents) | `add-module`, `remove-module` |
+| Outils NS8 (si présents) | `api-cli` |
 
 ### `sam-root` — équivalent root
 

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -137,7 +137,9 @@ printf "%%sam-operator ALL=(root) PASSWD: ${DMESG}\n"                       >> "
 printf "%%sam-operator ALL=(root) PASSWD: ${LSOF}\n"                        >> "${OP_FILE}.tmp"
 printf "%%sam-operator ALL=(root) PASSWD: ${LSOF} -i\n"                     >> "${OP_FILE}.tmp"
 printf "%%sam-operator ALL=(root) PASSWD: ${DU} -sh /var/* /opt/* /home/*\n" >> "${OP_FILE}.tmp"
-for bin in runagent api-cli; do
+# api-cli is intentionally NOT exposed to sam-operator (NS8 management
+# scope). It stays available to sam-pkg only — see issue #394.
+for bin in runagent; do
     bin_path=$(_bin "$bin")
     [ -x "$bin_path" ] && _rule "${OP_FILE}.tmp" "sam-operator" "${bin_path}"
 done


### PR DESCRIPTION
## Summary

\`api-cli\` (outil de gestion NS8) était dans les règles sudoers de \`sam-operator\` ET \`sam-pkg\`. Cette PR le retire de \`sam-operator\` (dont le périmètre est exploitation / diagnostic) et le garde dans \`sam-pkg\` (gestion paquets / modules). \`runagent\` reste dans les deux groupes.

## Changes

- \`provision-host.sh\` : la boucle sam-operator passe de \`for bin in runagent api-cli\` à \`for bin in runagent\`, avec un commentaire renvoyant à #394.
- \`README.md\` : la table sam-operator ne liste plus \`api-cli\` ; une note explique son absence volontaire ; la table sam-pkg gagne une ligne \`Outils NS8 → api-cli\`.

## Test plan

- [ ] Re-provisionner un serveur déjà géré : \`/etc/sudoers.d/sam-operator\` ne contient plus de règle \`api-cli\` ; \`/etc/sudoers.d/sam-pkg\` la contient toujours.
- [ ] Tester en tant qu'utilisateur \`sam-operator\` : \`sudo api-cli ...\` doit échouer (\`a password is required\` ou refus).
- [ ] Tester en tant qu'utilisateur \`sam-pkg\` : \`sudo api-cli ...\` continue de fonctionner avec PASSWD.
- [ ] \`visudo -c\` valide les deux fichiers sudoers générés.

Closes #394