### PR TITLE
docs(readme): remove obsolete mention of the rename warning span

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ Depuis **ServerDetail** (rôle `sysadmin`) → bouton **Edit** → champ Hostnam
 
 - Valide le nouveau nom (RFC 1123)
 - Refuse si le nouveau nom est déjà utilisé par un autre serveur
-- Affiche un avertissement contextuel : « Renaming changes the URL. A SERVER_RENAMED audit entry records the change. »
 
 Après save, l'UI redirige vers `/servers/<nouveau-hostname>` (le component remount proprement). Un audit `SERVER_RENAMED` enregistre `{old_hostname, new_hostname}` avec l'admin et l'horodatage.
 


### PR DESCRIPTION
## Summary
- README still described a contextual warning under the Hostname field in EditServerModal that was removed from the UI in PR #403
- Drop the now-inaccurate bullet so the documentation matches the actual behavior

## Test plan
- [x] grep confirms no remaining occurrence of "Renaming changes the URL" in the docs