### PR TITLE
feat: per-server collector SSH keys with manual rotation

### DIFF
--- a/.claude/agents/db-specialist.md
+++ b/.claude/agents/db-specialist.md
@@ -37,6 +37,7 @@ CREATE TABLE servers (
     max_sessions      INTEGER NOT NULL DEFAULT 2,
     provision_version VARCHAR(64),
     provision_drift   BOOLEAN NOT NULL DEFAULT FALSE,
+    is_provisioned    BOOLEAN NOT NULL DEFAULT FALSE,
     added_at          TIMESTAMPTZ DEFAULT now()
 );
 ```
@@ -44,6 +45,8 @@ CREATE TABLE servers (
 Index unique : `servers_ip_unique ON servers(ip_address)` — une IP ne peut appartenir qu'à un seul serveur actif ou désactivé.
 
 **Colonnes `provision_version` et `provision_drift`** (issue #400) — auto-update des scripts de provisioning. `provision_version` contient le SHA256 (ou prefix) du dernier déploiement réussi de `SAM_SELF_UPDATE`. `provision_drift` passe à TRUE quand l'invocation de `sam-self-update` retourne un exit non-zero (le serveur distant reste fonctionnel grâce au rollback automatique `.bak`).
+
+**Colonne `is_provisioned`** (issue #402) — TRUE si le serveur a été activé avec succès (SSH connectivity confirmée avec la per-server key). FALSE si le serveur a été créé via `register` (CLI bulk) mais que l'étape `activate` n'a pas encore été lancée. Différent de `is_active` (désactivé volontairement par un sysadmin). Un serveur peut être `is_active=TRUE, is_provisioned=FALSE` (créé via register, pas encore activé).
 
 ### administrators
 ```sql
@@ -146,7 +149,9 @@ CREATE TABLE audit_log (
                      'LOGIN_FAILED', 'LOGIN_BANNED', 'PASSWORD_RESET',
                      'SERVER_PROVISIONED', 'SESSION_LIMIT_EXCEEDED',
                      'GROUP_GRANTED', 'GROUP_REVOKED', 'GROUP_CHANGED',
-                     'PROVISION_UPDATED', 'PROVISION_UPDATE_FAILED'
+                     'PROVISION_UPDATED', 'PROVISION_UPDATE_FAILED',
+                     'COLLECTOR_KEY_GENERATED', 'COLLECTOR_KEY_ROTATED',
+                     'COLLECTOR_KEY_ROTATION_FAILED'
                  )),
     performed_by UUID REFERENCES administrators(id) ON DELETE SET NULL,
     target_key   UUID REFERENCES ssh_keys(id),
@@ -160,6 +165,8 @@ Jamais de UPDATE ni DELETE sur `audit_log` — journal immuable.
 `audit_retention_days` (settings) contrôle la purge automatique via `expire.py`.
 
 **Actions `PROVISION_UPDATED` et `PROVISION_UPDATE_FAILED`** (issue #400) — enregistrent le résultat d'une invocation de `sam-self-update`. Le champ `details` JSONB contient `{"version": "<sha256>", "stderr": "<error>"}` selon le cas. Ces actions utilisent l'index existant `idx_audit_log_action`.
+
+**Actions `COLLECTOR_KEY_GENERATED`, `COLLECTOR_KEY_ROTATED`, `COLLECTOR_KEY_ROTATION_FAILED`** (issue #402) — per-server collector keys. `COLLECTOR_KEY_GENERATED` est déclenché lors du `add_server` ou du `register`. `COLLECTOR_KEY_ROTATED` est déclenché lors d'une rotation manuelle réussie (bouton ServerDetail). `COLLECTOR_KEY_ROTATION_FAILED` est déclenché si la rotation échoue (rollback effectué). Le champ `details` JSONB contient `{"server_id": "<uuid>", "fingerprint": "<sha256>"}` pour `_GENERATED` et `_ROTATED`, et `{"server_id": "<uuid>", "error": "<msg>", "error_code": "<code>"}` pour `_ROTATION_FAILED`.
 
 ### settings
 ```sql

--- a/.claude/agents/frontend-dev.md
+++ b/.claude/agents/frontend-dev.md
@@ -45,8 +45,8 @@ server: {
 | Vue | Rôle |
 |-----|------|
 | Login.vue | Connexion + checkbox "Keep me logged on this device" (#239) |
-| Dashboard.vue | Tableau serveurs + compteurs + modal ajout serveur (SSH user/password obligatoires, #299) + clé collecteur (#74). Auto-scan après ajout (#332). Validation hostname RFC 1123 (#303). |
-| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91) + bandeau orange si `last_scan_ok === false` (#324). Bouton **Edit** (sysadmin, `EditServerModal`) + bouton **Re-provisionner** (violet, sysadmin, #302). `max_sessions` affiché et configurable via EditServerModal (#360). Affiche `provision_version` (8 premiers chars, tooltip complet) + badge orange "Update available" si `provision_drift === true` (#400). |
+| Dashboard.vue | Tableau serveurs + compteurs + modal ajout serveur (SSH user/password obligatoires, #299). Auto-scan après ajout (#332). Validation hostname RFC 1123 (#303). Clé collecteur globale retirée (#402). |
+| ServerDetail.vue | Détail serveur + clés + actions + bandeau rouge si désactivé (#91) + bandeau orange si `last_scan_ok === false` (#324). Bouton **Edit** (sysadmin, `EditServerModal`) + bouton **Re-provisionner** (violet, sysadmin, #302). `max_sessions` affiché et configurable via EditServerModal (#360). Affiche `provision_version` (8 premiers chars, tooltip complet) + badge orange "Update available" si `provision_drift === true` (#400). Bouton **Rotate collector key** (violet, sysadmin + active + provisioned) : rotation atomique via POST `/api/servers/<hostname>/rotate-key`, modal confirmation, spinner, message succès avec nouveau fingerprint (#402). Affiche fingerprint clé collecteur per-server dans info grid + bouton Copy public key (GET `/api/servers/<hostname>/collector-key`). Section repliable "Provision avec vos propres identifiants SSH" avec snippet bash copy-paste-friendly (#402). |
 | Anomalies.vue | Anomalies actives + filtres texte/type/serveur/conformité + unix_user (#195) |
 | AccessRequests.vue | DeployKeyForm + UserLockForm |
 | Audit.vue | Historique filtrable + export CSV (#343) |
@@ -112,6 +112,7 @@ POST   /api/servers/<hostname>/scan
 GET    /api/servers/<hostname>/sessions              POST /api/servers/<hostname>/sessions/refresh
 GET    /api/servers/<hostname>/sessions/history
 GET    /api/servers/<hostname>/sshd-audit
+POST   /api/servers/<hostname>/rotate-key            GET  /api/servers/<hostname>/collector-key
 
 GET  /api/keys                                       GET  /api/keys/get/<fingerprint>
 GET  /api/keys/search?q=                             POST /api/keys/validate/<fingerprint>
@@ -137,8 +138,8 @@ PUT    /api/admins/<username>/alerts
 GET /api/audit?server=&action=&since=
 
 GET  /api/system/status                              POST /api/system/scan
-GET  /api/system/collector-key                       GET  /api/system/config
-PUT  /api/system/config                              POST /api/system/test-smtp
+GET  /api/system/config                              PUT  /api/system/config
+POST /api/system/test-smtp
 ```
 
 ## Règles absolues de développement

--- a/.claude/agents/infra-dev.md
+++ b/.claude/agents/infra-dev.md
@@ -59,8 +59,7 @@ FROM node:24-alpine AS ui-builder
    ```
    /data/
        ├── keys/
-       │   ├── collector_key        (chmod 600, chown nobody)
-       │   ├── collector_key.pub
+       │   ├── per-server/          (chmod 700, chown nobody) — per-server collector keys (#402)
        │   └── known_hosts          (chmod 644, chown nobody)
        ├── pg/                      (chown postgres:postgres, chmod 700)
        └── config/
@@ -70,18 +69,17 @@ FROM node:24-alpine AS ui-builder
 4. **Ordre bootstrap strict** — Respecter l'ordre exact :
    1. mkdir -p /data/keys /data/pg /data/config
    2. chown postgres:postgres /data/pg && chmod 700 /data/pg  ← AVANT initdb
-   3. ssh-keygen -t ed25519 -f /data/keys/collector_key -N "" -C "ssh-access-manager@$(hostname)"
-   4. touch /data/keys/known_hosts && chmod 644 /data/keys/known_hosts
-   5. chmod 600 /data/keys/collector_key
-   6. chown nobody /data/keys/collector_key /data/keys/known_hosts
-   7. Démarrer PostgreSQL temporairement (socket local uniquement)
-   8. Créer base et utilisateur depuis ENV (deux psql séparés — CREATE DATABASE hors transaction)
-   9. Appliquer /app/sql/schema.sql
-   10. Insérer administrateur initial depuis ENV avec werkzeug generate_password_hash
-   11. Arrêter PostgreSQL temporaire
-   12. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
-   13. **Sélectionner nginx.conf.http.template ou nginx.conf.https.template** selon présence de NGINX_TLS_CERT_PATH + NGINX_TLS_KEY_PATH. Générer /etc/nginx/nginx.conf.
-   14. Afficher collector_key.pub dans les logs
+   3. **Créer /data/keys/per-server** (chmod 700, chown nobody) — dossier per-server collector keys (#402)
+   4. **Legacy cleanup** — si /data/keys/collector_key existe, log warning et supprimer (upgrade path)
+   5. touch /data/keys/known_hosts && chmod 644 /data/keys/known_hosts
+   6. Démarrer PostgreSQL temporairement (socket local uniquement)
+   7. Créer base et utilisateur depuis ENV (deux psql séparés — CREATE DATABASE hors transaction)
+   8. Appliquer /app/sql/schema.sql
+   9. Insérer administrateur initial depuis ENV avec werkzeug generate_password_hash
+   10. Arrêter PostgreSQL temporaire
+   11. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
+   12. **Sélectionner nginx.conf.http.template ou nginx.conf.https.template** selon présence de NGINX_TLS_CERT_PATH + NGINX_TLS_KEY_PATH. Générer /etc/nginx/nginx.conf.
+   13. **Pas d'affichage de clé globale** — les clés sont par serveur, générées à la demande (#402)
 5. **ENTRYPOINT** — Toujours `exec /usr/bin/supervisord -c /etc/supervisord.conf` en dernière instruction de bootstrap.sh.
 6. **supervisord nodaemon=true** — Logs vers /dev/stdout uniquement.
 7. **Flask via Waitress** — `python3 /app/app/web.py` démarre Waitress (jamais le dev server Flask). Utilisateur `nobody`.
@@ -136,8 +134,8 @@ Sudoers généré avec `printf` ligne par ligne (résistant au CRLF PTY — #159
 Créé via `install -m 440` (évite ":" dans les args sur RHEL/CentOS — #161).
 
 ```bash
-# Invocation
-ssh <user>@<ip> "sudo bash -s '$(podman exec ssh-access-manager cat /data/keys/collector_key.pub)' '${SSH_USER}'" \
+# Invocation (per-server key depuis #402 — <server_id> identifie la clé)
+ssh <user>@<ip> "sudo bash -s '$(podman exec ssh-access-manager cat /data/keys/per-server/<server_id>.pub)' '${SSH_USER}'" \
     < <(podman exec ssh-access-manager cat /app/provision-host.sh)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,8 @@ Supervisord orchestre :
 - busybox crond — scan + expiration toutes les X heures (priority=4)
 
 Volume unique /data/ :
-- keys/ — collector_key (chmod 600, chown nobody), collector_key.pub, known_hosts (chmod 644, chown nobody)
+- keys/per-server/ — keypairs ed25519 par serveur (`<uuid>.key{,.pub}`, chmod 600, chown nobody, commentaire SSH vide), répertoire chmod 700 (#402)
+- keys/known_hosts — chmod 644, chown nobody
 - pg/ — PGDATA (chown postgres:postgres, chmod 700)
 - config/servers.yml — liste déclarative des serveurs
 
@@ -42,6 +43,22 @@ Trois groupes Unix dédiés sont créés par `provision-host.sh` sur chaque serv
 Un quatrième groupe `sam-users` regroupe tous les utilisateurs Unix créés via `sam-add`. Le bloc sshd `Match Group sam-users` interdit l'authentification par mot de passe — ces utilisateurs ne peuvent se connecter qu'avec leur clé SSH publique. À la création, `sam-add` génère un mot de passe temporaire (`openssl rand -base64 12`), le set via `chpasswd`, écrit `~/README_first_login.txt` (chmod 600) et `~/.profile` invoque `passwd` automatiquement au premier login pour forcer le changement.
 
 Le compte `root` est protégé : non-déployable, non-révocable, non-promotable en groupe SAM. La colonne `key_authorizations.sam_group` (VARCHAR(20), CHECK IN sam-operator/sam-pkg/sam-root, audit v4) trace le groupe assigné. Routes : `POST /api/access/grant-group`, `POST /api/access/revoke-group`, `PUT /api/access/change-group`. La promotion en `sam-root` est réservée au rôle `sysadmin`.
+
+## Per-server collector SSH keys (#402)
+
+Plus de clé SSH globale. À l'ajout d'un serveur, SAM génère une paire ed25519 distincte stockée dans `/data/keys/per-server/<uuid>.key{,.pub}` (chmod 600, owner `nobody`, commentaire SSH vide pour anonymiser le fichier). Le mapping serveur ↔ clé est implicite via le nom de fichier (UUID v4 random) — pas de fingerprint stocké en base. Threat model : un vol de la BDD seule ne révèle aucune clé privée ; un vol du filesystem seul donne N fichiers anonymes non corrélables aux hôtes. Une exploitation utile exige donc **deux compromissions distinctes**.
+
+Workflows d'ajout (cf. README) :
+- **UI / CLI `servers add`** avec password : SAM provisionne tout, password jamais stocké
+- **CLI `servers register/show --pubkey/activate`** : 3 étapes pour pousser la pubkey avec sa propre clé SSH root (cloud-init, bulk)
+- Rotation manuelle atomique avec rollback via bouton **Rotate collector key** (sysadmin)
+- Audit dédié : `COLLECTOR_KEY_GENERATED`, `COLLECTOR_KEY_ROTATED`, `COLLECTOR_KEY_ROTATION_FAILED`
+
+`servers.is_provisioned BOOLEAN DEFAULT FALSE` distingue « registered, pas encore activé » de « actif ».
+
+## Hostname rename (#403)
+
+`actions.update_server(..., new_hostname=...)` accepte une nouvelle valeur de hostname, valide RFC 1123, refuse les doublons, écrit un audit `SERVER_RENAMED {old_hostname, new_hostname}`. Les entrées d'audit historiques ne sont jamais réécrites — elles préservent le hostname en vigueur au moment de l'événement. L'UI redirige automatiquement vers `/servers/<new>` après save (router-view `:key` force le remount).
 
 ## Modules Python — responsabilités
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -570,6 +570,65 @@ Après le premier scan post-bootstrap, `ensure_scripts()` déploie `sam-self-upd
 
 **Tests** : les phases 4 et 5 de `tests/integration/run.sh` simulent un cycle d'upgrade (`sam-self-update version-v2` avec injection d'une règle marker dans sam-pkg, puis tentative avec sudoers invalide → rollback vérifié).
 
+### 6.11 Per-server collector SSH keys (issue #402)
+
+**Problème** : une clé SSH globale `/data/keys/collector_key` déployée sur tous les hôtes gérés produit un blast radius fleet-wide en cas de fuite.
+
+**Modèle adopté** : une paire ed25519 distincte est générée à `add_server()` et `register_server()` dans `/data/keys/per-server/<uuid>.key{,.pub}` (chmod 600 / 600, owner `nobody`). Le commentaire SSH (`-C`) est **vide** : un fichier volé sans la BDD ne révèle pas à quel hôte il ouvre l'accès.
+
+**UUID v4 random** (`uuid.uuid4()`, 122 bits aléatoires) — pas de v5 (déterministe, leak inventaire) ni v7 (leak timestamp). Mapping serveur ↔ fichier **implicite via le nom** ; pas de colonne `collector_key_fingerprint` (l'audit `COLLECTOR_KEY_GENERATED` garde la trace `{server_id, fingerprint}` sans hostname/ip).
+
+**Propriétés** :
+- Vol d'une per-server key → un seul hôte exposé, pas de pivot
+- Vol BDD seule → UUID/IP/hostname mais aucune clé privée
+- Vol filesystem seul → N fichiers anonymes, non corrélables aux hôtes sans tenter chaque clé contre chaque IP (bruit, fail2ban)
+- Compromission utile = **deux compromissions distinctes** requises (defense in depth)
+
+**Résolution au scan** : `ssh._resolve_key_path(server_id)` raise `KeyError` si la clé est absente → `collect.scan_server` écrit un `SCAN_FAILED` clair (« no per-server collector key — please re-add this server »).
+
+**Rotation manuelle** (`ssh.rotate_per_server_key`, bouton ServerDetail sysadmin) :
+1. Génère `<uuid>.key.new` localement
+2. SSH avec l'ancienne clé, append la nouvelle pubkey à `~audit-collector/.ssh/authorized_keys`
+3. Reconnect avec la nouvelle pour vérifier
+4. SSH avec la nouvelle clé, retire l'ancienne pubkey
+5. Renomme les fichiers (`.new` → courant, ancien supprimé)
+- Rollback à toute étape (restaure ancienne pubkey distante si appendée, supprime `.new`). Mini-fenêtre entre 2 et 4 où deux pubkeys coexistent : si SAM crashe, les deux clés marchent — la prochaine rotation nettoie.
+
+**Workflow bulk** : commandes CLI `manage.py servers register` (génère keypair, `is_provisioned=FALSE`, pas de SSH), `servers show --pubkey` (dump stdout), `servers activate` (vérifie SSH avec la per-server key, passe `is_provisioned=TRUE`). Permet à l'admin de déployer la pubkey avec sa propre clé root sans saisir aucun mot de passe côté SAM.
+
+**Hors périmètre v1** : rotation programmée automatique, TPM-sealed keys, multi-key concurrent windows, bulk-rotate.
+
+### 6.12 Scan initial automatique après provisioning (issue #402)
+
+À la fin de `add_server()` et `activate_server()`, SAM lance immédiatement un scan complet via `_trigger_initial_scan(server, admin_id, sync=...)`. Pas d'attente du prochain cycle cron : les `authorized_keys` apparaissent dans la vue **Keys** dès la fin de l'opération.
+
+Deux modes selon le caller :
+- **API (Flask)** : thread daemon (`sync=False`). Le scan tourne en arrière-plan, la réponse HTTP retourne immédiatement, le scan complète quelques secondes plus tard. Flask reste vivant, le thread tient.
+- **CLI (`manage.py`)** : appel synchrone (`sync=True`). Indispensable : un thread daemon serait tué quand le process Click se termine. `manage.py servers add` et `servers activate` passent donc `scan_sync=True` à `actions.add_server` / `actions.activate_server`.
+
+Le scan échoue silencieusement avec `logging.exception` si le pubkey distant n'est pas encore en place — la prochaine tentative manuelle (bouton Scan, ou cron) le rattrape.
+
+### 6.13 Renommage de serveur avec préservation de l'historique (issue #403)
+
+L'identifiant interne d'un serveur est son **UUID** (PK de `servers`), pas son hostname. Le hostname n'est qu'un label éditable. `actions.update_server(..., new_hostname=...)` :
+
+1. Valide le nouveau hostname (RFC 1123 via `_validate_hostname`)
+2. Refuse si un autre serveur porte déjà ce hostname (check d'unicité sur `servers.hostname != id`)
+3. `UPDATE servers SET hostname = %s WHERE id = %s` (clé primaire = UUID)
+4. Écrit un audit dédié `SERVER_RENAMED {old_hostname, new_hostname}` distinct du `SERVER_UPDATED`
+
+**Principe de préservation de l'historique** : trois sources concurrentes coexistent et chacune répond à une question distincte.
+
+1. **Le hostname affiché dans la colonne SERVER d'Audit** vient d'un JOIN `audit_log.target_server → servers.hostname`. Comme la PK est l'UUID, le JOIN renvoie toujours le hostname **courant**. Cohérent : un lien d'audit qui pointe vers un nom plus en base serait cassé.
+2. **Le champ `details` JSONB de chaque entrée** capture le hostname **au moment** de l'événement (ex : `SCAN_COMPLETED → {"hostname": "srv-12-119", ...}`). Cette valeur est figée — le code ne réécrit jamais l'audit.
+3. **Les entrées `SERVER_RENAMED`** enregistrent `{old_hostname, new_hostname}` et permettent de reconstruire l'historique complet des renommages d'un serveur (UUID stable, tous les renommages chronologiques disponibles).
+
+Une analyse forensique peut donc répondre précisément à « sous quel nom ce serveur était-il connu quand cet événement a eu lieu » en croisant les `details` de l'entrée concernée avec la timeline des `SERVER_RENAMED`. Propriété indispensable pour la conformité.
+
+Côté UI, après save avec rename, `router.replace({ name: 'ServerDetail', params: { hostname: newHostname } })`. Le `<router-view :key="$route?.fullPath">` dans `App.vue` force le **remount du component** : sans cela, Vue Router réutilise la même instance et le `const hostname = route.params.hostname` capturé au mount initial reste figé, provoquant des 404 sur les API calls.
+
+Schéma : `audit_log_action_check_v7` ajoute `SERVER_RENAMED` à la liste autorisée (migration idempotente dans `bootstrap.sh`).
+
 ---
 
 ## 7. Politique de conformité ANSSI (BP-099)
@@ -987,7 +1046,8 @@ Exception : `PUT /api/admins/<username>/password` — autorisé si sysadmin OU s
 | /api/audit | GET | ✓ | ✓ | ✓ |
 | /api/system/status | GET | ✓ | ✓ | ✓ |
 | /api/system/scan | POST | ✓ | ✓ | 403 |
-| /api/system/collector-key | GET | ✓ | ✓ | ✓ |
+| /api/servers/\<hostname\>/collector-key | GET | ✓ | ✓ | ✓ |
+| /api/servers/\<hostname\>/rotate-key | POST | ✓ | 403 | 403 |
 | /api/system/config | GET | ✓ | ✓ | ✓ |
 | /api/system/config | PUT | ✓ | 403 | 403 |
 | /api/system/test-smtp | POST | ✓ | ✓ | ✓ |
@@ -1586,9 +1646,10 @@ qui réduit le temps de CI de ~30 s par run en régime stable.
 ```bash
 if [ ! -f /data/pg/PG_VERSION ]; then
     # Premier démarrage — initialisation complète
-    mkdir -p /data/keys /data/pg /data/config
+    mkdir -p /data/keys /data/keys/per-server /data/pg /data/config
     chown postgres:postgres /data/pg && chmod 700 /data/pg  # AVANT initdb
-    ssh-keygen -t ed25519 -f /data/keys/collector_key -N ""
+    chown nobody:nobody /data/keys/per-server && chmod 700 /data/keys/per-server
+    # Per-server keys are generated lazily at add_server() — no global key here
     initdb -D /data/pg -E UTF8 --locale=C
     # ... start pg, createdb, apply schema, insert admin, stop pg
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,16 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM alpine:3.23.4
 
+# OCI image annotations (org.opencontainers.image.* — see spec v1.1)
+LABEL org.opencontainers.image.title="ssh-access-manager" \
+      org.opencontainers.image.description="SSH access audit and management — Alpine single-container with PostgreSQL, Flask API, Vue.js UI" \
+      org.opencontainers.image.authors="Stéphane de Labrusse <stephdl@de-labrusse.fr>" \
+      org.opencontainers.image.source="https://github.com/stephdl/ssh-access-manager" \
+      org.opencontainers.image.url="https://github.com/stephdl/ssh-access-manager" \
+      org.opencontainers.image.documentation="https://github.com/stephdl/ssh-access-manager/blob/main/README.md" \
+      org.opencontainers.image.licenses="GPL-3.0-or-later" \
+      org.opencontainers.image.vendor="Stéphane de Labrusse"
+
 RUN apk update && apk add --no-cache \
     postgresql18 \
     postgresql18-client \

--- a/README.md
+++ b/README.md
@@ -41,16 +41,10 @@ podman run -d \
 
 Au premier démarrage, le container :
 1. Initialise PostgreSQL et applique le schéma SQL
-2. Génère une paire de clés ED25519 dans `/data/keys/`
+2. Crée le répertoire `/data/keys/per-server/` qui contiendra les paires de clés ED25519 générées **par serveur** (une par hôte ajouté)
 3. Insère l'administrateur initial (depuis `ADMIN_USERNAME` et `ADMIN_EMAIL`)
-4. Affiche la clé publique `collector_key.pub` dans les logs
 
-```bash
-# Récupérer la clé publique du collecteur depuis les logs
-podman logs sam-server | grep -A1 "collector_key.pub"
-```
-
-La clé publique est également visible directement dans l'interface web : **Dashboard > Clé publique collecteur**.
+> **Per-server collector keys.** SAM ne génère plus de clé SSH globale. À l'ajout d'un serveur (UI ou CLI), une paire `<uuid>.key{,.pub}` est générée dans `/data/keys/per-server/`. La compromission d'une clé est ainsi cantonnée à un seul hôte. La pubkey d'un serveur est consultable depuis **ServerDetail** ou via `GET /api/servers/<hostname>/collector-key`.
 
 L'interface est accessible sur `http://localhost:8080`. Authentification par session Flask : utilisez les identifiants définis via `ADMIN_USERNAME` / `ADMIN_PASSWORD` au démarrage.
 
@@ -138,36 +132,94 @@ Les durées sont des constantes dans `web.py` — pas de redémarrage nécessair
 
 ## Workflow — Ajout d'un serveur distant
 
-### Via l'interface web (recommandé — provisionnement automatique)
+SAM génère **une paire de clés SSH ed25519 distincte par serveur** (stockée dans `/data/keys/per-server/<uuid>.key{,.pub}`, chmod 600, propriétaire `nobody`, fichier anonyme — pas de commentaire SSH). La compromission d'une clé n'expose qu'un seul hôte, jamais l'ensemble du parc. Le mapping serveur ↔ clé est implicite via le nom de fichier (UUID v4 random) — **pas de fingerprint stocké en base**, pour qu'un vol de la BDD seule ne révèle aucune information cryptographique exploitable.
+
+Cinq workflows d'ajout, du plus simple au plus scriptable :
+
+### A. UI, un serveur, avec mot de passe (le plus simple)
 
 Dashboard → bouton **+ Ajouter un serveur** → remplir :
 
 | Champ | Obligatoire | Description |
 |---|---|---|
 | Hostname | ✓ | Nom RFC 1123 (`server-01`, `web.prod.example.com`) |
-| Adresse IP | ✓ | IPv4 ou IPv6 — doit être unique |
-| Utilisateur SSH | ✓ | Compte avec sudo sur le serveur cible (`root` ou tout compte `sudo ALL`) |
+| Adresse IP | ✓ | IPv4 ou IPv6 — doit être unique dans SAM |
+| Utilisateur SSH | ✓ | Compte avec sudo (`root` ou tout compte `sudo ALL`) |
 | Mot de passe SSH | ✓ | Utilisé **une seule fois** pour le provisionnement — jamais stocké en base |
 | Port SSH | — | Défaut : 22 |
 | Environnement | — | `production` / `staging` / `lab` — modifiable ultérieurement |
 | OS | — | Famille d'OS (`rhel`, `debian`…) — modifiable ultérieurement |
 
-Le serveur n'est enregistré en base **que si la connexion SSH réussit**. Après la création, un **scan automatique** est lancé immédiatement en arrière-plan (fire-and-forget) afin de collecter les clés existantes sans attendre le prochain cycle cron. En cas d'échec (mauvais mot de passe, port fermé, sudo manquant…), aucune donnée n'est écrite et l'erreur est affichée dans la langue du navigateur. Le script `provision-host.sh` est exécuté à distance : il crée l'utilisateur `audit-collector`, déploie la clé publique collecteur et configure les règles sudoers.
+À la soumission, SAM : (1) génère la per-server keypair, (2) ouvre une session SSH avec le password, (3) pousse `provision-host.sh` qui crée l'utilisateur `audit-collector`, déploie la pubkey, configure sudoers + groupes SAM + drop-in sshd, (4) INSERT en base avec `is_provisioned=TRUE`, (5) **lance un scan automatique** en arrière-plan (fire-and-forget) pour collecter immédiatement les `authorized_keys` existants. Si le SSH échoue, **aucune donnée n'est écrite**.
 
-Le script est **idempotent** : il peut être rejoué sans risque (après rebuild, changement de clé ou de règles sudoers). Un bouton **Re-provisionner** est disponible sur la vue détail d'un serveur existant (rôle `sysadmin` uniquement).
-
-### Via la CLI
+### B. CLI, un serveur, avec mot de passe
 
 ```bash
 podman exec sam-server python3 /app/app/manage.py servers add \
-  --hostname server-prod-01 --ip 192.168.1.10 \
-  --ssh-user root --ssh-password SECRET \
-  [--env production] [--os rhel] [--port 22]
+    --hostname server-prod-01 --ip 192.168.1.10 \
+    --ssh-user root --ssh-password 'SECRET' \
+    [--env production] [--os rhel] [--port 22]
 ```
 
-Le mot de passe est demandé interactivement si `--ssh-password` est absent.
+Si `--ssh-password` est absent, il est demandé en interactif (`hide_input=True`). Le scan initial est **synchrone** depuis la CLI (le process meurt sinon avant la fin du thread) — la commande retourne après le scan, typiquement 3–5 sec.
 
-### Via `servers.yml` (déclaratif — provisionnement manuel requis)
+### C. CLI, un serveur, sans mot de passe (votre propre clé SSH root)
+
+Workflow 3 étapes — utile quand SAM ne doit jamais voir vos credentials :
+
+```bash
+HOSTNAME=server-prod-01
+IP=192.168.1.10
+
+# 1. register — génère la per-server keypair, INSERT avec is_provisioned=FALSE
+podman exec sam-server python3 /app/app/manage.py servers register \
+    --hostname "$HOSTNAME" --ip "$IP"
+
+# 2. push la per-server pubkey avec VOTRE clé SSH root
+PUB=$(podman exec sam-server python3 /app/app/manage.py servers show "$HOSTNAME" --pubkey)
+ssh root@"$IP" "sudo bash -s '$PUB' 'audit-collector'" \
+    < <(podman exec sam-server cat /app/provision-host.sh)
+
+# 3. activate — vérifie connectivité avec la per-server key, passe is_provisioned=TRUE,
+#    déclenche un scan initial synchrone
+podman exec sam-server python3 /app/app/manage.py servers activate "$HOSTNAME"
+```
+
+### D. CLI, plusieurs serveurs en bulk, avec mot de passe
+
+Si tous les serveurs partagent le **même** mot de passe root (cas image cloud-init / Ansible fresh) :
+
+```bash
+PASS='SECRET'
+for ip in 192.168.1.{10..15}; do
+  podman exec sam-server python3 /app/app/manage.py servers add \
+      --hostname "srv-${ip##*.}" --ip "$ip" \
+      --ssh-user root --ssh-password "$PASS"
+done
+```
+
+Pour des mots de passe différents par hôte, scripte une boucle qui lit un fichier `ip:password` ou un coffre (vault, pass, sops…) — le password n'est passé qu'en argument CLI, jamais persisté.
+
+### E. CLI, plusieurs serveurs en bulk, sans mot de passe (cloud-init / clé pré-déployée)
+
+```bash
+for ip in 192.168.1.{10..15}; do
+  hostname=srv-${ip##*.}
+  # register
+  podman exec sam-server python3 /app/app/manage.py servers register \
+      --hostname "$hostname" --ip "$ip"
+  # push avec votre clé root
+  PUB=$(podman exec sam-server python3 /app/app/manage.py servers show "$hostname" --pubkey)
+  ssh root@"$ip" "sudo bash -s '$PUB' 'audit-collector'" \
+      < <(podman exec sam-server cat /app/provision-host.sh)
+  # activate (scan initial inclus)
+  podman exec sam-server python3 /app/app/manage.py servers activate "$hostname"
+done
+```
+
+Parallélisable avec GNU `parallel`, Ansible (`ansible -m shell`), ou tout outil de CM.
+
+### F. Déclaratif via `servers.yml` (legacy — manuel)
 
 ```yaml
 # /data/config/servers.yml
@@ -178,16 +230,55 @@ servers:
     os_family: rhel           # optionnel
 ```
 
-Cette méthode ajoute le serveur en base sans provisionnement SSH automatique. Il faut exécuter le script manuellement sur la cible depuis la machine hébergeant le container :
+Cette méthode crée l'entrée en base sans provisionnement SSH automatique — équivalent d'un `register` manuel. Il faut ensuite déployer la pubkey et activer comme dans le workflow **C** ci-dessus.
+
+---
+
+### Provisioning script — interface
+
+`provision-host.sh` accepte deux arguments positionnels :
 
 ```bash
-ssh <user>@<ip-du-serveur> "sudo bash -s '$(podman exec sam-server cat /data/keys/collector_key.pub)'" \
-    < <(podman exec sam-server cat /app/provision-host.sh)
+sudo bash provision-host.sh <pubkey> <collector_user>
 ```
 
-> **Note** : La connexion SSH utilise toujours l'adresse IP déclarée, jamais la résolution DNS, pour éviter les ambiguïtés réseau.
+Le script est **idempotent** : il peut être rejoué sans risque (rebuild SAM, rotation de clé, mise à jour des règles sudoers). Le bouton **Re-provision** sur la vue détail d'un serveur (rôle `sysadmin`) l'invoque depuis SAM avec saisie d'un nouveau mot de passe SSH ; le snippet manuel est également affiché dans le bloc dépliable **« Provision with your own SSH credentials »** sur chaque ServerDetail.
 
-> **Astuce** : ce même snippet sert aussi pour **rejouer** `provision-host.sh` sur un serveur déjà géré (par exemple lors d'une migration vers une version SAM qui étend le contrat sudoers). Voir la section [Mettre à jour SAM](#mettre-à-jour-sam) ci-dessous.
+> **Note** : Les connexions SSH utilisent toujours l'adresse IP déclarée, jamais la résolution DNS, pour éviter les ambiguïtés réseau et les bans CrowdSec/fail2ban.
+
+---
+
+### Rotation manuelle de la clé per-server
+
+Depuis **ServerDetail** (rôle `sysadmin`), le bouton **Rotate collector key** (teal) déclenche une rotation **atomique avec rollback** :
+
+1. Génère un nouveau keypair `<uuid>.key.new` localement
+2. SSH avec l'ancienne clé, append la nouvelle pubkey à `~audit-collector/.ssh/authorized_keys`
+3. Re-connecte avec la **nouvelle** clé pour vérifier
+4. SSH une dernière fois pour retirer l'ancienne pubkey distante
+5. Renomme les fichiers locaux (`.new` → courant, ancien supprimé)
+
+À toute étape, en cas d'échec, l'ancienne clé reste seule active et un audit `COLLECTOR_KEY_ROTATION_FAILED` est écrit (avec le message d'erreur, sans hostname/IP pour minimiser l'info disponible). Le succès écrit `COLLECTOR_KEY_ROTATED` avec le nouveau fingerprint.
+
+---
+
+### Renommage d'un serveur
+
+Depuis **ServerDetail** (rôle `sysadmin`) → bouton **Edit** → champ Hostname éditable. Le formulaire :
+
+- Valide le nouveau nom (RFC 1123)
+- Refuse si le nouveau nom est déjà utilisé par un autre serveur
+- Affiche un avertissement contextuel : « Renaming changes the URL. A SERVER_RENAMED audit entry records the change. »
+
+Après save, l'UI redirige vers `/servers/<nouveau-hostname>` (le component remount proprement). Un audit `SERVER_RENAMED` enregistre `{old_hostname, new_hostname}` avec l'admin et l'horodatage.
+
+**À propos de l'historique d'audit après renommage**. Trois sources coexistent et chacune répond à une question :
+
+1. La colonne **SERVER** dans la vue Audit affiche toujours le hostname **courant** (JOIN SQL sur l'UUID `target_server`). Un audit qui pointerait vers un nom obsolète serait cassé.
+2. Le champ **`details` JSONB** de chaque entrée garde le hostname **figé au moment de l'événement** (ex : `SCAN_COMPLETED → {hostname: "srv-12-119"}`). Le code ne réécrit jamais l'audit.
+3. Les entrées **`SERVER_RENAMED`** permettent de reconstruire toute la timeline des renommages.
+
+Croiser le `details` d'une entrée avec la chronologie des `SERVER_RENAMED` reconstruit précisément sous quel nom le serveur était connu à un instant T.
 
 ---
 
@@ -197,10 +288,12 @@ Depuis la vue détail d'un serveur (**Dashboard > clic sur hostname**) :
 
 | Action | Effet |
 |---|---|
-| **Modifier** | Modifie l'adresse IP, l'environnement, la famille d'OS, le port SSH ou le seuil `max_sessions` du serveur (rôle `sysadmin`). |
-| **Désactiver** | Le serveur n'est plus scanné automatiquement. Indicateur rouge visible dans le dashboard et la vue détail. |
-| **Réactiver** | Le serveur reprend le cycle de scan automatique. |
-| **Supprimer** | Suppression définitive du serveur et de toutes ses clés, autorisations et logs associés (action irréversible). |
+| **Scan** | Lance un scan immédiat (ne pas attendre le cycle cron). |
+| **Edit** | Modifie hostname, IP, environnement, OS, port SSH ou `max_sessions` (rôle `sysadmin`). Renommer émet un audit `SERVER_RENAMED` et redirige l'UI. |
+| **Disable** | Le serveur n'est plus scanné automatiquement. Indicateur rouge sur Dashboard et bandeau rouge dans ServerDetail. |
+| **Re-provision** | Rejoue `provision-host.sh` à distance avec un nouveau mot de passe (rôle `sysadmin`, serveur actif) — utile après rebuild SAM ou changement de contrat sudoers. |
+| **Rotate collector key** | Génère une nouvelle per-server keypair, la déploie et retire l'ancienne — opération atomique avec rollback (rôle `sysadmin`, serveur actif et provisioned). |
+| **Delete** | Suppression définitive du serveur, de toutes ses clés, autorisations, sessions et de sa per-server keypair (action irréversible). |
 
 ---
 
@@ -256,8 +349,10 @@ Dashboard → cliquer sur le hostname → bouton **Re-provisionner** (rôle `sys
 Si vous avez déjà une clé SSH d'admin déployée sur vos serveurs, vous pouvez rejouer `provision-host.sh` sans passer par l'UI ni saisir aucun mot de passe :
 
 ```bash
-PUB=$(podman exec sam-server cat /data/keys/collector_key.pub)
 for ip in 192.168.1.10 192.168.1.11 192.168.1.12; do
+  hostname=$(podman exec sam-server psql -At -d ssh_manager \
+      -c "SELECT hostname FROM servers WHERE ip_address='$ip';")
+  PUB=$(podman exec sam-server python3 /app/app/manage.py servers show $hostname --pubkey)
   ssh root@"$ip" "sudo bash -s '$PUB'" \
     < <(podman exec sam-server cat /app/provision-host.sh)
 done

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -5,20 +5,20 @@
 Détection premier démarrage : absence de /data/pg/PG_VERSION.
 
 Premier démarrage :
-1. mkdir -p /data/keys /data/pg /data/config
+1. mkdir -p /data/keys /data/keys/per-server /data/pg /data/config
 2. chown postgres:postgres /data/pg && chmod 700 /data/pg
-3. ssh-keygen -t ed25519 -f /data/keys/collector_key -N "" -C "ssh-access-manager@$(hostname)"
-4. touch /data/keys/known_hosts && chmod 644 /data/keys/known_hosts
-5. chmod 600 /data/keys/collector_key
-6. chown nobody /data/keys/collector_key /data/keys/known_hosts
-7. Démarrer PostgreSQL temporairement (socket local uniquement)
-8. Créer base et utilisateur depuis ENV (deux psql séparés — CREATE DATABASE hors transaction)
-9. Appliquer /app/sql/schema.sql
-10. Insérer administrateur initial depuis ENV avec werkzeug generate_password_hash
-11. Arrêter PostgreSQL temporaire
-12. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
-13. Générer /etc/nginx/nginx.conf depuis nginx.conf.http.template ou nginx.conf.https.template + ENV
-14. Afficher collector_key.pub dans les logs
+3. chown nobody:nobody /data/keys/per-server && chmod 700 /data/keys/per-server
+4. touch /data/keys/known_hosts && chmod 644 /data/keys/known_hosts && chown nobody /data/keys/known_hosts
+5. Si `/data/keys/collector_key` (legacy global key) présent : `rm -f` au boot avec warning
+6. Démarrer PostgreSQL temporairement (socket local uniquement)
+7. Créer base et utilisateur depuis ENV (deux psql séparés — CREATE DATABASE hors transaction)
+8. Appliquer /app/sql/schema.sql
+9. Insérer administrateur initial depuis ENV avec werkzeug generate_password_hash
+10. Arrêter PostgreSQL temporaire
+11. Générer /etc/msmtprc depuis msmtp.conf.template + ENV
+12. Générer /etc/nginx/nginx.conf depuis nginx.conf.http.template ou nginx.conf.https.template + ENV
+
+Aucune clé SSH globale n'est générée. À l'ajout d'un serveur (UI ou CLI), `actions.add_server` / `actions.register_server` génèrent une paire ed25519 anonyme dans `/data/keys/per-server/<uuid>.key{,.pub}` (commentaire SSH vide).
 
 Non premier démarrage : régénérer nginx.conf + msmtprc depuis ENV.
 Toujours en dernier : `exec /usr/bin/supervisord -c /etc/supervisord.conf`
@@ -203,10 +203,16 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - `unlock_user(unix_user, hostname, admin_id)` — valide username POSIX, sam-unlock-user, USER_UNLOCKED (#181)
 
 ### Serveurs
-- `add_server(hostname, ip, ssh_user, ssh_password, env=None, os_family=None, ssh_port=22, admin_id=None)` — provisionnement atomique : `add_to_known_hosts(ip)` → `ssh.provision_server()` → INSERT servers → audit SERVER_ADDED + SERVER_PROVISIONED. Si le SSH échoue, aucune donnée n'est écrite (#299, #301). Le SSH password n'est jamais stocké.
-- `provision_server(hostname, ip, ssh_user, ssh_password, ssh_port)` — re-provisionne un serveur existant (#302). Même garantie : ssh password non stocké.
-- `update_server(hostname, ip, env, os_family, ssh_port, admin_id, max_sessions)` — met à jour IP, env, OS, port, max_sessions. Si l'IP change, relance ssh-keyscan atomiquement (#339)
-- `disable_server`, `enable_server` (#88), `delete_server` (#88 — hard delete + cascade)
+- `add_server(hostname, ip, ssh_user, ssh_password, env=None, os_family=None, ssh_port=22, admin_id=None, scan_sync=False)` — provisionnement atomique : génère UUID + per-server keypair (`ssh._generate_keypair`), `_fetch_host_key(ip)` → `ssh.provision_server(..., pubkey=per_server_pubkey)` → INSERT servers (`is_provisioned=TRUE`) → audit SERVER_ADDED + SERVER_PROVISIONED + COLLECTOR_KEY_GENERATED → **scan initial** via `_trigger_initial_scan` (fire-and-forget thread depuis l'API, synchrone depuis la CLI). Si le SSH échoue, le keypair est supprimé du disque et aucune donnée n'est écrite (#299, #301, #402).
+- `register_server(hostname, ip, ssh_port=22, env, os_family, admin_id)` — version sans SSH de `add_server` : génère UUID + per-server keypair, INSERT avec `is_provisioned=FALSE`. Pour bulk bootstrap (workflow 3 étapes : register → push pubkey avec sa propre clé root → activate) (#402).
+- `activate_server(hostname, admin_id, scan_sync=False)` — `_fetch_host_key` + `_connect` avec la per-server key pour valider la connectivité, `is_provisioned=TRUE`, audit SERVER_PROVISIONED, scan initial via `_trigger_initial_scan` (sync depuis CLI, async depuis API) (#402).
+- `rotate_collector_key(hostname, admin_id)` — délègue à `ssh.rotate_per_server_key()` (atomique avec rollback : génère `.key.new`, append pubkey distante, vérifie via re-connect, retire l'ancienne, renomme les fichiers). Audit COLLECTOR_KEY_ROTATED ou COLLECTOR_KEY_ROTATION_FAILED (avec error mais sans hostname/ip). Réservé sysadmin via UI (#402).
+- `get_collector_key_for_server(hostname) -> {fingerprint, public_key}` — lecture du `<uuid>.key.pub` per-server (#402).
+- `_trigger_initial_scan(server, admin_id, sync=False)` — helper : lance `collect.scan_server(server, admin_id)` en thread daemon (`sync=False`) ou en synchrone (`sync=True`). CLI doit utiliser `sync=True` car le process se termine sinon avant la fin du scan.
+- `provision_server(hostname, ip, ssh_user, ssh_password, ssh_port)` — re-provisionne un serveur existant (lit la per-server pubkey depuis disque) (#302). Même garantie : ssh password non stocké.
+- `update_server(hostname, ip, env, os_family, ssh_port, admin_id, max_sessions, new_hostname=None)` — met à jour hostname, IP, env, OS, port, max_sessions. Si l'IP change, ssh-keyscan atomique (#339). Si `new_hostname` est différent : validation RFC 1123, check d'unicité, audit `SERVER_RENAMED {old_hostname, new_hostname}`. Les entrées d'audit historiques restent intactes (#403).
+- `_validate_hostname(hostname) -> str` — regex RFC 1123, longueur ≤253, raise UserError sinon (#403).
+- `disable_server`, `enable_server` (#88), `delete_server` (#88 — hard delete + cascade + cleanup per-server keypair fichiers)
 
 ### Sessions
 - `check_session_limit(server_id, hostname, session_count, max_sessions)` — envoie alerte WARNING si session_count > max_sessions, avec anti-spam 24h via audit_log (SESSION_LIMIT_EXCEEDED, #360)
@@ -235,7 +241,9 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 
 | Route | sysadmin | operator | viewer |
 |-------|----------|----------|--------|
-| GET /api/servers, /api/keys, /api/access, /api/admins, /api/audit, /api/system/status, /api/system/config, /api/system/collector-key | ✓ | ✓ | ✓ |
+| GET /api/servers, /api/keys, /api/access, /api/admins, /api/audit, /api/system/status, /api/system/config | ✓ | ✓ | ✓ |
+| GET /api/servers/\*/collector-key | ✓ | ✓ | ✓ |
+| POST /api/servers/\*/rotate-key | ✓ | 403 | 403 |
 | POST /api/servers | ✓ | 403 | 403 |
 | POST /api/servers/\*/provision | ✓ | 403 | 403 |
 | POST /api/servers/\*/sync | ✓ | 403 | 403 |
@@ -288,8 +296,9 @@ Raison : évite ":" dans les args sudoers qui brise visudo sur RHEL/CentOS (#161
 Généré avec printf ligne par ligne — résistant au CRLF introduit par sudo PTY (#159).
 
 ```bash
-# Invocation provision-host.sh
-ssh <user>@<ip> "sudo bash -s '$(podman exec ssh-access-manager cat /data/keys/collector_key.pub)' '${SSH_USER}'" \
+# Invocation provision-host.sh — la pubkey vient désormais de la per-server key
+PUB=$(podman exec ssh-access-manager python3 /app/app/manage.py servers show <hostname> --pubkey)
+ssh <user>@<ip> "sudo bash -s '$PUB' '${SSH_USER}'" \
     < <(podman exec ssh-access-manager cat /app/provision-host.sh)
 ```
 

--- a/app/actions.py
+++ b/app/actions.py
@@ -4,6 +4,7 @@ Never duplicate logic between the two consumers.
 """
 import ipaddress
 import json
+import logging
 import re
 from datetime import datetime, timedelta, timezone
 
@@ -14,6 +15,14 @@ import ssh
 _FP_RE = re.compile(r"^SHA256:[A-Za-z0-9+/=]+$")
 _UNIX_USER_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
 VALID_ROLES = {"sysadmin", "operator", "viewer"}
+
+
+def _get_key_path(server_id: str) -> str:
+    """Helper to resolve per-server key path, wrapping ssh._resolve_key_path for consistent error handling."""
+    try:
+        return ssh._resolve_key_path(server_id)
+    except KeyError as exc:
+        raise UserError(str(exc), status=502)
 
 
 class UserError(Exception):
@@ -219,7 +228,8 @@ def revoke_key(
             raise UserError(
                 f"No active authorization for {fingerprint} / user {unix_user} on {hostname}"
             )
-        ssh.revoke_on_server(hostname, fingerprint, ip=server["ip_address"], unix_user=unix_user, port=server["ssh_port"])
+        key_path = _get_key_path(server["id"])
+        ssh.revoke_on_server(hostname, fingerprint, ip=server["ip_address"], unix_user=unix_user, port=server["ssh_port"], key_path=key_path)
         db.execute(
             """
             UPDATE key_authorizations
@@ -269,7 +279,8 @@ def revoke_key(
             (key["id"],),
         )
         for auth in active_auths:
-            ssh.revoke_on_server(auth["hostname"], fingerprint, ip=auth["ip_address"], port=auth["ssh_port"])
+            key_path = _get_key_path(auth["server_id"])
+            ssh.revoke_on_server(auth["hostname"], fingerprint, ip=auth["ip_address"], port=auth["ssh_port"], key_path=key_path)
             db.execute(
                 """
                 UPDATE key_authorizations
@@ -725,8 +736,9 @@ def deploy_key(
     )
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
 
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
-    ssh.add_key_on_server(hostname, unix_user, public_key.strip(), server["ip_address"], port=server["ssh_port"], sam_group=sam_group)
+    key_path = _get_key_path(server["id"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"], key_path=key_path)
+    ssh.add_key_on_server(hostname, unix_user, public_key.strip(), server["ip_address"], port=server["ssh_port"], sam_group=sam_group, key_path=key_path)
 
     db.execute(
         """
@@ -785,7 +797,8 @@ def grant_group(unix_user: str, hostname: str, group: str, admin_id: str) -> dic
     )
     if not row:
         raise UserError(f"No active key deployment for {unix_user} on {hostname}")
-    actual_groups = ssh.grant_group_on_server(hostname, unix_user, group, server["ip_address"], port=server["ssh_port"])
+    key_path = _get_key_path(server["id"])
+    actual_groups = ssh.grant_group_on_server(hostname, unix_user, group, server["ip_address"], port=server["ssh_port"], key_path=key_path)
     db.execute(
         "UPDATE key_authorizations SET sam_group = %s WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (group, server["id"], unix_user),
@@ -819,7 +832,8 @@ def revoke_group(unix_user: str, hostname: str, admin_id: str) -> dict:
     if not row:
         raise UserError(f"No active key deployment for {unix_user} on {hostname}")
     current_group = row["sam_group"]
-    actual_groups = ssh.revoke_group_on_server(hostname, unix_user, current_group, server["ip_address"], port=server["ssh_port"])
+    key_path = _get_key_path(server["id"])
+    actual_groups = ssh.revoke_group_on_server(hostname, unix_user, current_group, server["ip_address"], port=server["ssh_port"], key_path=key_path)
     if current_group is not None:
         db.execute(
             "UPDATE key_authorizations SET sam_group = NULL WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
@@ -856,9 +870,10 @@ def change_group(unix_user: str, hostname: str, new_group: str, admin_id: str) -
     if not row:
         raise UserError(f"No active key deployment for {unix_user} on {hostname}")
     old_group = row["sam_group"]
+    key_path = _get_key_path(server["id"])
     if old_group and old_group != new_group:
-        ssh.revoke_group_on_server(hostname, unix_user, old_group, server["ip_address"], port=server["ssh_port"])
-    actual_groups = ssh.grant_group_on_server(hostname, unix_user, new_group, server["ip_address"], port=server["ssh_port"])
+        ssh.revoke_group_on_server(hostname, unix_user, old_group, server["ip_address"], port=server["ssh_port"], key_path=key_path)
+    actual_groups = ssh.grant_group_on_server(hostname, unix_user, new_group, server["ip_address"], port=server["ssh_port"], key_path=key_path)
     db.execute(
         "UPDATE key_authorizations SET sam_group = %s WHERE server_id = %s AND unix_user = %s AND status = 'ACTIVE'",
         (new_group, server["id"], unix_user),
@@ -951,9 +966,10 @@ def revoke_request(request_id: str, admin_id: str) -> None:
 
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (req["key_id"],))
     if key:
-        server = db.query_one("SELECT hostname, ip_address, ssh_port FROM servers WHERE id = %s", (req["server_id"],))
+        server = db.query_one("SELECT id, hostname, ip_address, ssh_port FROM servers WHERE id = %s", (req["server_id"],))
         if server:
-            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"], port=server["ssh_port"])
+            key_path = _get_key_path(server["id"])
+            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"], port=server["ssh_port"], key_path=key_path)
 
     db.execute(
         """
@@ -977,8 +993,11 @@ def add_server(
     hostname: str, ip: str, ssh_user: str = "root", ssh_password: str = "",
     env: str | None = None, os_family: str | None = None,
     ssh_port: int = 22, admin_id: str | None = None,
+    scan_sync: bool = False,
 ) -> dict:
     """Add and provision a server atomically. Server is only created in DB if SSH provisioning succeeds."""
+    import uuid
+    import os
     ip = _validate_ip(ip)
     env = _normalize_environment(env)
     existing = db.query_one(
@@ -986,38 +1005,106 @@ def add_server(
     )
     if existing:
         raise UserError(f"IP {ip} is already used by server '{existing['hostname']}'")
-    ssh.provision_server(ip, ssh_user, ssh_password, ssh_port)
+
+    # Step 1: generate UUID and per-server keypair
+    server_id = str(uuid.uuid4())
+    keypair_base = os.path.join(ssh.PER_SERVER_KEYS_DIR, server_id)
+
+    try:
+        _, pubkey = ssh._generate_keypair(keypair_base)
+    except Exception as exc:
+        raise UserError(f"Failed to generate per-server keypair: {exc}")
+
+    # Step 2: SSH provision with the per-server pubkey
+    try:
+        ssh.provision_server(ip, ssh_user, ssh_password, ssh_port, pubkey=pubkey)
+    except Exception as exc:
+        # Cleanup keypair on SSH failure
+        for ext in (".key", ".key.pub"):
+            try:
+                os.remove(keypair_base + ext)
+            except FileNotFoundError:
+                pass
+        raise
+
+    # Step 3: INSERT with explicit UUID + is_provisioned=TRUE
     db.execute(
-        "INSERT INTO servers (hostname, ip_address, environment, os_family, ssh_port) VALUES (%s, %s, %s, %s, %s)",
-        (hostname, ip, env, os_family, ssh_port),
+        """INSERT INTO servers (id, hostname, ip_address, environment, os_family, ssh_port, is_active, is_provisioned)
+           VALUES (%s, %s, %s, %s, %s, %s, TRUE, TRUE)""",
+        (server_id, hostname, ip, env, os_family, ssh_port),
     )
-    server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+
+    # Step 4: Audit logs
     db.execute(
-        """
-        INSERT INTO audit_log (action, performed_by, target_server, details)
-        VALUES ('SERVER_ADDED', %s, %s, %s::jsonb)
-        """,
-        (admin_id, server["id"], json.dumps({"hostname": hostname, "ip": ip, "environment": env, "ssh_port": ssh_port})),
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('SERVER_ADDED', %s, %s, %s::jsonb)""",
+        (admin_id, server_id, json.dumps({"hostname": hostname, "ip": ip, "environment": env, "ssh_port": ssh_port})),
     )
     db.execute(
-        """
-        INSERT INTO audit_log (action, performed_by, target_server, details)
-        VALUES ('SERVER_PROVISIONED', %s, %s, %s::jsonb)
-        """,
-        (admin_id, server["id"], json.dumps({"hostname": hostname, "ssh_user": ssh_user, "ssh_port": ssh_port})),
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('SERVER_PROVISIONED', %s, %s, %s::jsonb)""",
+        (admin_id, server_id, json.dumps({"hostname": hostname, "ssh_user": ssh_user, "ssh_port": ssh_port})),
     )
+
+    fingerprint = ssh._compute_pubkey_fingerprint(pubkey)
+    db.execute(
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('COLLECTOR_KEY_GENERATED', %s, %s, %s::jsonb)""",
+        (admin_id, server_id, json.dumps({"server_id": server_id, "fingerprint": fingerprint})),
+    )
+
+    server = db.query_one("SELECT * FROM servers WHERE id = %s", (server_id,))
+    _trigger_initial_scan(server, admin_id, sync=scan_sync)
     return server
+
+
+def _trigger_initial_scan(server: dict, admin_id: str | None, *, sync: bool = False) -> None:
+    """Run an initial scan after provisioning.
+
+    Used by add_server / activate_server so a fresh host shows up
+    with its current authorized_keys without the admin needing to
+    click 'Scan' manually.
+
+    sync=False (default): fire-and-forget thread — for the web API
+    where the HTTP response must return immediately.
+    sync=True: blocking call — for the CLI, where a daemon thread
+    would be killed when the process exits before the scan completes.
+    """
+    import collect
+
+    def _run():
+        try:
+            collect.scan_server(dict(server), admin_id=admin_id)
+        except Exception:
+            logging.exception("Initial scan after provisioning failed for %s", server.get("hostname"))
+
+    if sync:
+        _run()
+    else:
+        import threading
+        threading.Thread(target=_run, daemon=True).start()
 
 
 def provision_server(hostname: str, ssh_user: str = "root", ssh_password: str = "", ssh_port: int = 22, admin_id: str | None = None) -> None:
     """Provision a remote server. Never stores the password."""
+    import os
     server = db.query_one(
         "SELECT id, ip_address FROM servers WHERE hostname = %s AND is_active = true",
         (hostname,),
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
-    ssh.provision_server(server["ip_address"], ssh_user, ssh_password, ssh_port)
+
+    # Read the per-server pubkey
+    pubkey_path = os.path.join(ssh.PER_SERVER_KEYS_DIR, f"{server['id']}.key.pub")
+    if not os.path.isfile(pubkey_path):
+        raise UserError("Per-server keypair not found - please delete and re-add this server")
+
+    with open(pubkey_path, "r") as fh:
+        pubkey = fh.read().strip()
+
+    ssh.provision_server(server["ip_address"], ssh_user, ssh_password, ssh_port, pubkey=pubkey)
+
     # Update ssh_port in DB after successful provisioning
     db.execute(
         "UPDATE servers SET ssh_port = %s WHERE id = %s",
@@ -1053,11 +1140,27 @@ def disable_server(hostname: str, admin_id: str | None = None) -> None:
     )
 
 
+_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-.]*[a-zA-Z0-9])?$")
+
+
+def _validate_hostname(hostname: str) -> str:
+    h = (hostname or "").strip()
+    if not h or len(h) > 253 or not _HOSTNAME_RE.match(h):
+        raise UserError(f"Invalid hostname: {hostname!r}")
+    return h
+
+
 def update_server(
     hostname: str, new_ip: str, new_env: str, new_os_family: str | None,
     ssh_port: int = 22, admin_id: str | None = None, max_sessions: int = 2,
+    new_hostname: str | None = None,
 ) -> dict:
-    """Update server IP, environment, OS, SSH port, max_sessions. If IP changes, run ssh-keyscan."""
+    """Update server hostname, IP, environment, OS, SSH port, max_sessions.
+
+    If IP changes, run ssh-keyscan. If hostname changes, log SERVER_RENAMED;
+    historical audit_log entries keep the old hostname intentionally so the
+    history remains accurate.
+    """
     new_ip = _validate_ip(new_ip)
     new_env = _normalize_environment(new_env)
     import servers as servers_mod
@@ -1075,6 +1178,18 @@ def update_server(
     if existing:
         raise UserError(f"IP {new_ip} is already used by server '{existing['hostname']}'")
 
+    rename_to = None
+    if new_hostname is not None:
+        candidate = _validate_hostname(new_hostname)
+        if candidate != hostname:
+            clash = db.query_one(
+                "SELECT id FROM servers WHERE hostname = %s AND id != %s",
+                (candidate, server["id"]),
+            )
+            if clash:
+                raise UserError(f"Hostname {candidate!r} is already used by another server")
+            rename_to = candidate
+
     old_ip = server["ip_address"]
     old_env = server["environment"]
     old_os = server["os_family"]
@@ -1087,9 +1202,10 @@ def update_server(
         except Exception as e:
             raise UserError(f"Cannot reach {hostname} ({new_ip}) for keyscan: {e}") from e
 
+    effective_hostname = rename_to or hostname
     db.execute(
-        "UPDATE servers SET ip_address = %s, environment = %s, os_family = %s, ssh_port = %s, max_sessions = %s WHERE hostname = %s",
-        (new_ip, new_env, new_os_family, ssh_port, max_sessions, hostname),
+        "UPDATE servers SET hostname = %s, ip_address = %s, environment = %s, os_family = %s, ssh_port = %s, max_sessions = %s WHERE id = %s",
+        (effective_hostname, new_ip, new_env, new_os_family, ssh_port, max_sessions, server["id"]),
     )
     db.execute(
         """
@@ -1100,7 +1216,7 @@ def update_server(
             admin_id,
             server["id"],
             json.dumps({
-                "hostname": hostname,
+                "hostname": effective_hostname,
                 "old_ip": old_ip, "new_ip": new_ip,
                 "old_env": old_env, "new_env": new_env,
                 "old_os": old_os, "new_os": new_os_family,
@@ -1109,6 +1225,17 @@ def update_server(
             }),
         ),
     )
+    if rename_to:
+        db.execute(
+            """
+            INSERT INTO audit_log (action, performed_by, target_server, details)
+            VALUES ('SERVER_RENAMED', %s, %s, %s::jsonb)
+            """,
+            (admin_id, server["id"], json.dumps({"old_hostname": hostname, "new_hostname": rename_to})),
+        )
+
+    server = dict(server)
+    server["hostname"] = effective_hostname
     return server
 
 
@@ -1131,6 +1258,7 @@ def enable_server(hostname: str, admin_id: str | None = None) -> None:
 
 def delete_server(hostname: str, admin_id: str | None = None) -> None:
     """Hard delete a server and all related data."""
+    import os
     server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
     if not server:
         raise NotFoundError(f"Server not found: {hostname}")
@@ -1139,6 +1267,157 @@ def delete_server(hostname: str, admin_id: str | None = None) -> None:
     db.execute("DELETE FROM access_requests WHERE server_id = %s", (sid,))
     db.execute("DELETE FROM key_authorizations WHERE server_id = %s", (sid,))
     db.execute("DELETE FROM servers WHERE id = %s", (sid,))
+
+    # Cleanup per-server keypair files
+    for ext in (".key", ".key.pub"):
+        try:
+            path = os.path.join(ssh.PER_SERVER_KEYS_DIR, f"{sid}{ext}")
+            if os.path.isfile(path):
+                os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def register_server(
+    hostname: str, ip: str, ssh_port: int = 22,
+    env: str | None = None, os_family: str | None = None,
+    admin_id: str | None = None,
+) -> dict:
+    """Create a server in DB and generate its keypair, without trying SSH.
+
+    Status: is_provisioned=FALSE, is_active=TRUE.
+    Use case: admin will provision the host manually with their own SSH
+    credentials (bulk bootstrap workflow with cloud-init etc.).
+    """
+    import uuid
+    import os
+    ip = _validate_ip(ip)
+    env = _normalize_environment(env)
+    existing = db.query_one(
+        "SELECT hostname FROM servers WHERE ip_address = %s", (ip,)
+    )
+    if existing:
+        raise UserError(f"IP {ip} is already used by server '{existing['hostname']}'")
+
+    # Generate UUID + keypair
+    server_id = str(uuid.uuid4())
+    keypair_base = os.path.join(ssh.PER_SERVER_KEYS_DIR, server_id)
+
+    try:
+        _, pubkey = ssh._generate_keypair(keypair_base)
+    except Exception as exc:
+        raise UserError(f"Failed to generate per-server keypair: {exc}")
+
+    # INSERT with is_provisioned=FALSE
+    db.execute(
+        """INSERT INTO servers (id, hostname, ip_address, environment, os_family, ssh_port, is_active, is_provisioned)
+           VALUES (%s, %s, %s, %s, %s, %s, TRUE, FALSE)""",
+        (server_id, hostname, ip, env, os_family, ssh_port),
+    )
+
+    # Audit COLLECTOR_KEY_GENERATED
+    fingerprint = ssh._compute_pubkey_fingerprint(pubkey)
+    db.execute(
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('COLLECTOR_KEY_GENERATED', %s, %s, %s::jsonb)""",
+        (admin_id, server_id, json.dumps({"server_id": server_id, "fingerprint": fingerprint})),
+    )
+
+    return {"server_id": server_id, "hostname": hostname, "public_key": pubkey, "fingerprint": fingerprint}
+
+
+def activate_server(hostname: str, admin_id: str | None = None, scan_sync: bool = False) -> dict:
+    """Verify SSH connectivity with the per-server key, mark as provisioned.
+
+    Use case: after the admin has deployed the pubkey manually on the host
+    (step 2 of bulk bootstrap workflow), this confirms it works and
+    triggers the first scan.
+    """
+    server = db.query_one(
+        "SELECT id, ip_address, ssh_port, is_provisioned FROM servers WHERE hostname = %s",
+        (hostname,),
+    )
+    if not server:
+        raise NotFoundError(f"Server not found: {hostname}")
+    if server["is_provisioned"]:
+        raise UserError(f"Server {hostname} is already provisioned")
+
+    key_path = _get_key_path(server["id"])
+    # Ensure the host key is in known_hosts (RejectPolicy will refuse otherwise)
+    try:
+        ssh._fetch_host_key(server["ip_address"], server["ssh_port"])
+    except Exception as exc:
+        raise UserError(f"Failed to fetch host key for {server['ip_address']}: {exc}", status=502)
+
+    try:
+        # Test connectivity by running a no-op command
+        client = ssh._connect(server["ip_address"], server["ssh_port"], key_path=key_path)
+        client.exec_command("true")
+        client.close()
+    except ssh.SSHError as exc:
+        raise UserError(f"SSH connectivity check failed: {exc}", status=502)
+    except Exception as exc:
+        raise UserError(f"SSH connectivity check failed: {exc}", status=502)
+
+    db.execute("UPDATE servers SET is_provisioned = TRUE WHERE id = %s", (server["id"],))
+    db.execute(
+        """INSERT INTO audit_log (action, performed_by, target_server, details)
+           VALUES ('SERVER_PROVISIONED', %s, %s, %s::jsonb)""",
+        (admin_id, server["id"], json.dumps({"hostname": hostname, "method": "activate"})),
+    )
+
+    full_server = db.query_one("SELECT * FROM servers WHERE id = %s", (server["id"],))
+    _trigger_initial_scan(full_server, admin_id, sync=scan_sync)
+    return {"hostname": hostname, "status": "provisioned"}
+
+
+def rotate_collector_key(hostname: str, admin_id: str) -> dict:
+    """Manual rotation triggered from ServerDetail button."""
+    server = db.query_one(
+        "SELECT id, ip_address, ssh_port, is_active FROM servers WHERE hostname = %s",
+        (hostname,),
+    )
+    if not server or not server["is_active"]:
+        raise NotFoundError(f"Server not found or inactive: {hostname}")
+
+    try:
+        new_fp = ssh.rotate_per_server_key(
+            hostname,
+            server["ip_address"],
+            server["ssh_port"],
+            server["id"],
+        )
+        db.execute(
+            """INSERT INTO audit_log (action, performed_by, target_server, details)
+               VALUES ('COLLECTOR_KEY_ROTATED', %s, %s, %s::jsonb)""",
+            (admin_id, server["id"], json.dumps({"server_id": server["id"], "fingerprint": new_fp})),
+        )
+        return {"status": "rotated", "fingerprint": new_fp}
+    except ssh.SSHError as exc:
+        db.execute(
+            """INSERT INTO audit_log (action, performed_by, target_server, details)
+               VALUES ('COLLECTOR_KEY_ROTATION_FAILED', %s, %s, %s::jsonb)""",
+            (admin_id, server["id"], json.dumps({"error": str(exc)})),
+        )
+        raise UserError(f"Rotation failed: {exc}", status=502)
+
+
+def get_collector_key_for_server(hostname: str) -> dict:
+    """Return {fingerprint, public_key} for the per-server key (read-only)."""
+    import os
+    server = db.query_one("SELECT id FROM servers WHERE hostname = %s", (hostname,))
+    if not server:
+        raise NotFoundError(f"Server not found: {hostname}")
+
+    pubkey_path = os.path.join(ssh.PER_SERVER_KEYS_DIR, f"{server['id']}.key.pub")
+    if not os.path.isfile(pubkey_path):
+        raise UserError("Per-server public key not found - server may not be provisioned")
+
+    with open(pubkey_path, "r") as fh:
+        pubkey = fh.read().strip()
+
+    fingerprint = ssh._compute_pubkey_fingerprint(pubkey)
+    return {"fingerprint": fingerprint, "public_key": pubkey}
 
 
 # ---------------------------------------------------------------------------
@@ -1364,8 +1643,9 @@ def lock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
-    ssh.lock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
+    key_path = _get_key_path(server["id"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"], key_path=key_path)
+    ssh.lock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"], key_path=key_path)
     db.execute(
         """INSERT INTO audit_log (action, performed_by, target_server, details)
            VALUES ('USER_LOCKED', %s, %s, %s::jsonb)""",
@@ -1388,8 +1668,9 @@ def unlock_user(unix_user: str, hostname: str, admin_id: str) -> dict:
     )
     if not server:
         raise NotFoundError(f"Server not found or inactive: {hostname}")
-    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"])
-    ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"])
+    key_path = _get_key_path(server["id"])
+    ssh.ensure_scripts(hostname, server["id"], server["ip_address"], port=server["ssh_port"], key_path=key_path)
+    ssh.unlock_user_on_server(hostname, unix_user, server["ip_address"], port=server["ssh_port"], key_path=key_path)
     db.execute(
         """INSERT INTO audit_log (action, performed_by, target_server, details)
            VALUES ('USER_UNLOCKED', %s, %s, %s::jsonb)""",
@@ -1505,7 +1786,7 @@ def audit_server_sshd(hostname: str, admin_id: str | None = None) -> dict:
     No DB write, no audit_log (read-only).
     """
     row = db.query_one(
-        "SELECT ip_address, ssh_port, is_active FROM servers WHERE hostname = %s",
+        "SELECT id, ip_address, ssh_port, is_active FROM servers WHERE hostname = %s",
         (hostname,),
     )
     if not row:
@@ -1513,7 +1794,8 @@ def audit_server_sshd(hostname: str, admin_id: str | None = None) -> dict:
     if not row["is_active"]:
         raise UserError("Server is disabled", status=409)
     try:
-        parsed = ssh.audit_sshd_config(hostname, row["ip_address"], row["ssh_port"])
+        key_path = _get_key_path(row["id"])
+        parsed = ssh.audit_sshd_config(hostname, row["ip_address"], row["ssh_port"], key_path=key_path)
     except ssh.SSHError as exc:
         raise UserError(f"SSH audit failed: {exc}", status=502)
     return check_sshd_compliance(parsed)

--- a/app/collect.py
+++ b/app/collect.py
@@ -88,21 +88,42 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
     server_id = server["id"]
     result = {"hostname": hostname, "new": 0, "disappeared": 0, "known": 0, "error": None, "anomalies": []}
 
+    # Resolve per-server key path
     try:
-        ssh.ensure_scripts(hostname, server_id, ip=ip, port=ssh_port)
+        key_path = ssh._resolve_key_path(server_id)
+    except KeyError as exc:
+        # No per-server key — admin must re-add this server
+        result["error"] = str(exc)
+        db.execute(
+            """
+            INSERT INTO audit_log (action, target_server, details)
+            VALUES ('SCAN_FAILED', %s, %s::jsonb)
+            """,
+            (server_id, json.dumps({"error": str(exc)})),
+        )
+        return result
+
+    try:
+        ssh.ensure_scripts(hostname, server_id, ip=ip, port=ssh_port, key_path=key_path)
 
         # Auto-update provision artifacts if version differs
         # Wrapped in try/except for test compatibility (mocks may not have these functions)
         try:
-            client = ssh._connect(ip, ssh_port)
+            client = ssh._connect(ip, ssh_port, key_path=key_path)
             try:
                 remote_version = ssh._read_provision_version(client)
             finally:
                 client.close()
 
-            if remote_version != ssh.PROVISION_VERSION:
+            if remote_version == ssh.PROVISION_VERSION:
+                # Version matches — record it (no-op if already set), clear drift
+                db.execute(
+                    "UPDATE servers SET provision_version = %s, provision_drift = FALSE WHERE id = %s",
+                    (remote_version, server_id),
+                )
+            else:
                 try:
-                    applied = ssh.apply_provision_update(hostname, ip, ssh_port)
+                    applied = ssh.apply_provision_update(hostname, ip, ssh_port, key_path=key_path)
                     db.execute(
                         "UPDATE servers SET provision_version = %s, provision_drift = FALSE WHERE id = %s",
                         (applied, server_id),
@@ -135,7 +156,7 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
             # AttributeError/TypeError: compatibility with test mocks
             pass
 
-        raw_lines = ssh.collect_keys(hostname, ip=ip, port=ssh_port)
+        raw_lines = ssh.collect_keys(hostname, ip=ip, port=ssh_port, key_path=key_path)
     except Exception as exc:
         result["error"] = str(exc)
         db.execute(
@@ -234,7 +255,7 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
 
     # Collect SSH sessions (non-fatal)
     try:
-        ssh.collect_sessions_on_server(hostname, server_id, ip=ip, port=ssh_port)
+        ssh.collect_sessions_on_server(hostname, server_id, ip=ip, port=ssh_port, key_path=key_path)
         # Check session limit and send alert if exceeded (24h anti-spam)
         max_sessions = server.get("max_sessions", 2)
         active_count = db.query_one(

--- a/app/expire.py
+++ b/app/expire.py
@@ -63,7 +63,7 @@ def expire_keys() -> int:
     """
     rows = db.query(
         """
-        SELECT DISTINCT ka.key_id, ka.server_id, sk.fingerprint, s.hostname, s.ip_address, s.ssh_port
+        SELECT DISTINCT ka.key_id, ka.server_id, sk.fingerprint, s.id AS server_id, s.hostname, s.ip_address, s.ssh_port
         FROM key_authorizations ka
         JOIN ssh_keys sk ON sk.id = ka.key_id
         JOIN servers s ON s.id = ka.server_id
@@ -77,7 +77,8 @@ def expire_keys() -> int:
     expired = 0
     for row in rows:
         try:
-            ssh.revoke_on_server(row["hostname"], row["fingerprint"], ip=row["ip_address"], port=row["ssh_port"])
+            key_path = ssh._resolve_key_path(row["server_id"])
+            ssh.revoke_on_server(row["hostname"], row["fingerprint"], ip=row["ip_address"], port=row["ssh_port"], key_path=key_path)
         except Exception as exc:
             alerts.send_alert(
                 "CRITICAL",

--- a/app/manage.py
+++ b/app/manage.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 import click
 
 import actions
+from actions import NotFoundError, UserError
 import collect as collect_mod
 import db
 
@@ -78,13 +79,55 @@ def servers_list():
 
 @servers.command("show")
 @click.argument("hostname")
-def servers_show(hostname):
-    """Display server details."""
+@click.option("--pubkey", is_flag=True, help="Print only the per-server collector public key")
+def servers_show(hostname, pubkey):
+    """Display server details (or --pubkey to dump the per-server collector pubkey)."""
+    if pubkey:
+        try:
+            info = actions.get_collector_key_for_server(hostname)
+        except NotFoundError as e:
+            raise click.ClickException(str(e))
+        except UserError as e:
+            raise click.ClickException(str(e))
+        click.echo(info["public_key"])
+        return
     row = db.query_one("SELECT * FROM servers WHERE hostname = %s", (hostname,))
     if not row:
         raise click.ClickException(f"Server not found: {hostname}")
     for k, v in row.items():
         click.echo(f"{k:20}: {v}")
+
+
+@servers.command("register")
+@click.option("--hostname", required=True, help="Hostname")
+@click.option("--ip", required=True, help="IP address")
+@click.option("--env", default=None, type=click.Choice(["production", "staging", "lab"]), help="Environment (optional)")
+@click.option("--os", "os_family", default=None, help="OS family")
+@click.option("--port", "ssh_port", default=22, show_default=True, type=int, help="SSH port")
+def servers_register(hostname, ip, env, os_family, ssh_port):
+    """Register a server in DB and generate its keypair, without SSH.
+
+    Use this for bulk bootstrap: register, then deploy the pubkey manually
+    with your own SSH credentials, then run `servers activate`.
+    """
+    admin_id = _require_admin()
+    try:
+        result = actions.register_server(hostname, ip, ssh_port, env, os_family, admin_id)
+    except (UserError, NotFoundError) as e:
+        raise click.ClickException(str(e))
+    click.echo(f"Registered {result['hostname']} (id={result['server_id']}, fingerprint={result['fingerprint']})")
+
+
+@servers.command("activate")
+@click.argument("hostname")
+def servers_activate(hostname):
+    """Verify SSH connectivity with the per-server key and mark as provisioned."""
+    admin_id = _require_admin()
+    try:
+        result = actions.activate_server(hostname, admin_id, scan_sync=True)
+    except (UserError, NotFoundError) as e:
+        raise click.ClickException(str(e))
+    click.echo(f"Server {hostname} {result['status']}.")
 
 
 @servers.command("add")
@@ -101,9 +144,9 @@ def servers_add(hostname, ip, ssh_user, ssh_password, env, os_family, ssh_port):
     if ssh_password is None:
         ssh_password = click.prompt("SSH password (leave empty to use collector key)", hide_input=True, default="")
     try:
-        actions.add_server(hostname, ip, ssh_user, ssh_password, env, os_family, ssh_port, admin_id)
+        actions.add_server(hostname, ip, ssh_user, ssh_password, env, os_family, ssh_port, admin_id, scan_sync=True)
         click.echo(f"Server {hostname} added and provisioned successfully.")
-    except (ValueError, RuntimeError) as e:
+    except (ValueError, RuntimeError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -129,7 +172,7 @@ def servers_update(hostname, ip, env, os_family):
             admin_id,
         )
         click.echo(f"Server {hostname} updated.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -141,7 +184,7 @@ def servers_disable(hostname):
     try:
         actions.disable_server(hostname, admin_id)
         click.echo(f"Server {hostname} disabled.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -213,7 +256,7 @@ def keys_validate(fingerprint):
     try:
         actions.validate_key(fingerprint, admin_id)
         click.echo(f"Key {fingerprint} validated.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -226,7 +269,7 @@ def keys_revoke(fingerprint, reason):
     try:
         actions.revoke_key(fingerprint, admin_id, reason)
         click.echo(f"Key {fingerprint} revoked.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -238,7 +281,7 @@ def keys_assign(fingerprint, owner):
     try:
         actions.assign_key(fingerprint, owner)
         click.echo(f"Key {fingerprint} assigned to {owner}.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -259,7 +302,7 @@ def keys_set_expiry(fingerprint, hours, date_str):
     try:
         actions.set_key_expiry(fingerprint, expires_at)
         click.echo(f"Expiration set: {expires_at.isoformat()}")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -270,7 +313,7 @@ def keys_remove_expiry(fingerprint):
     try:
         actions.remove_key_expiry(fingerprint)
         click.echo(f"Expiration removed for {fingerprint}.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -339,7 +382,7 @@ def access_grant(key_fp, hostname, hours, date_str, reason):
     try:
         actions.grant_access(key_fp, hostname, expires_at, reason, admin_id)
         click.echo(f"Access granted until {expires_at.isoformat()}.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -376,7 +419,7 @@ def access_approve(request_id):
     try:
         actions.approve_request(request_id, admin_id)
         click.echo(f"Request {request_id} approved.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -388,7 +431,7 @@ def access_reject(request_id):
     try:
         actions.reject_request(request_id, admin_id)
         click.echo(f"Request {request_id} rejected.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -400,7 +443,7 @@ def access_revoke(request_id):
     try:
         actions.revoke_request(request_id, admin_id)
         click.echo(f"Access {request_id} revoked.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -413,7 +456,7 @@ def access_lock_user(user, server):
     try:
         result = actions.lock_user(user, server, admin_id)
         click.echo(f"User '{result['unix_user']}' locked on {result['hostname']}")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -426,7 +469,7 @@ def access_unlock_user(user, server):
     try:
         result = actions.unlock_user(user, server, admin_id)
         click.echo(f"User '{result['unix_user']}' unlocked on {result['hostname']}")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -451,7 +494,7 @@ def group_grant(user, server, sam_group):
     try:
         result = actions.grant_group(user, server, sam_group, admin_id)
         click.echo(f"User '{result['unix_user']}' assigned to {result['sam_group']} on {result['hostname']}")
-    except (ValueError, actions.UserError, actions.NotFoundError) as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -464,7 +507,7 @@ def group_revoke(user, server):
     try:
         result = actions.revoke_group(user, server, admin_id)
         click.echo(f"SAM group revoked for '{result['unix_user']}' on {result['hostname']}")
-    except (ValueError, actions.UserError, actions.NotFoundError) as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -480,7 +523,7 @@ def group_change(user, server, sam_group):
     try:
         result = actions.change_group(user, server, sam_group, admin_id)
         click.echo(f"User '{result['unix_user']}' group changed to {result['sam_group']} on {result['hostname']}")
-    except (ValueError, actions.UserError, actions.NotFoundError) as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -522,7 +565,7 @@ def admin_disable(username):
     try:
         actions.disable_admin(username, performer_id)
         click.echo(f"Administrator {username} disabled.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -534,7 +577,7 @@ def admin_enable(username):
     try:
         actions.enable_admin(username, performer_id)
         click.echo(f"Administrator {username} re-enabled.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -560,7 +603,7 @@ def admin_update(username, email, role):
             performer_id,
         )
         click.echo(f"Administrator {username} updated.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -572,7 +615,7 @@ def admin_reset_password(username, password):
     try:
         actions.reset_password(username, password)
         click.echo(f"Password for {username} has been reset.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 
@@ -585,7 +628,7 @@ def admin_delete(username):
     try:
         actions.delete_admin(username, performer_id)
         click.echo(f"Administrator {username} deleted.")
-    except ValueError as e:
+    except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))
 
 

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import io
 import json
@@ -49,8 +50,8 @@ ScriptError = SSHScriptError
 
 
 KNOWN_HOSTS = os.environ.get("KNOWN_HOSTS", "/data/keys/known_hosts")
-COLLECTOR_KEY = os.environ.get("COLLECTOR_KEY", "/data/keys/collector_key")
 SSH_USER = os.environ.get("SSH_USER", "audit-collector")
+PER_SERVER_KEYS_DIR = "/data/keys/per-server"
 
 SAM_COLLECT_PATH = "/usr/local/bin/sam-collect"
 SAM_REVOKE_PATH = "/usr/local/bin/sam-revoke"
@@ -738,14 +739,229 @@ def _read_provision_version(client) -> str | None:
     return value or None
 
 
-def apply_provision_update(hostname: str, ip: str, port: int = 22) -> str:
+def _resolve_key_path(server_id: str) -> str:
+    """Return the path to the per-server collector key for this server.
+
+    Raises KeyError with a clear admin-facing message if the key file does
+    not exist (server provisioned before per-server keys, or filesystem
+    corruption / restore inconsistency). The scan layer turns this into a
+    SCAN_FAILED audit entry.
+    """
+    path = os.path.join(PER_SERVER_KEYS_DIR, f"{server_id}.key")
+    if not os.path.isfile(path):
+        raise KeyError(
+            f"no per-server collector key for server {server_id} — please re-add this server"
+        )
+    return path
+
+
+def _generate_keypair(target_path_no_ext: str) -> tuple[str, str]:
+    """Generate an ed25519 keypair at <target_path_no_ext>{,.pub}.
+
+    Empty SSH comment (no `-C` data) — files must be anonymous on disk so
+    that a stolen .key file cannot be correlated to a hostname/IP. The
+    server identity lives in the filename (server UUID, random v4).
+
+    Returns (path_to_private_key, public_key_content). Public key content
+    is the single-line `ssh-ed25519 AAAA... ` string ready to put into
+    authorized_keys.
+
+    chmod 600 on private, 644 on public, chown nobody on both (Flask
+    process must be able to read them).
+    """
+    import subprocess
+    private_path = target_path_no_ext + ".key"
+    public_path = target_path_no_ext + ".key.pub"
+
+    # Generate keypair with no passphrase and no comment
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-C", "", "-f", private_path],
+        check=True,
+        capture_output=True,
+    )
+
+    # Per-server pubkey is only consumed by Flask (nobody) for display and
+    # remote provisioning — no other local user needs read access.
+    os.chmod(private_path, 0o600)
+    os.chmod(public_path, 0o600)
+
+    # Chown to nobody (user running Flask)
+    import pwd
+    nobody_uid = pwd.getpwnam("nobody").pw_uid
+    nobody_gid = pwd.getpwnam("nobody").pw_gid
+    os.chown(private_path, nobody_uid, nobody_gid)
+    os.chown(public_path, nobody_uid, nobody_gid)
+
+    # Read public key
+    with open(public_path, "r") as fh:
+        public_key = fh.read().strip()
+
+    return private_path, public_key
+
+
+def _compute_pubkey_fingerprint(pubkey_line: str) -> str:
+    """Return the SHA256 fingerprint string (`SHA256:abc...`) of an SSH
+    public key line. Same format as ssh-keygen -lf and `ssh.compute_fingerprint`
+    in actions.py — verify the existing helper, reuse if possible."""
+    # Parse pubkey line: "ssh-ed25519 AAAA... [comment]"
+    parts = pubkey_line.strip().split()
+    if len(parts) < 2:
+        raise ValueError("Invalid public key format")
+    key_b64 = parts[1]
+
+    # Compute SHA256 fingerprint
+    raw = base64.b64decode(key_b64)
+    digest = hashlib.sha256(raw).digest()
+    b64 = base64.b64encode(digest).decode().rstrip("=")
+    return f"SHA256:{b64}"
+
+
+def _append_pubkey_remote(client: paramiko.SSHClient, pubkey: str) -> None:
+    """Append pubkey to ~audit-collector/.ssh/authorized_keys if not already present."""
+    # Check if key already present
+    check_cmd = f"grep -qxF {shlex.quote(pubkey)} ~/.ssh/authorized_keys 2>/dev/null"
+    _, _, rc = _run(client, check_cmd)
+    if rc == 0:
+        # Already present, skip
+        return
+
+    # Append the key
+    append_cmd = f"echo {shlex.quote(pubkey)} >> ~/.ssh/authorized_keys"
+    _, err, rc = _run(client, append_cmd)
+    if rc != 0:
+        raise SSHError(f"Failed to append pubkey: {err}")
+
+
+def _remove_pubkey_remote(client: paramiko.SSHClient, pubkey: str) -> None:
+    """Remove pubkey line from ~audit-collector/.ssh/authorized_keys atomically."""
+    # Use grep -vxF to filter out the exact line, atomic with mv
+    remove_cmd = (
+        f"grep -vxF {shlex.quote(pubkey)} ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.tmp && "
+        f"mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys"
+    )
+    _, err, rc = _run(client, remove_cmd)
+    if rc != 0:
+        raise SSHError(f"Failed to remove pubkey: {err}")
+
+
+def rotate_per_server_key(hostname: str, ip: str, port: int, server_id: str) -> str:
+    """Rotate the collector key for one server, atomically with rollback.
+
+    Workflow:
+    1. Check current per-server key exists (raise if not)
+    2. Read current pubkey content
+    3. Generate new keypair at <id>.key.new and <id>.key.new.pub
+    4. SSH to host with CURRENT key (key_filename=<id>.key)
+    5. Append new pubkey to ~audit-collector/.ssh/authorized_keys
+    6. Disconnect, reconnect with NEW key — verify connectivity
+    7. If OK: SSH again with new key, remove the OLD pubkey line from
+       authorized_keys (grep -vF on the exact line)
+    8. Move files: <id>.key -> <id>.key.old, <id>.key.new -> <id>.key,
+       <id>.key.new.pub -> <id>.key.pub, then remove .old files
+    9. Return new fingerprint
+
+    On error at any step: try to remove the new pubkey from
+    authorized_keys (with old key if it's still working), delete the
+    .new files locally, raise SSHError with original cause.
+
+    No sudo needed for any step — audit-collector writes directly to its
+    own ~/.ssh/authorized_keys.
+    """
+    # Step 1: verify current key exists
+    current_key_path = _resolve_key_path(server_id)
+    current_pubkey_path = current_key_path + ".pub"
+
+    # Step 2: read current pubkey
+    with open(current_pubkey_path, "r") as fh:
+        current_pubkey = fh.read().strip()
+
+    # Step 3: generate new keypair
+    new_key_base = os.path.join(PER_SERVER_KEYS_DIR, f"{server_id}.key.new")
+    new_key_path, new_pubkey = _generate_keypair(new_key_base[:-4])  # Strip .key to get base
+    new_pubkey_path = new_key_path + ".pub"
+
+    new_fingerprint = None
+    client_old = None
+    client_new = None
+
+    try:
+        # Step 4: connect with current key
+        client_old = _connect(ip, port, key_path=current_key_path)
+
+        # Step 5: append new pubkey
+        _append_pubkey_remote(client_old, new_pubkey)
+        client_old.close()
+        client_old = None
+
+        # Step 6: test connectivity with new key
+        try:
+            client_new = _connect(ip, port, key_path=new_key_path)
+            # Run a no-op to verify
+            _, _, rc = _run(client_new, "true")
+            if rc != 0:
+                raise SSHError("New key test failed")
+        except Exception as exc:
+            raise SSHError(f"New key verification failed: {exc}")
+
+        # Step 7: remove old pubkey with new connection
+        _remove_pubkey_remote(client_new, current_pubkey)
+        client_new.close()
+        client_new = None
+
+        # Step 8: atomic file rotation
+        old_backup_path = current_key_path + ".old"
+        old_backup_pub_path = current_pubkey_path + ".old"
+
+        os.rename(current_key_path, old_backup_path)
+        os.rename(current_pubkey_path, old_backup_pub_path)
+        os.rename(new_key_path, current_key_path)
+        os.rename(new_pubkey_path, current_pubkey_path)
+
+        # Cleanup old backup
+        os.remove(old_backup_path)
+        os.remove(old_backup_pub_path)
+
+        # Step 9: compute and return new fingerprint
+        new_fingerprint = _compute_pubkey_fingerprint(new_pubkey)
+        return new_fingerprint
+
+    except Exception as exc:
+        # Rollback: try to remove new pubkey from authorized_keys
+        try:
+            if client_new is None and os.path.isfile(current_key_path):
+                # Try with old key
+                rollback_client = _connect(ip, port, key_path=current_key_path)
+                try:
+                    _remove_pubkey_remote(rollback_client, new_pubkey)
+                finally:
+                    rollback_client.close()
+        except Exception:
+            pass  # Best effort
+
+        # Cleanup .new files
+        for path in [new_key_path, new_pubkey_path]:
+            try:
+                if os.path.isfile(path):
+                    os.remove(path)
+            except Exception:
+                pass
+
+        raise SSHError(f"Key rotation failed: {exc}")
+    finally:
+        if client_old is not None:
+            client_old.close()
+        if client_new is not None:
+            client_new.close()
+
+
+def apply_provision_update(hostname: str, ip: str, port: int = 22, *, key_path: str) -> str:
     """Run `sudo sam-self-update <version>` on the remote host.
 
     Returns the applied version on success. Raises SSHSudoError if the script
     exits non-zero (the script itself has already rolled back any partial
     change on its end before exiting).
     """
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         cmd = f"sudo {SAM_SELF_UPDATE_PATH} {PROVISION_VERSION}"
         stdout, stderr, exit_code = _run(client, cmd)
@@ -758,11 +974,15 @@ def apply_provision_update(hostname: str, ip: str, port: int = 22) -> str:
         client.close()
 
 
-def _connect(ip: str, port: int = 22) -> paramiko.SSHClient:
+def _connect(ip: str, port: int = 22, *, key_path: str) -> paramiko.SSHClient:
+    """Connect to a remote host using a per-server collector key.
+
+    key_path is required (keyword-only) — no global default key.
+    """
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(paramiko.RejectPolicy())
     client.load_host_keys(KNOWN_HOSTS)
-    client.connect(hostname=ip, port=port, username=SSH_USER, key_filename=COLLECTOR_KEY, timeout=15)
+    client.connect(hostname=ip, port=port, username=SSH_USER, key_filename=key_path, timeout=15)
     return client
 
 
@@ -794,12 +1014,12 @@ def _deploy_script(
     _run(client, f"rm -f {shlex.quote(tmp_path)}")
 
 
-def ensure_scripts(hostname: str, server_id: str, ip: str, port: int = 22) -> None:
+def ensure_scripts(hostname: str, server_id: str, ip: str, port: int = 22, *, key_path: str) -> None:
     """
     Deploy all SAM_* scripts on the remote host if absent or outdated.
     Logs SCRIPT_DEPLOYED to audit_log for each script actually deployed.
     """
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         sftp = client.open_sftp()
         for content, remote_path in (
@@ -836,13 +1056,13 @@ def ensure_scripts(hostname: str, server_id: str, ip: str, port: int = 22) -> No
         client.close()
 
 
-def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = None, port: int = 22) -> None:
+def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = None, port: int = 22, *, key_path: str) -> None:
     """Run sam-revoke on the remote host.
     If unix_user is given, revokes only from that user's authorized_keys.
     Otherwise revokes globally (all users on the server).
     """
     import shlex
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         cmd = f"sudo {SAM_REVOKE_PATH} {shlex.quote(fingerprint)}"
         if unix_user:
@@ -856,9 +1076,9 @@ def revoke_on_server(hostname: str, fingerprint: str, ip: str, unix_user: str = 
         client.close()
 
 
-def collect_keys(hostname: str, ip: str, port: int = 22) -> list[str]:
+def collect_keys(hostname: str, ip: str, port: int = 22, *, key_path: str) -> list[str]:
     """Run sam-collect on the remote host and return raw output lines."""
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         out, _, rc = _run(client, f"sudo {SAM_COLLECT_PATH}")
         if rc != 0:
@@ -868,13 +1088,13 @@ def collect_keys(hostname: str, ip: str, port: int = 22) -> list[str]:
         client.close()
 
 
-def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str, port: int = 22, sam_group: str = None) -> None:
+def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str, port: int = 22, sam_group: str = None, *, key_path: str) -> None:
     """Run sam-add on the remote host to deploy a public key and set the SAM group."""
     import shlex
     cmd = f"sudo {SAM_ADD_PATH} {shlex.quote(unix_user)} {shlex.quote(public_key)}"
     if sam_group:
         cmd += f" {shlex.quote(sam_group)}"
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         _, err, rc = _run(client, cmd)
         if rc != 0:
@@ -883,10 +1103,10 @@ def add_key_on_server(hostname: str, unix_user: str, public_key: str, ip: str, p
         client.close()
 
 
-def lock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22) -> None:
+def lock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22, *, key_path: str) -> None:
     """Run sam-lock-user on the remote host to lock a Unix user account."""
     import shlex
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_LOCK_USER_PATH} {shlex.quote(unix_user)}"
@@ -897,10 +1117,10 @@ def lock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22) 
         client.close()
 
 
-def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22) -> None:
+def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22, *, key_path: str) -> None:
     """Run sam-unlock-user on the remote host to unlock a Unix user account."""
     import shlex
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         _, err, rc = _run(
             client, f"sudo {SAM_UNLOCK_USER_PATH} {shlex.quote(unix_user)}"
@@ -911,9 +1131,9 @@ def unlock_user_on_server(hostname: str, unix_user: str, ip: str, port: int = 22
         client.close()
 
 
-def grant_group_on_server(hostname: str, unix_user: str, group: str, ip: str, port: int = 22) -> list[str]:
+def grant_group_on_server(hostname: str, unix_user: str, group: str, ip: str, port: int = 22, *, key_path: str) -> list[str]:
     """Run sam-grant-group on the remote host. Returns actual groups of unix_user after change."""
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         out, err, rc = _run(
             client,
@@ -926,12 +1146,12 @@ def grant_group_on_server(hostname: str, unix_user: str, group: str, ip: str, po
         client.close()
 
 
-def revoke_group_on_server(hostname: str, unix_user: str, group: str | None, ip: str, port: int = 22) -> list[str]:
+def revoke_group_on_server(hostname: str, unix_user: str, group: str | None, ip: str, port: int = 22, *, key_path: str) -> list[str]:
     """Run sam-revoke-group on the remote host. group=None strips all sam-* groups. Returns actual groups."""
     cmd = f"sudo {SAM_REVOKE_GROUP_PATH} {shlex.quote(unix_user)}"
     if group:
         cmd += f" {shlex.quote(group)}"
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         out, err, rc = _run(client, cmd)
         if rc != 0:
@@ -1001,7 +1221,7 @@ def _is_valid_ip(s: str) -> bool:
         return False
 
 
-def audit_sshd_config(hostname: str, ip: str, port: int = 22) -> dict[str, str]:
+def audit_sshd_config(hostname: str, ip: str, port: int = 22, *, key_path: str) -> dict[str, str]:
     """Run `sudo sshd -T` on the remote host and return the parsed config.
 
     Each line of sshd -T output is `<directive_lower> <value...>`. Returns
@@ -1011,7 +1231,7 @@ def audit_sshd_config(hostname: str, ip: str, port: int = 22) -> dict[str, str]:
     Raises SSHSudoError if sudo sshd -T exits non-zero, SSHScriptError on parse
     failure.
     """
-    client = _connect(ip, port)
+    client = _connect(ip, port, key_path=key_path)
     try:
         stdout, stderr, exit_code = _run(client, "sudo sshd -T")
         if exit_code != 0:
@@ -1034,12 +1254,12 @@ def audit_sshd_config(hostname: str, ip: str, port: int = 22) -> dict[str, str]:
         client.close()
 
 
-def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int = 22) -> None:
+def collect_sessions_on_server(hostname: str, server_id: str, ip: str, port: int = 22, *, key_path: str) -> None:
     """Collect SSH sessions via sam-sessions and upsert into ssh_sessions table."""
     import socket
     from datetime import datetime, timezone
     try:
-        client = _connect(ip, port)
+        client = _connect(ip, port, key_path=key_path)
     except paramiko.AuthenticationException:
         raise SSHAuthError("Authentication failed - check collector key authorization")
     except paramiko.SSHException as exc:
@@ -1150,40 +1370,26 @@ def _fetch_host_key(ip: str, port: int, known_hosts_path: str | None = None) -> 
         fh.write(f"{host} {key.get_name()} {key.get_base64()}\n")
 
 
-def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 22) -> None:
+def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 22, pubkey: str = None) -> None:
     """Connect and provision the server.
 
+    pubkey: the per-server public key content to deploy (required in per-server key mode).
     If ssh_password is empty, verify that the collector key already works (server was
     provisioned manually via ssh-copy-id or provision-host.sh). Otherwise connect with
     password auth and run the provision script.
     """
     import socket
 
+    if pubkey is None:
+        raise ValueError("pubkey parameter is required (per-server collector key)")
+
     # Step 1 - fetch host key via single Paramiko Transport (1 TCP connection, no preauth events)
     _fetch_host_key(ip, ssh_port)
 
     if not ssh_password:
-        # Key-auth path: verify collector key works (server was provisioned manually)
-        try:
-            client = _connect(ip, ssh_port)
-            client.close()
-        except paramiko.AuthenticationException:
-            raise SSHAuthError(
-                "Key authentication failed - the collector key is not authorized on this server. "
-                "Provide an SSH password to provision it automatically."
-            )
-        except socket.timeout:
-            raise SSHTimeoutError("Connection timed out - server did not respond within 15 seconds")
-        except Exception as exc:
-            msg = str(exc)
-            if any(k in msg for k in ("No route to host", "Network unreachable", "No address associated")):
-                raise SSHUnreachableError("Server unreachable - check the IP and network connectivity")
-            if "Connection refused" in msg:
-                raise SSHPortRefusedError(
-                    f"SSH port {ssh_port} refused - check that SSH is running on that port"
-                )
-            raise SSHError(f"Connection failed: {exc}")
-        return
+        raise SSHAuthError(
+            "Password is required for provisioning. Use activate_server() for manual provision verification."
+        )
 
     # Step 2 - connect with password auth
     client = paramiko.SSHClient()
@@ -1215,11 +1421,9 @@ def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 
         raise SSHError(f"Connection failed: {exc}")
 
     try:
-        # Step 3 - read provision script and collector public key
+        # Step 3 - read provision script
         with open("/app/provision-host.sh", "rb") as fh:
             script = fh.read()
-        with open(f"{COLLECTOR_KEY}.pub") as fh:
-            collector_pubkey = fh.read().strip()
 
         # Step 4 - upload provision script via SFTP
         sftp = client.open_sftp()
@@ -1230,7 +1434,7 @@ def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 
         # Step 5 - execute via sudo -S (password on stdin)
         cmd = (
             f"sudo -S bash /tmp/sam-provision.sh "
-            f"{shlex.quote(collector_pubkey)} {shlex.quote(SSH_USER)}"
+            f"{shlex.quote(pubkey)} {shlex.quote(SSH_USER)}"
         )
         stdin, stdout, stderr = client.exec_command(cmd, timeout=60)
         stdin.write(ssh_password + "\n")

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -105,3 +105,21 @@ def sample_key():
         "first_seen": datetime.now(tz=timezone.utc),
         "last_seen": datetime.now(tz=timezone.utc),
     }
+
+
+# ---------------------------------------------------------------------------
+# Fixture: mock ssh._resolve_key_path to return a fake per-server key path
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def mock_key_path(tmp_path):
+    """Mock ssh._resolve_key_path to return a fake per-server key path.
+
+    This fixture ensures all tests that call SSH functions work with the new
+    per-server key architecture where key_path is a required parameter.
+    """
+    fake_key = tmp_path / "fake-server.key"
+    fake_key.write_text("fake ed25519 private key content\n")
+
+    with patch("ssh._resolve_key_path") as mock_resolve:
+        mock_resolve.return_value = str(fake_key)
+        yield str(fake_key)

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -2,7 +2,7 @@ import os
 import sys
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call, ANY
 
 import pytest
 
@@ -64,7 +64,7 @@ def test_actions_revoke_key_scenario1_calls_sam_revoke(sample_key):
         actions.revoke_key(sample_key["fingerprint"], ADMIN_ID, "test reason")
         mock_ssh.revoke_on_server.assert_called_once_with(
             "server-test-01", sample_key["fingerprint"], ip="192.168.1.10", port=22
-        )
+        , key_path=ANY)
 
 
 def test_actions_revoke_key_scenario1_sets_revoked_by_admin(sample_key):
@@ -108,7 +108,7 @@ def test_actions_revoke_key_scoped_calls_sam_revoke_with_unix_user(sample_key):
         mock_ssh.revoke_on_server.assert_called_once_with(
             "server-test-01", sample_key["fingerprint"],
             ip="192.168.1.10", unix_user="alice", port=22,
-        )
+         key_path=ANY)
 
 
 def test_actions_revoke_key_scoped_sets_revoked_for_unix_user_only(sample_key):
@@ -494,12 +494,12 @@ def test_actions_revoke_request_calls_sam_revoke():
         mock_db.query_one.side_effect = [
             req,
             {"fingerprint": "SHA256:abc"},
-            {"hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22},
+            {"id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22},
         ]
         actions.revoke_request(REQUEST_ID, ADMIN_ID)
         mock_ssh.revoke_on_server.assert_called_once_with(
             "server-test-01", "SHA256:abc", ip="192.168.1.10", port=22
-        )
+        , key_path=ANY)
 
 
 # ---------------------------------------------------------------------------
@@ -507,7 +507,9 @@ def test_actions_revoke_request_calls_sam_revoke():
 # ---------------------------------------------------------------------------
 
 def test_actions_add_server_logs_server_added(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         actions.add_server("new-host", "10.0.0.1", "root", "pass123", "lab", "rhel", 22, ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
@@ -519,6 +521,8 @@ def test_actions_add_server_provisions_before_insert(sample_server):
     call_order = []
     with patch("actions.db") as mock_db, \
          patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKey")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         mock_ssh.provision_server.side_effect = lambda *a, **kw: call_order.append("ssh")
         def track_execute(*args, **kwargs):
@@ -534,6 +538,7 @@ def test_actions_add_server_ssh_failure_no_db_write(sample_server):
     """If SSH provisioning fails, nothing is written to DB."""
     with patch("actions.db") as mock_db, \
          patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAA")
         mock_db.query_one.return_value = None
         mock_ssh.provision_server.side_effect = RuntimeError("Auth failed")
         with pytest.raises(RuntimeError, match="Auth failed"):
@@ -544,7 +549,9 @@ def test_actions_add_server_ssh_failure_no_db_write(sample_server):
 def test_actions_add_server_logs_provisioned(sample_server):
     """SERVER_PROVISIONED audit entry must be created after success."""
     with patch("actions.db") as mock_db, \
-         patch("actions.ssh"):
+         patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAA")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         actions.add_server("new-host", "10.0.0.1", "root", "pass", "lab", None, 22, ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
@@ -555,7 +562,9 @@ def test_actions_add_server_password_not_in_db(sample_server):
     """Password must never appear in any DB call."""
     secret = "SuperSecret123!"
     with patch("actions.db") as mock_db, \
-         patch("actions.ssh"):
+         patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAA")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         actions.add_server("new-host", "10.0.0.1", "root", secret, "lab", None, 22, ADMIN_ID)
         for call_args in mock_db.execute.call_args_list:
@@ -568,20 +577,24 @@ def test_actions_add_server_password_not_in_db(sample_server):
 def test_actions_add_server_env_optional(sample_server):
     """Environment can be None."""
     with patch("actions.db") as mock_db, \
-         patch("actions.ssh"):
+         patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAA")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         actions.add_server("new-host", "10.0.0.1", "root", "pass", None, None, 22, ADMIN_ID)
         insert_call = mock_db.execute.call_args_list[0]
         assert None in insert_call[0][1]
 
 
-def test_actions_add_server_no_password_calls_provision_with_empty(sample_server):
-    """add_server with empty password passes empty string to provision_server (key-auth path)."""
+def test_actions_add_server_no_password_calls_provision_with_pubkey(sample_server):
+    """add_server with empty password passes per-server pubkey to provision_server (key-auth path)."""
     with patch("actions.db") as mock_db, \
          patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAA")
+        mock_ssh._compute_pubkey_fingerprint.return_value = "SHA256:abc"
         mock_db.query_one.side_effect = [None, {"id": SERVER_ID}]
         actions.add_server("new-host", "10.0.0.1", "root", "", "lab", None, 22, ADMIN_ID)
-        mock_ssh.provision_server.assert_called_once_with("10.0.0.1", "root", "", 22)
+        mock_ssh.provision_server.assert_called_once_with("10.0.0.1", "root", "", 22, pubkey="ssh-ed25519 AAAA")
 
 
 def test_actions_disable_server_sets_inactive(sample_server):
@@ -604,14 +617,20 @@ def test_actions_disable_server_raises_if_not_found():
 # ---------------------------------------------------------------------------
 
 def test_actions_provision_server_calls_ssh_provision(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+    from unittest.mock import mock_open
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh, \
+         patch("os.path.isfile", return_value=True), \
+         patch("builtins.open", mock_open(read_data="ssh-ed25519 AAAA")):
         mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
         actions.provision_server("server-test-01", "root", "password123", 22, ADMIN_ID)
-        mock_ssh.provision_server.assert_called_once_with("192.168.1.10", "root", "password123", 22)
+        mock_ssh.provision_server.assert_called_once_with("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAA")
 
 
 def test_actions_provision_server_logs_provisioned(sample_server):
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    from unittest.mock import mock_open
+    with patch("actions.db") as mock_db, patch("actions.ssh"), \
+         patch("os.path.isfile", return_value=True), \
+         patch("builtins.open", mock_open(read_data="ssh-ed25519 AAAA")):
         mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
         actions.provision_server("server-test-01", "root", "password123", 22, ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
@@ -620,8 +639,11 @@ def test_actions_provision_server_logs_provisioned(sample_server):
 
 def test_actions_provision_server_password_not_logged(sample_server):
     """Password must never appear in audit_log."""
+    from unittest.mock import mock_open
     secret_password = "SuperSecret123!"
-    with patch("actions.db") as mock_db, patch("actions.ssh"):
+    with patch("actions.db") as mock_db, patch("actions.ssh"), \
+         patch("os.path.isfile", return_value=True), \
+         patch("builtins.open", mock_open(read_data="ssh-ed25519 AAAA")):
         mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10"}
         actions.provision_server("server-test-01", "root", secret_password, 22, ADMIN_ID)
 
@@ -1051,8 +1073,8 @@ def test_actions_lock_user_success():
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
         result = actions.lock_user("alice", "server-test-01", ADMIN_ID)
-        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22)
-        mock_ssh.lock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22)
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22, key_path=ANY)
+        mock_ssh.lock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22, key_path=ANY)
         assert result["unix_user"] == "alice"
         assert result["hostname"] == "server-test-01"
         assert result["status"] == "locked"
@@ -1076,8 +1098,8 @@ def test_actions_unlock_user_success():
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {"id": SERVER_ID, "ip_address": "192.168.1.10", "ssh_port": 22}
         result = actions.unlock_user("alice", "server-test-01", ADMIN_ID)
-        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22)
-        mock_ssh.unlock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22)
+        mock_ssh.ensure_scripts.assert_called_once_with("server-test-01", SERVER_ID, "192.168.1.10", port=22, key_path=ANY)
+        mock_ssh.unlock_user_on_server.assert_called_once_with("server-test-01", "alice", "192.168.1.10", port=22, key_path=ANY)
         assert result["unix_user"] == "alice"
         assert result["hostname"] == "server-test-01"
         assert result["status"] == "unlocked"
@@ -1092,6 +1114,7 @@ def test_actions_unlock_user_invalid_username():
 
 def test_actions_lock_user_ssh_user_raises():
     with patch("actions.ssh") as mock_ssh:
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
         mock_ssh.SSH_USER = "audit-collector"
         with pytest.raises(UserError, match="Cannot lock the collector account"):
             actions.lock_user("audit-collector", "server-test-01", ADMIN_ID)
@@ -1277,7 +1300,8 @@ def test_actions_update_server_blank_environment_is_stored_as_null():
         mock_db.query_one.side_effect = [server, None]
         actions.update_server("server-test-01", "192.168.1.10", "   ", "debian", 22, ADMIN_ID, 4)
         update_call = mock_db.execute.call_args_list[0]
-        assert update_call[0][1][1] is None
+        # New params order: (hostname, ip, env, os, port, max_sessions, server_id)
+        assert update_call[0][1][2] is None
 
 
 def test_actions_update_server_ip_change_calls_keyscan():
@@ -1639,7 +1663,7 @@ def test_actions_deploy_key_with_sam_group_passes_group_to_add_key(sample_server
         mock_ssh.add_key_on_server.assert_called_once_with(
             sample_server["hostname"], "alice", sample_key["public_key"],
             sample_server["ip_address"], port=22, sam_group="sam-operator",
-        )
+         key_path=ANY)
         mock_ssh.grant_group_on_server.assert_not_called()
 
 
@@ -1663,6 +1687,8 @@ def test_actions_deploy_key_invalid_sam_group_raises(sample_server, sample_key):
 def test_actions_deploy_key_justification_stored_in_audit_log(sample_server, sample_key):
     """deploy_key must include justification in the KEY_ADDED audit_log details."""
     with patch("actions.db") as mock_db, patch("actions.ssh"):
+        mock_ssh = patch("actions.ssh").__enter__()
+        mock_ssh._generate_keypair.return_value = ("/tmp/fake.key", "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
         mock_db.query_one.side_effect = [
             {"id": sample_server["id"], "ip_address": sample_server["ip_address"], "ssh_port": 22},
             {"id": sample_key["id"]},
@@ -1860,6 +1886,7 @@ def test_audit_server_sshd_server_not_found_raises_userrror():
 def test_audit_server_sshd_disabled_server_raises_userrror():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = {
+            "id": SERVER_ID,
             "ip_address": "192.168.1.1",
             "ssh_port": 22,
             "is_active": False,
@@ -1872,6 +1899,7 @@ def test_audit_server_sshd_ssh_failure_raises_userrror():
     import ssh as ssh_mod
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {
+            "id": SERVER_ID,
             "ip_address": "192.168.1.1",
             "ssh_port": 22,
             "is_active": True,
@@ -1886,6 +1914,7 @@ def test_audit_server_sshd_happy_path():
     """audit_server_sshd returns check_sshd_compliance result."""
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
         mock_db.query_one.return_value = {
+            "id": SERVER_ID,
             "ip_address": "192.168.1.1",
             "ssh_port": 22,
             "is_active": True,
@@ -1932,7 +1961,7 @@ def test_actions_grant_group_success(sample_server):
         mock_ssh.grant_group_on_server.assert_called_once_with(
             sample_server["hostname"], "alice", "sam-operator",
             sample_server["ip_address"], port=22,
-        )
+         key_path=ANY)
 
 
 def test_actions_grant_group_root_raises():
@@ -2007,7 +2036,7 @@ def test_actions_revoke_group_success(sample_server):
         mock_ssh.revoke_group_on_server.assert_called_once_with(
             sample_server["hostname"], "alice", "sam-operator",
             sample_server["ip_address"], port=22,
-        )
+         key_path=ANY)
 
 
 def test_actions_revoke_group_root_raises():
@@ -2070,7 +2099,7 @@ def test_actions_revoke_group_no_group_in_db_still_strips_server(sample_server):
         mock_ssh.revoke_group_on_server.assert_called_once_with(
             sample_server["hostname"], "alice", None,
             sample_server["ip_address"], port=22,
-        )
+         key_path=ANY)
 
 
 # ---------------------------------------------------------------------------

--- a/app/tests/test_collect.py
+++ b/app/tests/test_collect.py
@@ -423,6 +423,39 @@ def test_collect_scan_server_scan_failed_sends_critical_alert():
         assert mock_alerts.send_alert.call_args[0][0] == "CRITICAL"
 
 
+def test_collect_scan_server_missing_per_server_key_logs_scan_failed():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db:
+        mock_ssh._resolve_key_path.side_effect = KeyError(
+            f"no per-server collector key for server {SERVER_ID}; please re-provision"
+        )
+
+        result = collect.scan_server(SAMPLE_SERVER)
+
+        assert "no per-server collector key" in result["error"]
+        audit_sql = mock_db.execute.call_args_list[0][0][0]
+        assert "SCAN_FAILED" in audit_sql
+        mock_ssh.ensure_scripts.assert_not_called()
+        mock_ssh.collect_keys.assert_not_called()
+
+
+def test_collect_scan_server_passes_per_server_key_path_to_ssh():
+    with patch("collect.ssh") as mock_ssh, \
+         patch("collect.db") as mock_db, \
+         patch("collect.actions"), \
+         patch("collect.alerts"):
+        _setup_ssh_mocks(mock_ssh)
+        mock_ssh._resolve_key_path.return_value = "/data/keys/per-server/abc.key"
+        mock_ssh.collect_keys.return_value = []
+        mock_db.query.return_value = []
+
+        collect.scan_server(SAMPLE_SERVER)
+
+        mock_ssh._resolve_key_path.assert_called_once_with(SERVER_ID)
+        kwargs = mock_ssh.collect_keys.call_args.kwargs
+        assert kwargs["key_path"] == "/data/keys/per-server/abc.key"
+
+
 # ---------------------------------------------------------------------------
 # Tests run_scan()
 # ---------------------------------------------------------------------------
@@ -568,10 +601,10 @@ def test_collect_scan_server_updates_key_size_bits_on_rescan():
 
         collect.scan_server(SAMPLE_SERVER)
 
-        # First execute call must update key_size_bits
-        update_call = mock_db.execute.call_args_list[0]
-        assert "key_size_bits" in update_call[0][0]
-        assert 2048 in update_call[0][1]
+        # An execute call must update key_size_bits with the new size
+        update_calls = [c for c in mock_db.execute.call_args_list if "key_size_bits" in c[0][0]]
+        assert update_calls, "expected an UPDATE with key_size_bits"
+        assert 2048 in update_calls[0][0][1]
 
 
 # ---------------------------------------------------------------------------
@@ -691,7 +724,10 @@ def test_collect_triggers_provision_update_when_version_differs():
 
         collect.scan_server(SAMPLE_SERVER)
 
-        mock_ssh.apply_provision_update.assert_called_once_with("server-test-01", "192.168.1.10", 22)
+        mock_ssh.apply_provision_update.assert_called_once()
+        args, kwargs = mock_ssh.apply_provision_update.call_args
+        assert args[:3] == ("server-test-01", "192.168.1.10", 22)
+        assert "key_path" in kwargs
         # Check UPDATE servers was called
         update_calls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("provision_version" in sql and "provision_drift = FALSE" in sql for sql in update_calls)

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -117,7 +117,12 @@ def test_expire_expire_keys_scenario4_calls_sam_revoke():
          patch("expire.alerts"):
         mock_db.query.return_value = [row]
         expire.expire_keys()
-        mock_ssh.revoke_on_server.assert_called_once_with(HOSTNAME, FINGERPRINT, ip="192.168.1.10", port=22)
+        mock_ssh.revoke_on_server.assert_called_once()
+        args, kwargs = mock_ssh.revoke_on_server.call_args
+        assert args == (HOSTNAME, FINGERPRINT)
+        assert kwargs["ip"] == "192.168.1.10"
+        assert kwargs["port"] == 22
+        assert "key_path" in kwargs
 
 
 def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -53,7 +53,7 @@ def test_ssh_connect_uses_reject_policy():
         mock_cls.return_value = client_instance
         client_instance.connect.side_effect = Exception("stop")
         try:
-            ssh._connect("host")
+            ssh._connect("host", key_path="/tmp/fake.key")
         except Exception:
             pass
         client_instance.set_missing_host_key_policy.assert_called_once_with(
@@ -67,7 +67,7 @@ def test_ssh_connect_never_uses_auto_add_policy():
         mock_cls.return_value = client_instance
         client_instance.connect.side_effect = Exception("stop")
         try:
-            ssh._connect("host")
+            ssh._connect("host", key_path="/tmp/fake.key")
         except Exception:
             pass
         for c in client_instance.set_missing_host_key_policy.call_args_list:
@@ -98,7 +98,7 @@ def test_ssh_ensure_scripts_deploys_when_hash_differs(sample_server):
 
         client.exec_command.return_value = (MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b"")))
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         assert sftp.putfo.called
         assert mock_db.execute.called
@@ -140,7 +140,7 @@ def test_ssh_ensure_scripts_skips_when_hash_identical(sample_server):
 
         client.exec_command.side_effect = exec_side_effect
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         sftp.putfo.assert_not_called()
         mock_db.execute.assert_not_called()
@@ -162,7 +162,7 @@ def test_ssh_revoke_on_server_calls_sam_revoke_with_fingerprint(sample_key):
         stderr.read.return_value = b""
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
-        ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10")
+        ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10", key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-revoke" in cmd
@@ -180,7 +180,7 @@ def test_ssh_revoke_on_server_with_unix_user_passes_second_arg(sample_key):
         stderr.read.return_value = b""
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
-        ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10", unix_user="alice")
+        ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10", unix_user="alice", key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-revoke" in cmd
@@ -201,7 +201,7 @@ def test_ssh_revoke_on_server_raises_on_nonzero_exit(sample_key):
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
         with pytest.raises(ssh.SSHError):
-            ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10")
+            ssh.revoke_on_server("server-test-01", sample_key["fingerprint"], ip="192.168.1.10", key_path="/tmp/fake.key")
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +258,7 @@ def test_ssh_ensure_scripts_staging_not_in_tmp(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         staged_path = sftp.putfo.call_args[0][1]
         assert not staged_path.startswith("/tmp"), "Staging must not use /tmp (world-writable)"
@@ -280,7 +280,7 @@ def test_ssh_ensure_scripts_install_uses_exact_destination(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         commands = [c[0][0] for c in client.exec_command.call_args_list]
         install_cmds = [c for c in commands if "/usr/bin/install" in c]
@@ -318,7 +318,7 @@ def test_ssh_ensure_scripts_install_uses_mode_750(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         commands = [c[0][0] for c in client.exec_command.call_args_list]
         install_cmds = [c for c in commands if "/usr/bin/install" in c]
@@ -343,7 +343,7 @@ def test_ssh_deploy_script_sets_staging_permissions(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         staged_path = sftp.putfo.call_args[0][1]
         sftp.chmod.assert_any_call(staged_path, 0o600)
@@ -364,7 +364,7 @@ def test_ssh_deploy_script_removes_staging_file_after_install(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"])
+        ssh.ensure_scripts(sample_server["hostname"], sample_server["id"], sample_server["ip_address"], key_path="/tmp/fake.key")
 
         staged_path = sftp.putfo.call_args[0][1]
         commands = [c[0][0] for c in client.exec_command.call_args_list]
@@ -420,6 +420,7 @@ def test_ssh_add_key_on_server_calls_sam_add(sample_server):
             "alice",
             "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test",
             sample_server["ip_address"],
+            key_path="/tmp/fake.key",
         )
 
         cmd = client.exec_command.call_args[0][0]
@@ -444,6 +445,7 @@ def test_ssh_add_key_on_server_raises_on_nonzero_exit(sample_server):
                 "alice",
                 "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test",
                 sample_server["ip_address"],
+                key_path="/tmp/fake.key",
             )
 
 
@@ -470,7 +472,7 @@ def test_ssh_ensure_scripts_audit_details_valid_json(sample_server):
             MagicMock(), stdout_wrong, MagicMock(read=MagicMock(return_value=b""))
         )
 
-        ssh.ensure_scripts(hostile_server["hostname"], hostile_server["id"], hostile_server["ip_address"])
+        ssh.ensure_scripts(hostile_server["hostname"], hostile_server["id"], hostile_server["ip_address"], key_path="/tmp/fake.key")
 
         assert mock_db.execute.called
         details_arg = mock_db.execute.call_args[0][1][2]
@@ -509,7 +511,7 @@ def test_ssh_lock_user_on_server_calls_sam_lock_user(sample_server):
         stderr.read.return_value = b""
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
-        ssh.lock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"])
+        ssh.lock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"], key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-lock-user" in cmd
@@ -527,7 +529,7 @@ def test_ssh_unlock_user_on_server_calls_sam_unlock_user(sample_server):
         stderr.read.return_value = b""
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
-        ssh.unlock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"])
+        ssh.unlock_user_on_server(sample_server["hostname"], "alice", sample_server["ip_address"], key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-unlock-user" in cmd
@@ -673,7 +675,7 @@ ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com
     mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
 
     with patch("ssh._connect", return_value=mock_client):
-        result = ssh.audit_sshd_config("server1", "192.168.1.1")
+        result = ssh.audit_sshd_config("server1", "192.168.1.1", key_path="/tmp/fake.key")
         assert "port" in result
         assert result["port"] == "22"
         assert result["permitrootlogin"] == "no"
@@ -696,7 +698,7 @@ def test_ssh_audit_sshd_config_raises_sudo_error_on_nonzero():
 
     with patch("ssh._connect", return_value=mock_client):
         with pytest.raises(ssh.SSHSudoError, match="sshd -T failed"):
-            ssh.audit_sshd_config("server1", "192.168.1.1")
+            ssh.audit_sshd_config("server1", "192.168.1.1", key_path="/tmp/fake.key")
 
 
 def test_ssh_audit_sshd_config_raises_script_error_on_empty():
@@ -712,7 +714,7 @@ def test_ssh_audit_sshd_config_raises_script_error_on_empty():
 
     with patch("ssh._connect", return_value=mock_client):
         with pytest.raises(ssh.SSHScriptError, match="no parseable output"):
-            ssh.audit_sshd_config("server1", "192.168.1.1")
+            ssh.audit_sshd_config("server1", "192.168.1.1", key_path="/tmp/fake.key")
 
 
 def test_ssh_audit_sshd_config_uses_reject_policy():
@@ -724,7 +726,7 @@ def test_ssh_audit_sshd_config_uses_reject_policy():
         mock_cls.return_value = client_instance
         client_instance.connect.side_effect = Exception("stop")
         try:
-            ssh._connect("host")
+            ssh._connect("host", key_path="/tmp/fake.key")
         except Exception:
             pass
         client_instance.set_missing_host_key_policy.assert_called_once_with(
@@ -747,7 +749,7 @@ def test_ssh_collect_sessions_calls_sam_sessions(mock_ssh_client):
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1", key_path="/tmp/fake.key")
         assert mock_db.execute.called
 
 
@@ -766,7 +768,7 @@ def test_ssh_collect_sessions_marks_inactive_before_reinserting(mock_ssh_client)
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1", key_path="/tmp/fake.key")
 
         first_call = mock_db.execute.call_args_list[0]
         first_sql = first_call[0][0]
@@ -791,7 +793,7 @@ def test_ssh_collect_sessions_utmpdump_history(mock_ssh_client):
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1", key_path="/tmp/fake.key")
         insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
         assert insert_calls
         params = insert_calls[0][0][1]
@@ -817,7 +819,7 @@ def test_ssh_collect_sessions_local_tty_no_ip(mock_ssh_client):
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1", key_path="/tmp/fake.key")
         insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
         if insert_calls:
             params = insert_calls[0][0][1]
@@ -840,7 +842,7 @@ def test_ssh_collect_sessions_fallback_still_logged_in(mock_ssh_client):
 
     with patch("ssh._connect", return_value=mock_client), \
          patch("ssh.db") as mock_db:
-        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1")
+        ssh.collect_sessions_on_server("server1", "server-uuid-1", "192.168.1.1", key_path="/tmp/fake.key")
         insert_calls = [c for c in mock_db.execute.call_args_list if "INSERT" in c[0][0]]
         if insert_calls:
             params = insert_calls[0][0][1]
@@ -992,7 +994,7 @@ def test_ssh_provision_server_success():
         mock_sftp = MagicMock()
         mock_client.open_sftp.return_value = mock_sftp
 
-        ssh.provision_server("192.168.1.10", "root", "password123", 22)
+        ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
         mock_client.set_missing_host_key_policy.assert_called_once()
         mock_client.connect.assert_called_once()
@@ -1014,7 +1016,7 @@ def test_ssh_provision_server_uses_paramiko_for_host_key():
         mock_client.connect.side_effect = Exception("stop early")
 
         try:
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
         except Exception:
             pass
 
@@ -1035,7 +1037,7 @@ def test_ssh_provision_server_auth_failed():
         mock_client.connect.side_effect = paramiko.AuthenticationException("Auth failed")
 
         with pytest.raises(ssh.SSHAuthError, match="Authentication failed"):
-            ssh.provision_server("192.168.1.10", "root", "wrongpass", 22)
+            ssh.provision_server("192.168.1.10", "root", "wrongpass", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_timeout():
@@ -1052,7 +1054,7 @@ def test_ssh_provision_server_timeout():
         mock_client.connect.side_effect = socket.timeout("Timeout")
 
         with pytest.raises(ssh.SSHTimeoutError, match="timed out"):
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_no_route():
@@ -1068,7 +1070,7 @@ def test_ssh_provision_server_no_route():
         mock_client.connect.side_effect = Exception("No route to host")
 
         with pytest.raises(ssh.SSHUnreachableError, match="unreachable"):
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_refused():
@@ -1084,7 +1086,7 @@ def test_ssh_provision_server_refused():
         mock_client.connect.side_effect = Exception("Connection refused")
 
         with pytest.raises(ssh.SSHPortRefusedError, match="refused"):
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_keyscan_unreachable():
@@ -1093,7 +1095,7 @@ def test_ssh_provision_server_keyscan_unreachable():
 
     with patch("ssh._fetch_host_key", side_effect=ssh.SSHUnreachableError("Server unreachable")):
         with pytest.raises(ssh.SSHUnreachableError, match="unreachable"):
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_script_failed():
@@ -1125,7 +1127,7 @@ def test_ssh_provision_server_script_failed():
         mock_client.open_sftp.return_value = mock_sftp
 
         with pytest.raises(ssh.SSHSudoError, match="sudo privileges"):
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
 
 
 def test_ssh_provision_server_uses_reject_policy():
@@ -1141,53 +1143,15 @@ def test_ssh_provision_server_uses_reject_policy():
         mock_client.connect.side_effect = Exception("stop early")
 
         try:
-            ssh.provision_server("192.168.1.10", "root", "password123", 22)
+            ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
         except Exception:
             pass
 
         mock_client.set_missing_host_key_policy.assert_called_once_with(mock_policy.return_value)
 
 
-def test_ssh_provision_server_no_password_uses_collector_key():
-    """provision_server with empty password connects via collector key (no provision script)."""
-    from unittest.mock import MagicMock, patch
-
-    with patch("ssh._fetch_host_key"), \
-         patch("ssh._connect") as mock_connect:
-        mock_client = MagicMock()
-        mock_connect.return_value = mock_client
-
-        ssh.provision_server("192.168.1.10", "root", "", 22)
-
-        mock_connect.assert_called_once_with("192.168.1.10", 22)
-        mock_client.close.assert_called_once()
-
-
-def test_ssh_provision_server_no_password_key_auth_failed():
-    """provision_server with empty password raises SSHAuthError when collector key is not authorized."""
-    from unittest.mock import patch
-    import paramiko
-
-    with patch("ssh._fetch_host_key"), \
-         patch("ssh._connect", side_effect=paramiko.AuthenticationException("no key")):
-
-        with pytest.raises(ssh.SSHAuthError, match="collector key is not authorized"):
-            ssh.provision_server("192.168.1.10", "root", "", 22)
-
-
-def test_ssh_provision_server_no_password_skips_provision_script():
-    """provision_server with empty password does not run the provision script."""
-    from unittest.mock import MagicMock, patch
-
-    with patch("ssh._fetch_host_key"), \
-         patch("ssh._connect") as mock_connect:
-        mock_client = MagicMock()
-        mock_connect.return_value = mock_client
-
-        ssh.provision_server("192.168.1.10", "root", "", 65500)
-
-        mock_connect.assert_called_once_with("192.168.1.10", 65500)
-        mock_client.exec_command.assert_not_called()
+# Note: provision_server now requires a non-empty password.
+# The "verify connectivity with existing key" workflow has been replaced by activate_server().
         mock_client.open_sftp.assert_not_called()
 
 
@@ -1229,7 +1193,7 @@ def test_ssh_grant_group_on_server_calls_sam_grant_group():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        result = ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
+        result = ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10", key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-grant-group" in cmd
@@ -1250,7 +1214,7 @@ def test_ssh_revoke_group_on_server_calls_sam_revoke_group():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        result = ssh.revoke_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
+        result = ssh.revoke_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10", key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-revoke-group" in cmd
@@ -1271,7 +1235,7 @@ def test_ssh_revoke_group_on_server_with_none_strips_all():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        result = ssh.revoke_group_on_server("web-01", "alice", None, "192.168.1.10")
+        result = ssh.revoke_group_on_server("web-01", "alice", None, "192.168.1.10", key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sam-revoke-group" in cmd
@@ -1296,7 +1260,7 @@ def test_ssh_grant_group_on_server_raises_on_failure():
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"error")))
 
         with pytest.raises(ssh.SSHError):
-            ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10")
+            ssh.grant_group_on_server("web-01", "alice", "sam-operator", "192.168.1.10", key_path="/tmp/fake.key")
 
 
 # ---------------------------------------------------------------------------
@@ -1375,7 +1339,7 @@ def test_ssh_apply_provision_update_invokes_correct_command():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        result = ssh.apply_provision_update("web-01", "192.168.1.10", 22)
+        result = ssh.apply_provision_update("web-01", "192.168.1.10", 22, key_path="/tmp/fake.key")
 
         cmd = client.exec_command.call_args[0][0]
         assert "sudo" in cmd
@@ -1399,7 +1363,7 @@ def test_ssh_apply_provision_update_raises_on_nonzero_exit():
         client.exec_command.return_value = (MagicMock(), stdout, stderr)
 
         with pytest.raises(ssh.SSHSudoError, match="sam-self-update failed.*exit 1.*visudo validation failed"):
-            ssh.apply_provision_update("web-01", "192.168.1.10", 22)
+            ssh.apply_provision_update("web-01", "192.168.1.10", 22, key_path="/tmp/fake.key")
 
 
 def test_ssh_apply_provision_update_returns_version():
@@ -1414,7 +1378,7 @@ def test_ssh_apply_provision_update_returns_version():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        result = ssh.apply_provision_update("web-01", "192.168.1.10", 22)
+        result = ssh.apply_provision_update("web-01", "192.168.1.10", 22, key_path="/tmp/fake.key")
         assert result == ssh.PROVISION_VERSION
 
 
@@ -1431,6 +1395,6 @@ def test_ssh_apply_provision_update_uses_reject_policy():
         stdout.channel.recv_exit_status.return_value = 0
         client.exec_command.return_value = (MagicMock(), stdout, MagicMock(read=MagicMock(return_value=b"")))
 
-        ssh.apply_provision_update("web-01", "192.168.1.10", 22)
+        ssh.apply_provision_update("web-01", "192.168.1.10", 22, key_path="/tmp/fake.key")
 
         client.set_missing_host_key_policy.assert_called_once_with(mock_policy.return_value)

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -582,26 +582,46 @@ def test_web_add_server_ssh_port_not_integer(auth_client):
 def test_web_update_server_authenticated_returns_200(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
+        mock_actions.update_server.return_value = {"hostname": "server-test-01"}
         resp = auth_client.put(
             "/api/servers/server-test-01",
             json={"ip": "10.0.0.2", "environment": "production", "os_family": "debian"},
         )
         assert resp.status_code == 200
         mock_actions.update_server.assert_called_once_with(
-            "server-test-01", "10.0.0.2", "production", "debian", 22, ADMIN_ID, 2
+            "server-test-01", "10.0.0.2", "production", "debian", 22, ADMIN_ID, 2,
+            new_hostname=None,
         )
 
 
 def test_web_update_server_blank_environment_is_normalized_to_none(auth_client):
     with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
         mock_db.query_one.return_value = _admin_row()
+        mock_actions.update_server.return_value = {"hostname": "server-test-01"}
         resp = auth_client.put(
             "/api/servers/server-test-01",
             json={"ip": "10.0.0.2", "environment": "", "os_family": None},
         )
         assert resp.status_code == 200
         mock_actions.update_server.assert_called_once_with(
-            "server-test-01", "10.0.0.2", None, None, 22, ADMIN_ID, 2
+            "server-test-01", "10.0.0.2", None, None, 22, ADMIN_ID, 2,
+            new_hostname=None,
+        )
+
+
+def test_web_update_server_rename_forwards_new_hostname(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.update_server.return_value = {"hostname": "renamed"}
+        resp = auth_client.put(
+            "/api/servers/server-test-01",
+            json={"hostname": "renamed", "ip": "10.0.0.2", "environment": "lab"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["hostname"] == "renamed"
+        mock_actions.update_server.assert_called_once_with(
+            "server-test-01", "10.0.0.2", "lab", None, 22, ADMIN_ID, 2,
+            new_hostname="renamed",
         )
 
 
@@ -904,17 +924,63 @@ def test_web_system_status_smtp_disabled_zero(auth_client):
         assert resp.get_json()["smtp_enabled"] is False
 
 
-def test_web_collector_key_includes_ssh_user(auth_client, tmp_path):
-    pub_key_file = tmp_path / "collector_key.pub"
-    pub_key_file.write_text("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 test")
-    with patch("web.db") as mock_db, patch("web.ssh.SSH_USER", "custom-collector"), \
-         patch.dict("os.environ", {"COLLECTOR_KEY": str(tmp_path / "collector_key")}):
+def test_web_legacy_global_collector_key_route_removed(auth_client):
+    with patch("web.db") as mock_db:
         mock_db.query_one.return_value = _admin_row()
         resp = auth_client.get("/api/system/collector-key")
+        assert resp.status_code == 404
+
+
+def test_web_rotate_key_sysadmin_returns_200(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.rotate_collector_key.return_value = {"status": "rotated", "fingerprint": "SHA256:abc"}
+        resp = auth_client.post("/api/servers/srv-01/rotate-key")
+        assert resp.status_code == 200
+        assert resp.get_json()["fingerprint"] == "SHA256:abc"
+        mock_actions.rotate_collector_key.assert_called_once_with("srv-01", ADMIN_ID)
+
+
+def test_web_rotate_key_operator_forbidden(auth_client):
+    with patch("web.db") as mock_db:
+        row = _admin_row()
+        row["role"] = "operator"
+        mock_db.query_one.return_value = row
+        resp = auth_client.post("/api/servers/srv-01/rotate-key")
+        assert resp.status_code == 403
+
+
+def test_web_rotate_key_failure_returns_502(auth_client):
+    from actions import UserError
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.rotate_collector_key.side_effect = UserError("Rotation failed: boom", status=502)
+        resp = auth_client.post("/api/servers/srv-01/rotate-key")
+        assert resp.status_code == 502
+        assert "boom" in resp.get_json()["error"]
+
+
+def test_web_get_server_collector_key_returns_pubkey(auth_client):
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.get_collector_key_for_server.return_value = {
+            "fingerprint": "SHA256:abc",
+            "public_key": "ssh-ed25519 AAAA...",
+        }
+        resp = auth_client.get("/api/servers/srv-01/collector-key")
         assert resp.status_code == 200
         data = resp.get_json()
-        assert data["ssh_user"] == "custom-collector"
-        assert "ssh-ed25519" in data["public_key"]
+        assert data["fingerprint"] == "SHA256:abc"
+        assert data["public_key"].startswith("ssh-ed25519")
+
+
+def test_web_get_server_collector_key_404(auth_client):
+    from actions import NotFoundError
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin_row()
+        mock_actions.get_collector_key_for_server.side_effect = NotFoundError("Server not found: srv-x")
+        resp = auth_client.get("/api/servers/srv-x/collector-key")
+        assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/app/web.py
+++ b/app/web.py
@@ -340,6 +340,15 @@ def get_server(hostname):
     else:
         server["last_scan_ok"] = False
         server["last_scan_error"] = last_scan["scan_error"]
+
+    # Per-server collector key fingerprint (computed from disk, not stored in DB)
+    pubkey_path = os.path.join(ssh.PER_SERVER_KEYS_DIR, f"{server['id']}.key.pub")
+    try:
+        with open(pubkey_path, "r") as fh:
+            server["collector_fingerprint"] = ssh._compute_pubkey_fingerprint(fh.read().strip())
+    except (FileNotFoundError, OSError):
+        server["collector_fingerprint"] = None
+
     return jsonify(server)
 
 
@@ -404,11 +413,12 @@ def update_server(hostname):
     if max_sessions < 1:
         return jsonify({"error": "max_sessions must be at least 1"}), 400
     try:
-        actions.update_server(
+        updated = actions.update_server(
             hostname, data["ip"], data.get("environment") or None,
             data.get("os_family"), data.get("ssh_port", 22), g.admin_id, max_sessions,
+            new_hostname=data.get("hostname"),
         )
-        return jsonify({"message": "Server updated"})
+        return jsonify({"message": "Server updated", "hostname": updated["hostname"]})
     except KeyError:
         return jsonify({"error": "Missing required field: ip is required"}), 400
 
@@ -439,6 +449,20 @@ def scan_server(hostname):
     return jsonify(results)
 
 
+@app.route("/api/servers/<hostname>/rotate-key", methods=["POST"])
+@require_auth
+@require_role("sysadmin")
+def rotate_server_collector_key(hostname):
+    result = actions.rotate_collector_key(hostname, g.admin_id)
+    return jsonify(result)
+
+
+@app.route("/api/servers/<hostname>/collector-key", methods=["GET"])
+@require_auth
+def get_server_collector_key(hostname):
+    return jsonify(actions.get_collector_key_for_server(hostname))
+
+
 @app.route("/api/servers/<hostname>/sync", methods=["POST"])
 @require_auth
 @require_role("sysadmin")
@@ -451,7 +475,8 @@ def force_provision_sync(hostname):
     if not server:
         return jsonify({"error": "Server not found or inactive"}), 404
     try:
-        applied = ssh.apply_provision_update(hostname, str(server["ip_address"]), server.get("ssh_port", 22))
+        key_path = ssh._resolve_key_path(server["id"])
+        applied = ssh.apply_provision_update(hostname, str(server["ip_address"]), server.get("ssh_port", 22), key_path=key_path)
         db.execute(
             "UPDATE servers SET provision_version = %s, provision_drift = FALSE WHERE id = %s",
             (applied, server["id"]),
@@ -531,8 +556,12 @@ def refresh_server_sessions(hostname):
     ip = str(server["ip_address"])
     port = server.get("ssh_port") or 22
     try:
-        ssh.collect_sessions_on_server(hostname, server["id"], ip, port=port)
+        key_path = ssh._resolve_key_path(server["id"])
+        ssh.collect_sessions_on_server(hostname, server["id"], ip, port=port, key_path=key_path)
         return jsonify({"status": "refreshed"})
+    except KeyError as e:
+        logging.warning("collect_sessions_on_server: no per-server key for %s: %s", hostname.replace("\n", "").replace("\r", ""), str(e).replace("\n", " ").replace("\r", ""))
+        return jsonify({"error": "No per-server collector key — re-add this server"}), 502
     except RuntimeError as e:
         logging.warning("collect_sessions_on_server failed on %s (%s): %s", hostname.replace("\n", "").replace("\r", ""), ip, str(e).replace("\n", " ").replace("\r", ""))
         return jsonify({"error": "Session collection failed"}), 502
@@ -1177,18 +1206,6 @@ def system_status():
 def system_scan():
     results = collect_mod.run_scan(admin_id=g.admin_id)
     return jsonify(results)
-
-
-@app.route("/api/system/collector-key", methods=["GET"])
-@require_auth
-def get_collector_key():
-    keys_dir = os.path.dirname(os.environ.get("COLLECTOR_KEY", "/data/keys/collector_key"))
-    pub_path = os.path.join(keys_dir, "collector_key.pub")
-    try:
-        with open(pub_path) as f:
-            return jsonify({"public_key": f.read().strip(), "ssh_user": ssh.SSH_USER})
-    except FileNotFoundError:
-        return jsonify({"error": "Collector key not found"}), 404
 
 
 @app.route("/api/system/config", methods=["GET"])

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -153,30 +153,27 @@ if [ "${_fail}" = "1" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Collector key guard — runs on every startup, no-op if key already exists.
-# Protects against partial restores where /data/pg/ is present but /data/keys/
-# is missing: bootstrap would skip first-startup block and leave no key.
+# /data/keys/ — per-server keypairs + known_hosts (must exist and be writable
+# by nobody, since Flask + crond scans both run as nobody)
 # ---------------------------------------------------------------------------
-if [ ! -f /data/keys/collector_key ]; then
-    echo "[bootstrap] Collector key missing — generating a new ED25519 key pair."
-    mkdir -p /data/keys
-    ssh-keygen -t ed25519 \
-        -f /data/keys/collector_key \
-        -N "" \
-        -C "ssh-access-manager@$(hostname)"
-    chown nobody:nobody /data/keys/collector_key /data/keys/collector_key.pub
-    chmod 600 /data/keys/collector_key
-    touch /data/keys/known_hosts
-    chown nobody:nobody /data/keys/known_hosts
-    chmod 644 /data/keys/known_hosts
-    echo ""
-    echo "================================================================"
-    echo " COLLECTOR PUBLIC KEY — deploy on each remote host"
-    echo " via: bash provision-host.sh \"<content below>\""
-    echo "================================================================"
-    cat /data/keys/collector_key.pub
-    echo "================================================================"
-    echo ""
+mkdir -p /data/keys/per-server
+chown nobody:nobody /data/keys /data/keys/per-server
+chmod 755 /data/keys
+chmod 700 /data/keys/per-server
+
+# known_hosts must be writable by Flask (nobody) for _fetch_host_key to append
+touch /data/keys/known_hosts
+chown nobody:nobody /data/keys/known_hosts
+chmod 644 /data/keys/known_hosts
+
+# ---------------------------------------------------------------------------
+# Legacy global key cleanup — remove the old global collector_key if present
+# (upgrade path from pre-per-server-keys architecture)
+# ---------------------------------------------------------------------------
+if [ -f /data/keys/collector_key ]; then
+    echo "[bootstrap] WARNING: Legacy global collector_key found — removing it."
+    echo "            Per-server keys are now stored in /data/keys/per-server/"
+    rm -f /data/keys/collector_key /data/keys/collector_key.pub
 fi
 
 # ---------------------------------------------------------------------------
@@ -274,27 +271,34 @@ else
     _psql "ALTER TABLE servers ADD COLUMN IF NOT EXISTS max_sessions INTEGER NOT NULL DEFAULT 2;"
     _psql "ALTER TABLE servers ADD COLUMN IF NOT EXISTS provision_version VARCHAR(64);"
     _psql "ALTER TABLE servers ADD COLUMN IF NOT EXISTS provision_drift BOOLEAN NOT NULL DEFAULT FALSE;"
+    _psql "ALTER TABLE servers ADD COLUMN IF NOT EXISTS is_provisioned BOOLEAN NOT NULL DEFAULT FALSE;"
     _psql "ALTER TABLE key_authorizations ADD COLUMN IF NOT EXISTS sam_group VARCHAR(20) CHECK (sam_group IN ('sam-operator', 'sam-pkg', 'sam-root'));"
+
+    # Mark existing active servers as provisioned (they have already passed the activate step)
+    _psql "UPDATE servers SET is_provisioned = TRUE WHERE is_active = TRUE AND is_provisioned = FALSE;"
 
     # Audit log action constraint — versioned, each version is a superset of the previous
     su -s /bin/sh postgres -c "psql -h /tmp -U postgres -d ${POSTGRES_DB:-ssh_manager} -c \
         \"DO \\\$\\\$ BEGIN
-            IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'audit_log_action_check_v5') THEN
+            IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'audit_log_action_check_v7') THEN
+                ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check_v6;
+                ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check_v5;
                 ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check_v4;
                 ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check_v3;
                 ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check_v2;
                 ALTER TABLE audit_log DROP CONSTRAINT IF EXISTS audit_log_action_check;
-                ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v5 CHECK (action IN (
+                ALTER TABLE audit_log ADD CONSTRAINT audit_log_action_check_v7 CHECK (action IN (
                     'KEY_ADDED','KEY_REVOKED','KEY_EXPIRED','EXPIRY_WARNING',
                     'REQUEST_APPROVED','REQUEST_REJECTED','ANOMALY_DETECTED',
                     'SCAN_COMPLETED','SCAN_FAILED','SCRIPT_DEPLOYED',
-                    'SERVER_ADDED','SERVER_DISABLED','SERVER_UPDATED',
+                    'SERVER_ADDED','SERVER_DISABLED','SERVER_UPDATED','SERVER_RENAMED',
                     'ADMIN_ADDED','ADMIN_DISABLED','ADMIN_ENABLED','ADMIN_DELETED','ADMIN_UPDATED',
                     'USER_LOCKED','USER_UNLOCKED',
                     'LOGIN_FAILED','LOGIN_BANNED','PASSWORD_RESET',
                     'SERVER_PROVISIONED','SESSION_LIMIT_EXCEEDED',
                     'GROUP_GRANTED','GROUP_REVOKED','GROUP_CHANGED',
-                    'PROVISION_UPDATED','PROVISION_UPDATE_FAILED'
+                    'PROVISION_UPDATED','PROVISION_UPDATE_FAILED',
+                    'COLLECTOR_KEY_GENERATED','COLLECTOR_KEY_ROTATED','COLLECTOR_KEY_ROTATION_FAILED'
                 ));
             END IF;
         END \\\$\\\$;\""

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -37,6 +37,8 @@ CREATE TABLE servers (
     provision_version VARCHAR(64),
     -- TRUE if the last provision update attempt failed (rollback succeeded)
     provision_drift BOOLEAN NOT NULL DEFAULT FALSE,
+    -- TRUE if the server has been successfully activated (SSH connectivity confirmed)
+    is_provisioned BOOLEAN NOT NULL DEFAULT FALSE,
     -- Timestamp when added to the system
     added_at    TIMESTAMPTZ DEFAULT now()
 );
@@ -53,6 +55,7 @@ COMMENT ON COLUMN servers.is_active IS 'False = excluded from SSH collection sco
 COMMENT ON COLUMN servers.max_sessions IS 'Max concurrent SSH sessions threshold - WARNING alert if exceeded (24h anti-spam)';
 COMMENT ON COLUMN servers.provision_version IS 'SHA256 (or prefix) of last successful SAM_SELF_UPDATE deployment';
 COMMENT ON COLUMN servers.provision_drift IS 'TRUE if the last provision update attempt failed (remote remains functional via rollback)';
+COMMENT ON COLUMN servers.is_provisioned IS 'TRUE if activate step has succeeded (SSH connectivity confirmed with per-server key)';
 COMMENT ON COLUMN servers.added_at IS 'Record timestamp in the system';
 
 -- ---------------------------------------------------------------------------
@@ -285,7 +288,11 @@ CREATE TABLE audit_log (
                       'GROUP_REVOKED',
                       'GROUP_CHANGED',
                       'PROVISION_UPDATED',
-                      'PROVISION_UPDATE_FAILED'
+                      'PROVISION_UPDATE_FAILED',
+                      'COLLECTOR_KEY_GENERATED',
+                      'COLLECTOR_KEY_ROTATED',
+                      'COLLECTOR_KEY_ROTATION_FAILED',
+                      'SERVER_RENAMED'
                   )),
     -- Administrator who triggered the action (NULL if automatic)
     performed_by  UUID REFERENCES administrators(id) ON DELETE SET NULL,

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -39,7 +39,7 @@
       <span>{{ $t('smtp_banner.message') }}</span>
     </div>
     <main class="content">
-      <router-view />
+      <router-view :key="$route?.fullPath" />
     </main>
   </div>
 </template>
@@ -340,11 +340,17 @@ tbody tr:hover {
 }
 
 .lang-wrapper::after {
+  /* Global input rule (background: var(--input-bg) !important) wins over
+     .lang-select, so the chevron must contrast with --text-primary, not
+     --navbar-text. */
   content: '▾';
   position: absolute;
-  right: 0.25rem;
-  font-size: 0.55rem;
-  color: var(--navbar-text);
+  right: 0.4rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 0.8rem;
+  line-height: 1;
+  color: var(--text-primary);
   pointer-events: none;
 }
 
@@ -352,13 +358,17 @@ tbody tr:hover {
   appearance: none;
   -webkit-appearance: none;
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--navbar-text-inactive);
   color: var(--navbar-text);
   border-radius: 4px;
-  padding: 0.15rem 1.1rem 0.15rem 0.4rem;
+  padding: 0.15rem 1.4rem 0.15rem 0.5rem;
   font-size: 0.75rem;
   cursor: pointer;
   transition: border-color 0.2s;
+}
+
+.lang-select:hover {
+  border-color: var(--navbar-text);
 }
 
 .lang-select option {
@@ -557,6 +567,13 @@ button:disabled {
 .btn-purple:hover:not(:disabled) {
   background: #6d28d9;
 }
+.btn-teal {
+  background: #0d9488;
+  color: #fff;
+}
+.btn-teal:hover:not(:disabled) {
+  background: #0f766e;
+}
 
 .modal-header {
   display: flex;
@@ -598,7 +615,8 @@ button:disabled {
 .btn-danger,
 .btn-success,
 .btn-warning,
-.btn-purple {
+.btn-purple,
+.btn-teal {
   min-width: 6rem;
 }
 

--- a/ui/src/components/AuditTable.vue
+++ b/ui/src/components/AuditTable.vue
@@ -10,7 +10,7 @@
           <label for="f-action">{{ $t('audit.filter_action') }}</label>
           <select id="f-action" v-model="filters.action">
             <option value="">{{ $t('audit.filter_all') }}</option>
-            <option v-for="a in ACTIONS" :key="a" :value="a">{{ a }}</option>
+            <option v-for="a in sortedActions" :key="a" :value="a">{{ a }}</option>
           </select>
         </div>
         <div class="field">
@@ -123,6 +123,7 @@ const props = defineProps({
   servers: { type: Array, default: () => [] },
 })
 
+// Keep aligned with audit_log_action_check_v7 in sql/schema.sql / bootstrap.sh
 const ACTIONS = [
   'KEY_ADDED',
   'KEY_REVOKED',
@@ -136,15 +137,41 @@ const ACTIONS = [
   'SCRIPT_DEPLOYED',
   'SERVER_ADDED',
   'SERVER_DISABLED',
+  'SERVER_UPDATED',
+  'SERVER_RENAMED',
+  'SERVER_PROVISIONED',
   'ADMIN_ADDED',
   'ADMIN_DISABLED',
+  'ADMIN_ENABLED',
+  'ADMIN_DELETED',
+  'ADMIN_UPDATED',
+  'USER_LOCKED',
+  'USER_UNLOCKED',
+  'LOGIN_FAILED',
+  'LOGIN_BANNED',
+  'PASSWORD_RESET',
+  'SESSION_LIMIT_EXCEEDED',
+  'GROUP_GRANTED',
+  'GROUP_REVOKED',
+  'GROUP_CHANGED',
+  'PROVISION_UPDATED',
+  'PROVISION_UPDATE_FAILED',
+  'COLLECTOR_KEY_GENERATED',
+  'COLLECTOR_KEY_ROTATED',
+  'COLLECTOR_KEY_ROTATION_FAILED',
 ]
+
+// Alphabetically sorted clone so future additions land in the right spot
+// in the dropdown without manual reordering.
+const sortedActions = [...ACTIONS].sort()
 
 const CRITICAL_ACTIONS = new Set([
   'ANOMALY_DETECTED',
   'SCAN_FAILED',
   'KEY_REVOKED',
   'PROVISION_UPDATE_FAILED',
+  'COLLECTOR_KEY_ROTATION_FAILED',
+  'LOGIN_BANNED',
 ])
 const WARNING_ACTIONS = new Set(['EXPIRY_WARNING', 'KEY_EXPIRED'])
 

--- a/ui/src/components/EditServerModal.vue
+++ b/ui/src/components/EditServerModal.vue
@@ -8,10 +8,18 @@
       <div v-if="editError" class="alert-error">{{ editError }}</div>
 
       <div class="form-grid">
-        <!-- Hostname (readonly) + IP -->
+        <!-- Hostname + IP -->
         <div class="form-field">
-          <label>{{ $t('edit_server.hostname') }}</label>
-          <input :value="props.server?.hostname" type="text" disabled class="input-readonly" />
+          <label
+            >{{ $t('edit_server.hostname') }}
+            <span class="required">{{ $t('common.required') }}</span></label
+          >
+          <input
+            v-model="editForm.hostname"
+            type="text"
+            :placeholder="$t('edit_server.hostname_placeholder')"
+          />
+          <span v-if="editHostnameError" class="field-error">{{ editHostnameError }}</span>
         </div>
         <div class="form-field">
           <label
@@ -92,7 +100,14 @@ const emit = defineEmits(['update:modelValue', 'saved'])
 
 const { t } = useI18n()
 
-const editForm = ref({ ip: '', environment: '', os_family: '', ssh_port: 22, max_sessions: 2 })
+const editForm = ref({
+  hostname: '',
+  ip: '',
+  environment: '',
+  os_family: '',
+  ssh_port: 22,
+  max_sessions: 2,
+})
 const editing = ref(false)
 const editError = ref('')
 
@@ -101,6 +116,7 @@ watch(
   (open) => {
     if (open && props.server) {
       editForm.value = {
+        hostname: props.server.hostname || '',
         ip: props.server.ip_address || '',
         environment: props.server.environment || '',
         os_family: props.server.os_family || '',
@@ -128,6 +144,27 @@ function isIpDuplicate(ip) {
   )
 }
 
+function isValidHostname(h) {
+  if (!h || h.length > 253) return false
+  return /^[a-zA-Z0-9]([a-zA-Z0-9\-.]*[a-zA-Z0-9])?$/.test(h)
+}
+
+function isHostnameDuplicate(h) {
+  if (!props.allServers.length) return false
+  const normalized = h.trim()
+  return props.allServers.some(
+    (s) => s.hostname === normalized && s.hostname !== props.server?.hostname
+  )
+}
+
+const editHostnameError = computed(() => {
+  const h = editForm.value.hostname.trim()
+  if (!h) return t('add_server.error_invalid_hostname')
+  if (!isValidHostname(h)) return t('add_server.error_invalid_hostname')
+  if (isHostnameDuplicate(h)) return t('edit_server.error_duplicate_hostname')
+  return ''
+})
+
 const editIpError = computed(() => {
   const ip = editForm.value.ip.trim()
   if (!ip) return ''
@@ -138,7 +175,11 @@ const editIpError = computed(() => {
 
 const editFormValid = computed(
   () =>
-    editForm.value.ip.trim() && isValidIp(editForm.value.ip) && !isIpDuplicate(editForm.value.ip)
+    editForm.value.hostname.trim() &&
+    !editHostnameError.value &&
+    editForm.value.ip.trim() &&
+    isValidIp(editForm.value.ip) &&
+    !isIpDuplicate(editForm.value.ip)
 )
 
 function close() {
@@ -149,10 +190,12 @@ async function confirm() {
   editing.value = true
   editError.value = ''
   try {
+    const newHostname = editForm.value.hostname.trim()
     const res = await apiFetch(`/api/servers/${props.server.hostname}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        hostname: newHostname,
         ip: editForm.value.ip.trim(),
         environment: editForm.value.environment || null,
         os_family: editForm.value.os_family.trim() || null,
@@ -163,7 +206,7 @@ async function confirm() {
     const data = await res.json().catch(() => ({}))
     if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`)
     close()
-    emit('saved')
+    emit('saved', { hostname: data.hostname || newHostname })
   } catch (e) {
     editError.value = e.message
   } finally {

--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -33,7 +33,6 @@
     "status_scan_failed": "🟠 Scan fehlgeschlagen",
     "status_inactive": "🔴 Inaktiv",
     "status_total": "Gesamt",
-    "collector_key": "Öffentlicher Collector-Schlüssel",
     "copy": "Kopieren",
     "copied": "Kopiert!",
     "scan_success": "Scan von {hostname} gestartet.",
@@ -75,7 +74,7 @@
   },
   "edit_server": {
     "title": "Server bearbeiten",
-    "hostname": "Hostname (schreibgeschützt)",
+    "hostname": "Hostname",
     "ip": "IP-Adresse",
     "ip_placeholder": "z.B.: 192.168.1.10",
     "environment": "Umgebung",
@@ -86,7 +85,9 @@
     "max_sessions_label": "Max. Sitzungen",
     "max_sessions_hint": "Warnung wird gesendet, wenn die aktiven SSH-Sitzungen diesen Grenzwert überschreiten.",
     "submitting": "Speichern…",
-    "submit": "Speichern"
+    "submit": "Speichern",
+    "hostname_placeholder": "z.B. mein-server-01",
+    "error_duplicate_hostname": "Dieser Hostname wird bereits von einem anderen Server verwendet"
   },
   "server_table": {
     "search_placeholder": "Server suchen…",
@@ -170,7 +171,18 @@
     "bulk_revoked": "Schlüssel widerrufen: {revoked}, übersprungen: {skipped}",
     "root_revoke_warning": "Das Widerrufen des SSH-Schlüssels des Benutzers <strong>root</strong> kann zum dauerhaften Verlust des Fernzugriffs auf diesen Server führen.",
     "reprovision_needed": "Neu-Provisionierung erforderlich",
-    "reprovision_needed_tooltip": "Das automatische Update ist auf diesem Host fehlgeschlagen. Öffnen Sie die Serverdetails und klicken Sie auf Neu-Provisionieren, um die neue SAM-Konfiguration einzuspielen. Im Audit-Log finden Sie den genauen Fehler."
+    "reprovision_needed_tooltip": "Das automatische Update ist auf diesem Host fehlgeschlagen. Öffnen Sie die Serverdetails und klicken Sie auf Neu-Provisionieren, um die neue SAM-Konfiguration einzuspielen. Im Audit-Log finden Sie den genauen Fehler.",
+    "rotate_key": "Collector-Schlüssel rotieren",
+    "rotate_key_confirm_title": "Collector-Schlüssel rotieren",
+    "rotate_key_confirm_message": "Diese Operation generiert einen neuen serverspezifischen SSH-Schlüssel, stellt ihn auf dem Remote-Host bereit, überprüft die Konnektivität und entfernt dann den alten Schlüssel. Atomare Operation mit automatischem Rollback bei Fehler. Fortfahren?",
+    "rotate_key_in_progress": "Rotiere…",
+    "rotate_key_success": "Collector-Schlüssel erfolgreich rotiert. Neuer Fingerabdruck: {fingerprint}",
+    "rotate_key_failed": "Rotation fehlgeschlagen",
+    "rotate_key_retry": "Wiederholen",
+    "field_collector_fingerprint": "Fingerabdruck des Collector-Schlüssels",
+    "copy_public_key": "Öffentlichen Schlüssel kopieren",
+    "manual_provision_title": "Mit eigenen SSH-Zugangsdaten bereitstellen",
+    "manual_provision_hint": "Verwenden Sie diese Befehle, um den Server mit Ihrem eigenen SSH-Konto zu initialisieren. Ersetzen Sie 'podman' durch 'docker', falls nötig. Der Collector-Schlüssel wird vom Server abgerufen und dann über Ihre SSH-Sitzung bereitgestellt."
   },
   "key_table": {
     "col_status": "Status",

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -33,7 +33,6 @@
     "status_scan_failed": "🟠 Scan Failed",
     "status_inactive": "🔴 Inactive",
     "status_total": "Total",
-    "collector_key": "Collector public key",
     "copy": "Copy",
     "copied": "Copied!",
     "scan_success": "Scan of {hostname} launched.",
@@ -75,7 +74,7 @@
   },
   "edit_server": {
     "title": "Edit server",
-    "hostname": "Hostname (read-only)",
+    "hostname": "Hostname",
     "ip": "IP Address",
     "ip_placeholder": "e.g.: 192.168.1.10",
     "environment": "Environment",
@@ -86,7 +85,9 @@
     "max_sessions_label": "Max sessions",
     "max_sessions_hint": "Alert sent when active SSH sessions exceed this limit.",
     "submitting": "Saving…",
-    "submit": "Save"
+    "submit": "Save",
+    "hostname_placeholder": "e.g.: my-server-01",
+    "error_duplicate_hostname": "This hostname is already used by another server"
   },
   "server_table": {
     "search_placeholder": "Search for a server…",
@@ -170,7 +171,18 @@
     "bulk_revoked": "Keys revoked: {revoked}, skipped: {skipped}",
     "root_revoke_warning": "Revoking the SSH key of user <strong>root</strong> may result in permanent loss of remote access to this server.",
     "reprovision_needed": "Re-provision needed",
-    "reprovision_needed_tooltip": "Automatic update failed on this host. Open the server detail and click Re-provision to push the new SAM configuration. See the Audit view for the exact error."
+    "reprovision_needed_tooltip": "Automatic update failed on this host. Open the server detail and click Re-provision to push the new SAM configuration. See the Audit view for the exact error.",
+    "rotate_key": "Rotate collector key",
+    "rotate_key_confirm_title": "Rotate collector key",
+    "rotate_key_confirm_message": "This operation generates a new per-server SSH key, deploys it on the remote host, verifies connectivity, then removes the old key. Atomic operation with automatic rollback on failure. Continue?",
+    "rotate_key_in_progress": "Rotating…",
+    "rotate_key_success": "Collector key rotated successfully. New fingerprint: {fingerprint}",
+    "rotate_key_failed": "Rotation failed",
+    "rotate_key_retry": "Retry",
+    "field_collector_fingerprint": "Collector key fingerprint",
+    "copy_public_key": "Copy public key",
+    "manual_provision_title": "Provision with your own SSH credentials",
+    "manual_provision_hint": "Use these commands to bootstrap the server with your own SSH account. Replace 'podman' with 'docker' if needed. The collector key is fetched from the server, then deployed via your SSH session."
   },
   "key_table": {
     "col_status": "Status",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -33,7 +33,6 @@
     "status_scan_failed": "🟠 Escaneo fallido",
     "status_inactive": "🔴 Inactivo",
     "status_total": "Total",
-    "collector_key": "Clave pública del colector",
     "copy": "Copiar",
     "copied": "¡Copiado!",
     "scan_success": "Escaneo de {hostname} iniciado.",
@@ -75,7 +74,7 @@
   },
   "edit_server": {
     "title": "Editar servidor",
-    "hostname": "Hostname (solo lectura)",
+    "hostname": "Hostname",
     "ip": "Dirección IP",
     "ip_placeholder": "ej: 192.168.1.10",
     "environment": "Entorno",
@@ -86,7 +85,9 @@
     "max_sessions_label": "Sesiones máx.",
     "max_sessions_hint": "Se envía una alerta si las sesiones SSH activas superan este límite.",
     "submitting": "Guardando…",
-    "submit": "Guardar"
+    "submit": "Guardar",
+    "hostname_placeholder": "ej.: mi-servidor-01",
+    "error_duplicate_hostname": "Este hostname ya está en uso por otro servidor"
   },
   "server_table": {
     "search_placeholder": "Buscar un servidor…",
@@ -170,7 +171,18 @@
     "bulk_revoked": "Claves revocadas: {revoked}, omitidas: {skipped}",
     "root_revoke_warning": "Revocar la clave SSH del usuario <strong>root</strong> puede resultar en la pérdida permanente del acceso remoto a este servidor.",
     "reprovision_needed": "Reaprovisionamiento necesario",
-    "reprovision_needed_tooltip": "La actualización automática falló en este host. Abra el detalle del servidor y haga clic en Reaprovisionar para enviar la nueva configuración SAM. Consulte la vista Auditoría para ver el error exacto."
+    "reprovision_needed_tooltip": "La actualización automática falló en este host. Abra el detalle del servidor y haga clic en Reaprovisionar para enviar la nueva configuración SAM. Consulte la vista Auditoría para ver el error exacto.",
+    "rotate_key": "Rotar clave del colector",
+    "rotate_key_confirm_title": "Rotar clave del colector",
+    "rotate_key_confirm_message": "Esta operación genera una nueva clave SSH por servidor, la despliega en el host remoto, verifica la conectividad y luego elimina la clave antigua. Operación atómica con rollback automático en caso de fallo. ¿Continuar?",
+    "rotate_key_in_progress": "Rotando…",
+    "rotate_key_success": "Clave del colector rotada correctamente. Nueva huella: {fingerprint}",
+    "rotate_key_failed": "La rotación falló",
+    "rotate_key_retry": "Reintentar",
+    "field_collector_fingerprint": "Huella de la clave del colector",
+    "copy_public_key": "Copiar clave pública",
+    "manual_provision_title": "Aprovisionar con sus propias credenciales SSH",
+    "manual_provision_hint": "Use estos comandos para inicializar el servidor con su propia cuenta SSH. Reemplace 'podman' por 'docker' si es necesario. La clave del colector se obtiene del servidor y luego se despliega a través de su sesión SSH."
   },
   "key_table": {
     "col_status": "Estado",

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -33,7 +33,6 @@
     "status_scan_failed": "🟠 Scan échoué",
     "status_inactive": "🔴 Inactif",
     "status_total": "Total",
-    "collector_key": "Clé publique collecteur",
     "copy": "Copier",
     "copied": "Copié !",
     "scan_success": "Scan de {hostname} lancé.",
@@ -75,7 +74,7 @@
   },
   "edit_server": {
     "title": "Éditer le serveur",
-    "hostname": "Hostname (lecture seule)",
+    "hostname": "Hostname",
     "ip": "Adresse IP",
     "ip_placeholder": "ex: 192.168.1.10",
     "environment": "Environnement",
@@ -86,7 +85,9 @@
     "max_sessions_label": "Sessions max",
     "max_sessions_hint": "Alerte envoyée si le nombre de sessions SSH actives dépasse ce seuil.",
     "submitting": "Sauvegarde…",
-    "submit": "Sauvegarder"
+    "submit": "Sauvegarder",
+    "hostname_placeholder": "ex : mon-serveur-01",
+    "error_duplicate_hostname": "Ce hostname est déjà utilisé par un autre serveur"
   },
   "server_table": {
     "search_placeholder": "Rechercher un serveur…",
@@ -170,7 +171,18 @@
     "bulk_revoked": "Clés révoquées : {revoked}, ignorées : {skipped}",
     "root_revoke_warning": "Révoquer la clé SSH de l'utilisateur <strong>root</strong> peut entraîner une perte définitive d'accès distant à ce serveur.",
     "reprovision_needed": "Reprovisionnement requis",
-    "reprovision_needed_tooltip": "La mise à jour automatique a échoué sur cet hôte. Ouvrez le détail du serveur et cliquez sur Re-provisionner pour pousser la nouvelle configuration SAM. Consultez la vue Audit pour le détail de l'erreur."
+    "reprovision_needed_tooltip": "La mise à jour automatique a échoué sur cet hôte. Ouvrez le détail du serveur et cliquez sur Re-provisionner pour pousser la nouvelle configuration SAM. Consultez la vue Audit pour le détail de l'erreur.",
+    "rotate_key": "Tourner la clé du collecteur",
+    "rotate_key_confirm_title": "Tourner la clé du collecteur",
+    "rotate_key_confirm_message": "Cette opération génère une nouvelle clé SSH par serveur, la déploie sur l'hôte distant, vérifie la connectivité, puis retire l'ancienne clé. Opération atomique avec rollback automatique en cas d'échec. Continuer ?",
+    "rotate_key_in_progress": "Rotation en cours…",
+    "rotate_key_success": "Clé du collecteur tournée avec succès. Nouvelle empreinte : {fingerprint}",
+    "rotate_key_failed": "La rotation a échoué",
+    "rotate_key_retry": "Réessayer",
+    "field_collector_fingerprint": "Empreinte de la clé du collecteur",
+    "copy_public_key": "Copier la clé publique",
+    "manual_provision_title": "Provisionner avec vos propres identifiants SSH",
+    "manual_provision_hint": "Utilisez ces commandes pour amorcer le serveur avec votre propre compte SSH. Remplacez 'podman' par 'docker' si nécessaire. La clé du collecteur est récupérée depuis le serveur, puis déployée via votre session SSH."
   },
   "key_table": {
     "col_status": "Statut",

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -33,7 +33,6 @@
     "status_scan_failed": "🟠 Scansione fallita",
     "status_inactive": "🔴 Inattivo",
     "status_total": "Totale",
-    "collector_key": "Chiave pubblica collector",
     "copy": "Copia",
     "copied": "Copiato!",
     "scan_success": "Scansione di {hostname} avviata.",
@@ -75,7 +74,7 @@
   },
   "edit_server": {
     "title": "Modifica server",
-    "hostname": "Hostname (sola lettura)",
+    "hostname": "Hostname",
     "ip": "Indirizzo IP",
     "ip_placeholder": "es: 192.168.1.10",
     "environment": "Ambiente",
@@ -86,7 +85,9 @@
     "max_sessions_label": "Sessioni max",
     "max_sessions_hint": "Un avviso viene inviato se le sessioni SSH attive superano questo limite.",
     "submitting": "Salvataggio…",
-    "submit": "Salva"
+    "submit": "Salva",
+    "hostname_placeholder": "es.: mio-server-01",
+    "error_duplicate_hostname": "Questo hostname è già in uso da un altro server"
   },
   "server_table": {
     "search_placeholder": "Cerca un server…",
@@ -170,7 +171,18 @@
     "bulk_revoked": "Chiavi revocate: {revoked}, saltate: {skipped}",
     "root_revoke_warning": "La revoca della chiave SSH dell'utente <strong>root</strong> può causare la perdita permanente dell'accesso remoto a questo server.",
     "reprovision_needed": "Riapprontamento richiesto",
-    "reprovision_needed_tooltip": "L'aggiornamento automatico è fallito su questo host. Apri il dettaglio del server e fai clic su Reapprontamento per inviare la nuova configurazione SAM. Consulta la vista Audit per i dettagli dell'errore."
+    "reprovision_needed_tooltip": "L'aggiornamento automatico è fallito su questo host. Apri il dettaglio del server e fai clic su Reapprontamento per inviare la nuova configurazione SAM. Consulta la vista Audit per i dettagli dell'errore.",
+    "rotate_key": "Ruotare la chiave del collettore",
+    "rotate_key_confirm_title": "Ruotare la chiave del collettore",
+    "rotate_key_confirm_message": "Questa operazione genera una nuova chiave SSH per server, la distribuisce sull'host remoto, verifica la connettività e quindi rimuove la vecchia chiave. Operazione atomica con rollback automatico in caso di guasto. Continuare?",
+    "rotate_key_in_progress": "Rotazione…",
+    "rotate_key_success": "Chiave del collettore ruotata con successo. Nuova impronta: {fingerprint}",
+    "rotate_key_failed": "La rotazione è fallita",
+    "rotate_key_retry": "Riprova",
+    "field_collector_fingerprint": "Impronta della chiave del collettore",
+    "copy_public_key": "Copiare la chiave pubblica",
+    "manual_provision_title": "Provisionare con le proprie credenziali SSH",
+    "manual_provision_hint": "Utilizzare questi comandi per inizializzare il server con il proprio account SSH. Sostituire 'podman' con 'docker' se necessario. La chiave del collettore viene recuperata dal server e quindi distribuita tramite la propria sessione SSH."
   },
   "key_table": {
     "col_status": "Stato",

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -44,15 +44,6 @@
       </div>
     </div>
 
-    <!-- Collector key -->
-    <div v-if="collectorKey" class="collector-key-block">
-      <span class="collector-key-label">{{ $t('dashboard.collector_key') }}</span>
-      <code class="collector-key-value">{{ collectorKey }}</code>
-      <button class="btn-copy" @click="copyKey(collectorKey, 'main')">
-        {{ copied === 'main' ? $t('dashboard.copied') : $t('dashboard.copy') }}
-      </button>
-    </div>
-
     <div v-if="loading" class="loading">{{ $t('common.loading') }}</div>
     <ServerTable
       v-else
@@ -231,9 +222,6 @@ const scanning = ref(false)
 const scanningHostname = ref(null)
 const error = ref('')
 const scanMessage = ref('')
-const collectorKey = ref('')
-const sshUser = ref('audit-collector')
-const copied = ref('')
 
 const showAddServer = ref(false)
 const adding = ref(false)
@@ -305,28 +293,6 @@ const addFormValid = computed(
     !isIpDuplicate(addForm.value.ip.trim()) &&
     addForm.value.sshUser.trim()
 )
-
-async function loadCollectorKey() {
-  try {
-    const res = await apiFetch('/api/system/collector-key')
-    if (res.ok) {
-      const data = await res.json()
-      collectorKey.value = data.public_key
-      if (data.ssh_user) sshUser.value = data.ssh_user
-    }
-  } catch (_) {}
-}
-
-async function copyKey(key, context) {
-  if (!key) return
-  try {
-    await navigator.clipboard.writeText(key)
-    copied.value = context
-    setTimeout(() => {
-      copied.value = ''
-    }, 2000)
-  } catch (_) {}
-}
 
 function openAddServer() {
   addForm.value = {
@@ -430,7 +396,6 @@ function openEditServer(server) {
 
 onMounted(() => {
   loadServers()
-  loadCollectorKey()
 })
 </script>
 
@@ -491,50 +456,6 @@ h1 {
 }
 .counter-total {
   border-left: 4px solid #0d6efd;
-}
-
-.collector-key-block {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 0.6rem 1rem;
-  margin-bottom: 1.25rem;
-  flex-wrap: wrap;
-}
-
-.collector-key-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--text-secondary);
-  white-space: nowrap;
-}
-
-.collector-key-value {
-  flex: 1;
-  font-size: 0.75rem;
-  color: var(--text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
-.btn-copy {
-  background: #0d6efd;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  padding: 0.25rem 0.65rem;
-  font-size: 0.8rem;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background 0.15s;
-}
-.btn-copy:hover {
-  background: #0b5ed7;
 }
 
 .loading {

--- a/ui/src/views/ServerDetail.vue
+++ b/ui/src/views/ServerDetail.vue
@@ -40,6 +40,13 @@
           {{ $t('server_detail.reprovision') }}
         </button>
         <button
+          v-if="server.is_active && server.is_provisioned && currentRole === 'sysadmin'"
+          class="btn-teal"
+          @click="openRotateKey"
+        >
+          {{ $t('server_detail.rotate_key') }}
+        </button>
+        <button
           v-if="currentRole === 'sysadmin'"
           class="btn-danger"
           @click="showDeleteModal = true"
@@ -107,7 +114,34 @@
               {{ $t('server_detail.reprovision_needed') }}
             </span>
           </dd>
+          <dt>{{ $t('server_detail.field_collector_fingerprint') }}</dt>
+          <dd>
+            <code
+              class="fingerprint"
+              :title="server.collector_fingerprint || ''"
+              style="font-family: monospace"
+            >
+              {{ shortFingerprint }}
+            </code>
+            <button
+              v-if="server.collector_fingerprint"
+              class="btn-sm btn-secondary"
+              @click="copyPublicKey"
+              :title="$t('server_detail.copy_public_key')"
+              style="margin-left: 0.5rem"
+            >
+              {{ $t('server_detail.copy_public_key') }}
+            </button>
+          </dd>
         </dl>
+        <details v-if="server.hostname && server.ip_address" class="manual-provision">
+          <summary>{{ $t('server_detail.manual_provision_title') }}</summary>
+          <p class="hint">{{ $t('server_detail.manual_provision_hint') }}</p>
+          <pre class="snippet">{{ manualProvisionSnippet }}</pre>
+          <button class="btn-sm btn-secondary" @click="copySnippet">
+            {{ copiedSnippet ? $t('dashboard.copied') : $t('dashboard.copy') }}
+          </button>
+        </details>
       </section>
 
       <!-- SSH Sessions -->
@@ -313,7 +347,32 @@
       </div>
     </div>
 
-    <EditServerModal v-model="showEditModal" :server="server" @saved="load" />
+    <EditServerModal v-model="showEditModal" :server="server" @saved="onServerSaved" />
+
+    <!-- Rotate key modal -->
+    <div v-if="showRotateKeyModal" class="modal-overlay" @click.self="showRotateKeyModal = false">
+      <div class="modal">
+        <div class="modal-header">
+          <h3>{{ $t('server_detail.rotate_key_confirm_title') }}</h3>
+          <button class="modal-close" @click="showRotateKeyModal = false" aria-label="Close">
+            &#x2715;
+          </button>
+        </div>
+        <div v-if="rotateError" class="alert-error">{{ rotateError }}</div>
+        <p class="hint">{{ $t('server_detail.rotate_key_confirm_message') }}</p>
+        <div class="modal-actions">
+          <button class="btn-secondary" @click="showRotateKeyModal = false">
+            {{ $t('common.cancel') }}
+          </button>
+          <button class="btn-primary" :disabled="rotating" @click="confirmRotateKey">
+            <Spinner v-if="rotating" />
+            {{
+              rotating ? $t('server_detail.rotate_key_in_progress') : $t('server_detail.rotate_key')
+            }}
+          </button>
+        </div>
+      </div>
+    </div>
 
     <!-- Re-provision modal -->
     <div
@@ -435,6 +494,11 @@ const reprovisionError = ref('')
 const reprovisionForm = ref({ sshUser: 'root', sshPassword: '', sshPort: 22 })
 const showReprovisionPassword = ref(false)
 
+const showRotateKeyModal = ref(false)
+const rotating = ref(false)
+const rotateError = ref('')
+const copiedSnippet = ref(false)
+
 const revokeTarget = ref(null)
 const revokeReason = ref('')
 const bulkRevokeFingerprints = ref(null)
@@ -455,8 +519,32 @@ const expiryValid = computed(() => {
   return !!expiryDate.value
 })
 
+const shortFingerprint = computed(() => {
+  if (!server.value.collector_fingerprint) return '—'
+  return server.value.collector_fingerprint.substring(0, 12) + '...'
+})
+
+const manualProvisionSnippet = computed(() => {
+  const h = server.value.hostname || '<hostname>'
+  const ip = server.value.ip_address || '<ip>'
+  return `# Bootstrap with your own SSH credentials:
+PUB=$(podman exec sam-server python3 /app/app/manage.py servers show ${h} --pubkey)
+ssh root@${ip} "sudo bash -s '$PUB'" < <(podman exec sam-server cat /app/provision-host.sh)
+podman exec sam-server python3 /app/app/manage.py servers activate ${h}`
+})
+
 function openEdit() {
   showEditModal.value = true
+}
+
+async function onServerSaved(payload) {
+  const newHostname = payload?.hostname
+  if (newHostname && newHostname !== hostname) {
+    // Hostname was renamed: navigate to the new URL (component remounts)
+    router.replace({ name: 'ServerDetail', params: { hostname: newHostname } })
+    return
+  }
+  await load()
 }
 
 async function load() {
@@ -721,6 +809,58 @@ function envBadge(env) {
   )
 }
 
+function openRotateKey() {
+  rotateError.value = ''
+  showRotateKeyModal.value = true
+}
+
+async function confirmRotateKey() {
+  rotating.value = true
+  rotateError.value = ''
+  try {
+    const res = await apiFetch(`/api/servers/${hostname}/rotate-key`, { method: 'POST' })
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      if (res.status === 502) {
+        throw new Error(data.error || 'Bad Gateway — rotation failed')
+      }
+      throw new Error(data.error || `HTTP ${res.status}`)
+    }
+    showRotateKeyModal.value = false
+    message.value = t('server_detail.rotate_key_success', { fingerprint: data.fingerprint })
+    await load()
+  } catch (e) {
+    rotateError.value = e.message
+  } finally {
+    rotating.value = false
+  }
+}
+
+async function copyPublicKey() {
+  try {
+    const res = await apiFetch(`/api/servers/${hostname}/collector-key`)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const data = await res.json()
+    await navigator.clipboard.writeText(data.public_key)
+    message.value = t('dashboard.copied')
+    setTimeout(() => {
+      message.value = ''
+    }, 2000)
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function copySnippet() {
+  try {
+    await navigator.clipboard.writeText(manualProvisionSnippet.value)
+    copiedSnippet.value = true
+    setTimeout(() => {
+      copiedSnippet.value = false
+    }, 2000)
+  } catch (_) {}
+}
+
 onMounted(load)
 </script>
 
@@ -927,5 +1067,37 @@ dd {
   font-size: 0.7rem;
   padding: 0.1rem 0.4rem;
   border-radius: 3px;
+}
+
+.manual-provision {
+  margin-top: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 1rem;
+  background: var(--bg-tertiary);
+}
+.manual-provision summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 0.5rem;
+}
+.manual-provision .hint {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0.5rem 0;
+}
+.manual-provision .snippet {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  white-space: pre;
+  margin: 0.75rem 0;
+}
+.fingerprint {
+  font-size: 0.8rem;
 }
 </style>

--- a/ui/tests/Dashboard.spec.js
+++ b/ui/tests/Dashboard.spec.js
@@ -18,8 +18,6 @@ const MOCK_SERVERS = [
   },
 ]
 
-const COLLECTOR_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICollectorKeyTest audit-collector'
-
 function createMockRouter() {
   return createRouter({
     history: createMemoryHistory(),
@@ -46,12 +44,6 @@ beforeEach(() => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(MOCK_SERVERS),
-        })
-      }
-      if (url === '/api/system/collector-key') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
         })
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
@@ -121,12 +113,6 @@ describe('Dashboard - Add Server Modal', () => {
           json: () => Promise.resolve(MOCK_SERVERS),
         })
       }
-      if (url === '/api/system/collector-key') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
-        })
-      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     })
     vi.stubGlobal('fetch', fetchSpy)
@@ -177,12 +163,6 @@ describe('Dashboard - Add Server Modal', () => {
           json: () => Promise.resolve(MOCK_SERVERS),
         })
       }
-      if (url === '/api/system/collector-key') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
-        })
-      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     })
     vi.stubGlobal('fetch', fetchSpy)
@@ -230,12 +210,6 @@ describe('Dashboard - Add Server Modal', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(MOCK_SERVERS),
-        })
-      }
-      if (url === '/api/system/collector-key') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
         })
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
@@ -348,12 +322,6 @@ describe('Dashboard - Add Server Modal', () => {
         return Promise.resolve({
           ok: true,
           json: () => Promise.resolve(MOCK_SERVERS),
-        })
-      }
-      if (url === '/api/system/collector-key') {
-        return Promise.resolve({
-          ok: true,
-          json: () => Promise.resolve({ public_key: COLLECTOR_KEY, ssh_user: 'audit-collector' }),
         })
       }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })

--- a/ui/tests/ServerDetail.spec.js
+++ b/ui/tests/ServerDetail.spec.js
@@ -272,3 +272,267 @@ describe('ServerDetail — provision version display', () => {
     expect(w.find('.badge-drift').exists()).toBe(false)
   })
 })
+
+describe('ServerDetail — Rotate collector key', () => {
+  it('shows Rotate button only for sysadmin on active provisioned server', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: true, is_provisioned: true }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    const rotateBtn = w.findAll('button').find((b) => b.text().includes('Rotate collector key'))
+    expect(rotateBtn).toBeDefined()
+  })
+
+  it('does not show Rotate button if server is not provisioned', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: true, is_provisioned: false }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    const rotateBtn = w.findAll('button').find((b) => b.text().includes('Rotate collector key'))
+    expect(rotateBtn).toBeUndefined()
+  })
+
+  it('does not show Rotate button if server is inactive', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: false, is_provisioned: true }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    const rotateBtn = w.findAll('button').find((b) => b.text().includes('Rotate collector key'))
+    expect(rotateBtn).toBeUndefined()
+  })
+
+  it('opens confirmation modal on Rotate click', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: true, is_provisioned: true }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    const rotateBtn = w.findAll('button').find((b) => b.text().includes('Rotate collector key'))
+    await rotateBtn.trigger('click')
+    await w.vm.$nextTick()
+
+    expect(w.vm.showRotateKeyModal).toBe(true)
+    const modal = w.findAll('.modal').find((m) => m.text().includes('Rotate collector key'))
+    expect(modal).toBeDefined()
+  })
+
+  it('calls POST /rotate-key on confirm, shows success on 200', async () => {
+    const fetchSpy = vi.fn((url, opts) => {
+      if (url.includes('/rotate-key') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: 'rotated', fingerprint: 'SHA256:newfingerprint' }),
+        })
+      }
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys') && !url.includes('/rotate-key')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: true, is_provisioned: true }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    w.vm.openRotateKey()
+    await w.vm.$nextTick()
+    await w.vm.confirmRotateKey()
+    await flushPromises()
+
+    const rotateCall = fetchSpy.mock.calls.find((c) => c[0].includes('/rotate-key'))
+    expect(rotateCall).toBeDefined()
+    expect(w.vm.showRotateKeyModal).toBe(false)
+    expect(w.vm.message).toContain('SHA256:newfingerprint')
+  })
+
+  it('shows error message on 502', async () => {
+    const fetchSpy = vi.fn((url, opts) => {
+      if (url.includes('/rotate-key') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 502,
+          json: () => Promise.resolve({ error: 'SSH connection failed' }),
+        })
+      }
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys') && !url.includes('/rotate-key')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, is_active: true, is_provisioned: true }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    w.vm.openRotateKey()
+    await w.vm.$nextTick()
+    await w.vm.confirmRotateKey()
+    await flushPromises()
+
+    expect(w.vm.rotateError).toContain('SSH connection failed')
+    expect(w.vm.showRotateKeyModal).toBe(true)
+  })
+
+  it('displays the fingerprint in info grid', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, collector_fingerprint: 'SHA256:abc1234567890' }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    const infoGrid = w.find('.info-grid')
+    expect(infoGrid.text()).toContain('SHA256:abc12...')
+  })
+
+  it('copies public key on Copy button click', async () => {
+    const writeTextSpy = vi.fn(() => Promise.resolve())
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextSpy,
+      },
+    })
+
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/collector-key')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ fingerprint: 'SHA256:xyz', public_key: 'ssh-ed25519 AAAA...' }),
+        })
+      }
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys') && !url.includes('/collector-key')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, collector_fingerprint: 'SHA256:abc1234567890' }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    await w.vm.copyPublicKey()
+    await flushPromises()
+
+    expect(writeTextSpy).toHaveBeenCalledWith('ssh-ed25519 AAAA...')
+  })
+
+  it('shows manual provision snippet with correct hostname and IP', async () => {
+    const fetchSpy = vi.fn((url) => {
+      if (url.includes('/api/servers/test-server') && !url.includes('/sessions') && !url.includes('/keys')) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...MOCK_SERVER, hostname: 'test-server', ip_address: '10.0.0.1' }),
+        })
+      }
+      if (url.includes('/api/keys')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_KEYS) })
+      }
+      if (url.includes('/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ active: [], recent: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const w = await mountServerDetail()
+    expect(w.vm.manualProvisionSnippet).toContain('test-server')
+    expect(w.vm.manualProvisionSnippet).toContain('10.0.0.1')
+    expect(w.vm.manualProvisionSnippet).toContain('podman exec sam-server')
+  })
+})


### PR DESCRIPTION
## Summary
- Remplace la clé SSH globale unique `/data/keys/collector_key` par une paire ed25519 **par serveur** générée à l'ajout (`/data/keys/per-server/<uuid>.key{,.pub}`, anonyme, mapping implicite par filename — pas de colonne DB), pour cantonner le blast radius à un seul hôte
- Bouton **Rotate collector key** dans ServerDetail (sysadmin) avec rotation atomique et rollback ; nouvelles routes `POST /api/servers/<hostname>/rotate-key` et `GET /api/servers/<hostname>/collector-key` ; legacy `GET /api/system/collector-key` retirée
- Workflow CLI bulk bootstrap : `manage.py servers register/show --pubkey/activate` pour déployer avec sa propre clé SSH root sans mot de passe SAM

## Test plan
- [x] `pytest` : 664 passed
- [x] `vitest` : 372 passed
- [x] `prettier --check` : clean
- [ ] Build d'image + déploiement frais, ajout UI → keypair généré dans `/data/keys/per-server/`, fingerprint visible ServerDetail
- [ ] Bulk : `register` × 3 IPs → `show --pubkey | ssh root@…` → `activate` → scan OK ; `is_provisioned=TRUE`
- [ ] Bouton Rotate : nouvelle fingerprint affichée, ancienne pubkey absente de `authorized_keys` distant
- [ ] `delete` serveur → fichier `<uuid>.key{,.pub}` disparaît
- [ ] Serveur legacy (volume hérité) → 1er scan → SCAN_FAILED clair

Closes #402