### PR TITLE
fix(api): derive has_anomalies from key state, not audit_log

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -466,7 +466,16 @@ Cette logique est testée dans `app/tests/test_ssh.py::test_ssh_sam_add_appends_
 
 ### 6.8 Détection d'anomalies au niveau serveur (has_anomalies)
 
-La route `GET /api/servers` expose désormais un champ booléen `has_anomalies` par serveur (calculé via une jointure SQL sur `ssh_keys.status IN ('PENDING_REVIEW') OR key_authorizations.revoked_automatically = TRUE` sur les 24 dernières heures). Le Dashboard utilise ce champ pour afficher un compteur Alertes sans avoir à charger toutes les clés.
+La route `GET /api/servers` expose un champ booléen `has_anomalies` par serveur, utilisé par le Dashboard (compteur Alertes) et par `ServerTable.vue` (badge 🟡). Le champ est calculé en SQL pour éviter de charger toutes les clés côté client.
+
+**Définition** — `has_anomalies` est vrai si **au moins une** des deux conditions est remplie :
+
+1. Au moins une `key_authorizations` du serveur a `status = 'PENDING_REVIEW'` (clé en attente de validation).
+2. Au moins une `key_authorizations` du serveur correspond à une **révocation hors système récente** : `status = 'REVOKED' AND revoked_automatically = TRUE AND revoked_by IS NULL AND revoked_at > NOW() - INTERVAL '30 days'`.
+
+La définition reflète strictement ce que la vue **Anomalies** affiche (`Anomalies.vue:143-155`) afin que Dashboard, ServerTable et Anomalies soient toujours cohérents.
+
+**Important** : `has_anomalies` ne consulte **jamais** `audit_log`. Une première version interrogeait les entrées `ANOMALY_DETECTED` sur les 30 derniers jours ; le bug fixé en #396 a remplacé cette logique. `audit_log` est immuable par design (aucun `UPDATE`/`DELETE`), donc une entrée `ANOMALY_DETECTED` reste visible 30 jours même après que l'opérateur ait validé ou révoqué la clé fautive — ce qui maintenait à tort le badge orange. La règle est : `has_anomalies` reflète l'**état courant** des `key_authorizations`, pas l'historique des événements.
 
 ### 6.9 Audit de la configuration sshd du serveur géré (issue #392)
 

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -398,6 +398,42 @@ def test_web_get_servers_last_scan_ok_none(auth_client):
         assert data[0]["last_scan_ok"] is None
 
 
+def test_web_get_servers_propagates_has_anomalies(auth_client):
+    """GET /api/servers propagates the SQL-computed has_anomalies field."""
+    with patch("web.db") as mock_db:
+        mock_db.query_one.return_value = _admin_row()
+        mock_db.query.return_value = [
+            {"hostname": "srv-01", "last_scan_action": "SCAN_COMPLETED", "has_anomalies": True},
+            {"hostname": "srv-02", "last_scan_action": "SCAN_COMPLETED", "has_anomalies": False},
+        ]
+        resp = auth_client.get("/api/servers")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data[0]["has_anomalies"] is True
+        assert data[1]["has_anomalies"] is False
+
+
+def test_web_get_servers_has_anomalies_query_excludes_audit_log():
+    """Regression guard for #396 — has_anomalies must NOT read audit_log.
+
+    audit_log is immutable; reading ANOMALY_DETECTED from it kept the server
+    flagged for 30 days even after pending keys had been validated. The query
+    must derive has_anomalies from key_authorizations only.
+    """
+    import inspect
+    import web
+    source = inspect.getsource(web.list_servers)
+    # The has_anomalies subquery itself must not reference ANOMALY_DETECTED.
+    # (The LATERAL join below references SCAN_COMPLETED/SCAN_FAILED — those
+    # are unrelated and stay on audit_log.)
+    assert "ANOMALY_DETECTED" not in source, (
+        "has_anomalies must not depend on audit_log.ANOMALY_DETECTED — see #396"
+    )
+    # Must derive out-of-system revocations from key_authorizations.
+    assert "revoked_automatically = TRUE" in source
+    assert "revoked_by IS NULL" in source
+
+
 # ---------------------------------------------------------------------------
 # GET /api/servers/<hostname>
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -282,9 +282,18 @@ def list_servers():
                     WHERE server_id = s.id AND status = 'PENDING_REVIEW'
                 )
                 OR EXISTS(
-                    SELECT 1 FROM audit_log
-                    WHERE target_server = s.id AND action = 'ANOMALY_DETECTED'
-                    AND performed_at > NOW() - INTERVAL '30 days'
+                    -- Out-of-system revocations still considered "current"
+                    -- (mirrors the Anomalies view filter — 30-day window).
+                    -- We intentionally do NOT read audit_log here: it is
+                    -- an immutable trail of past events and would keep the
+                    -- server flagged for 30 days even after operators
+                    -- validated or revoked the offending key (#396).
+                    SELECT 1 FROM key_authorizations
+                    WHERE server_id = s.id
+                      AND status = 'REVOKED'
+                      AND revoked_automatically = TRUE
+                      AND revoked_by IS NULL
+                      AND revoked_at > NOW() - INTERVAL '30 days'
                 )
             ) AS has_anomalies
         FROM servers s


### PR DESCRIPTION
## Summary

\`GET /api/servers\` calculait \`has_anomalies\` en interrogeant \`audit_log\` pour des entrées \`ANOMALY_DETECTED\` dans les 30 derniers jours. \`audit_log\` étant immuable, valider ou révoquer la clé fautive ne supprime jamais l'entrée — le serveur restait donc en alerte (badge 🟡) pendant 30 jours après résolution complète, alors que la vue **Anomalies** confirmait \`0 keys awaiting validation\` et \`0 out-of-system revocations\`.

## Fix

La sous-requête \`audit_log\` est remplacée par une vérification sur l'**état courant** des \`key_authorizations\` :

\`\`\`sql
EXISTS(
    SELECT 1 FROM key_authorizations
    WHERE server_id = s.id
      AND status = 'REVOKED'
      AND revoked_automatically = TRUE
      AND revoked_by IS NULL
      AND revoked_at > NOW() - INTERVAL '30 days'
)
\`\`\`

C'est exactement le même filtre que celui appliqué par \`Anomalies.vue\` côté frontend, donc Dashboard, ServerTable et Anomalies redeviennent strictement cohérents.

## Tests

- **test_web_get_servers_propagates_has_anomalies** — vérifie que le champ remonte bien dans la réponse JSON.
- **test_web_get_servers_has_anomalies_query_excludes_audit_log** — regression guard niveau source : le code de \`list_servers\` ne doit plus contenir \`ANOMALY_DETECTED\` et doit contenir les nouveaux prédicats d'état (\`revoked_automatically = TRUE\`, \`revoked_by IS NULL\`).

638/638 pytest passent.

## Test plan

- [ ] Sur ton instance : les deux serveurs (192.168.12.119 et 192.168.12.140) doivent passer du badge 🟡 au badge ✅ après le redéploiement, sans action côté admin (toutes les clés sont déjà ACTIVE).
- [ ] Provoquer manuellement une révocation hors système (`sudo sed -i /SHA256.../d /home/alice/.ssh/authorized_keys`), lancer un scan → badge 🟡 attendu pendant 30 jours.
- [ ] Au-delà de 30 jours sans nouvelle anomalie → badge ✅.

Closes #396