### PR TITLE
test(ui): assert i18n key parity across the 5 locales

### DIFF
--- a/ui/src/locales/de.json
+++ b/ui/src/locales/de.json
@@ -470,6 +470,7 @@
     "group_error": "Gruppenänderung fehlgeschlagen: {error}",
     "active_session_tooltip": "Benutzer hat eine aktive Sitzung — Gruppenänderung blockiert",
     "active_session_badge": "Aktive Sitzung",
+    "refreshing_sessions": "Sitzungen werden aktualisiert…",
     "group_success_verified": "Gruppe für {user} auf {server} aktualisiert — Server bestätigt: {groups}",
     "root_user_tooltip": "Der root-Benutzer kann weder gesperrt noch seine Gruppe geändert werden",
     "root_protected_badge": "geschützt"

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -470,6 +470,7 @@
     "group_error": "Error al cambiar grupo: {error}",
     "active_session_tooltip": "El usuario tiene una sesión activa — cambio de grupo bloqueado",
     "active_session_badge": "Sesión activa",
+    "refreshing_sessions": "Actualizando sesiones…",
     "group_success_verified": "Grupo actualizado para {user} en {server} — servidor confirma: {groups}",
     "root_user_tooltip": "El usuario root no puede bloquearse ni cambiar de grupo",
     "root_protected_badge": "protegido"

--- a/ui/src/locales/fr.json
+++ b/ui/src/locales/fr.json
@@ -470,6 +470,7 @@
     "group_error": "Échec du changement de groupe : {error}",
     "active_session_tooltip": "L'utilisateur a une session active — changement de groupe bloqué",
     "active_session_badge": "Session active",
+    "refreshing_sessions": "Actualisation des sessions…",
     "group_success_verified": "Groupe mis à jour pour {user} sur {server} — serveur confirme : {groups}",
     "root_user_tooltip": "L'utilisateur root ne peut pas être verrouillé ni changer de groupe",
     "root_protected_badge": "protégé"

--- a/ui/src/locales/it.json
+++ b/ui/src/locales/it.json
@@ -470,6 +470,7 @@
     "group_error": "Modifica gruppo fallita: {error}",
     "active_session_tooltip": "L'utente ha una sessione attiva — modifica gruppo bloccata",
     "active_session_badge": "Sessione attiva",
+    "refreshing_sessions": "Aggiornamento sessioni…",
     "group_success_verified": "Gruppo aggiornato per {user} su {server} — il server conferma: {groups}",
     "root_user_tooltip": "L'utente root non può essere bloccato né cambiare gruppo",
     "root_protected_badge": "protetto"

--- a/ui/tests/i18n-parity.spec.js
+++ b/ui/tests/i18n-parity.spec.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import en from '../src/locales/en.json'
+import fr from '../src/locales/fr.json'
+import es from '../src/locales/es.json'
+import itLocale from '../src/locales/it.json'
+import de from '../src/locales/de.json'
+
+function flatten(obj, prefix = '') {
+  const keys = new Set()
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      for (const sub of flatten(v, key)) keys.add(sub)
+    } else {
+      keys.add(key)
+    }
+  }
+  return keys
+}
+
+const LOCALES = { en, fr, es, it: itLocale, de }
+const FLAT = Object.fromEntries(Object.entries(LOCALES).map(([l, d]) => [l, flatten(d)]))
+const REFERENCE = FLAT.en
+
+describe('i18n — key parity across the 5 locales', () => {
+  for (const lang of ['fr', 'es', 'it', 'de']) {
+    it(`${lang}.json has the same set of leaf keys as en.json`, () => {
+      const other = FLAT[lang]
+      const missing = [...REFERENCE].filter((k) => !other.has(k)).sort()
+      const extra = [...other].filter((k) => !REFERENCE.has(k)).sort()
+      expect({ missing, extra }).toEqual({ missing: [], extra: [] })
+    })
+  }
+
+  it('all locales report the same total leaf-key count', () => {
+    const counts = Object.fromEntries(Object.entries(FLAT).map(([l, s]) => [l, s.size]))
+    const unique = new Set(Object.values(counts))
+    expect(unique.size, JSON.stringify(counts)).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- New Vitest suite `ui/tests/i18n-parity.spec.js` flattens every locale JSON to a set of dot-notation leaf keys and asserts equality between `en` and each of `fr/es/it/de`.
- Detects regression in one direction (missing key) **and** the other (extra/typo key) on the same assertion.
- Extra sanity test on total leaf-key count — catches the edge case where two locales have the same size but with disjoint differences vs `en`.
- Fills in the missing translation `deployedUsers.refreshing_sessions` that already existed in `en.json` but was absent from the four other locales — uncovered while building the test.

## Test plan

- [x] `npx vitest run tests/i18n-parity.spec.js` — 5 tests green
- [x] Negative check: removed `deployedUsers.refreshing_sessions` from `fr.json` → test goes red on the `fr`-vs-`en` assertion **and** on the count assertion. Restored.
- [x] `npx prettier --check src/locales/ tests/i18n-parity.spec.js` — clean
- [ ] CI green on PR

Closes #405