### PR TITLE
test(ci): extend coverage gate to all backend modules with per-module floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,16 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Run pytest
-        run: python3 -m pytest tests/ --cov=actions --cov-fail-under=80 -v
+        run: |
+          python3 -m pytest tests/ \
+            --cov=actions --cov=alerts --cov=collect --cov=db --cov=expire \
+            --cov=manage --cov=servers --cov=ssh --cov=web \
+            --cov-report=term --cov-report=json:coverage.json \
+            --cov-fail-under=80 -v
+        working-directory: app
+
+      - name: Enforce per-module coverage floors
+        run: python3 tests/check_coverage_floors.py coverage.json
         working-directory: app
 
   tests-vue:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 *.pyc
 .coverage
 app/.coverage
+app/coverage.json
 app/__pycache__/
 app/tests/__pycache__/
 node_modules

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -274,7 +274,16 @@ Configurable sans redémarrage via PUT /api/system/config : login_max_attempts (
 - Mock msmtp via unittest.mock — jamais d'email réel
 - Un test = un comportement précis
 - Nommage : `test_<module>_<scenario>_<expected>`
-- Couverture minimale actions.py : 80%
+- Couverture minimale agrégée 80% sur les 9 modules backend (`actions, alerts, collect, db, expire, manage, servers, ssh, web`)
+- Planchers par module appliqués par `app/tests/check_coverage_floors.py` (raise OK, lower = changement visible)
+- Commande de référence locale :
+  ```
+  python3 -m pytest tests/ \
+    --cov=actions --cov=alerts --cov=collect --cov=db --cov=expire \
+    --cov=manage --cov=servers --cov=ssh --cov=web \
+    --cov-report=term --cov-report=json:coverage.json --cov-fail-under=80
+  python3 tests/check_coverage_floors.py coverage.json
+  ```
 - pytest doit passer avant tout commit
 
 Fichiers : conftest.py, test_db.py (7), test_servers.py (10), test_ssh.py (70), test_actions.py (186), test_collect.py (35), test_expire.py (16), test_alerts.py (23), test_web.py (178), test_manage.py (46), test_rbac.py (3).

--- a/app/tests/check_coverage_floors.py
+++ b/app/tests/check_coverage_floors.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Enforce a per-module coverage floor on top of pytest-cov's aggregate gate.
+
+Reads coverage.json produced by `pytest --cov-report=json:coverage.json` and
+fails (exit 1) if any module's line coverage falls below the floor declared
+in FLOORS below. Floors are set ~3 points below the value measured at the
+time this script was added — small enough to catch genuine drift, large
+enough to absorb non-deterministic noise (e.g. branches gated on import-time
+fallbacks).
+
+Raising a floor is encouraged when coverage improves. Lowering a floor
+should be a deliberate, reviewable change in this file.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FLOORS: dict[str, int] = {
+    "actions.py": 80,
+    "alerts.py": 90,
+    "collect.py": 90,
+    "db.py": 85,
+    "expire.py": 88,
+    "manage.py": 75,
+    "servers.py": 88,
+    "ssh.py": 65,
+    "web.py": 85,
+}
+
+
+def main(report_path: str = "coverage.json") -> int:
+    p = Path(report_path)
+    if not p.is_file():
+        print(f"FATAL: coverage report not found at {p}", file=sys.stderr)
+        return 2
+
+    data = json.loads(p.read_text())
+    files = data.get("files", {})
+
+    failures: list[str] = []
+    for name, floor in FLOORS.items():
+        match = next(
+            (info for key, info in files.items() if Path(key).name == name),
+            None,
+        )
+        if match is None:
+            failures.append(f"  {name}: missing from coverage report")
+            continue
+        pct = match["summary"]["percent_covered"]
+        marker = "OK  " if pct >= floor else "FAIL"
+        print(f"  {marker} {name:<14} {pct:5.1f}%  (floor {floor}%)")
+        if pct < floor:
+            failures.append(f"  {name}: {pct:.1f}% < floor {floor}%")
+
+    if failures:
+        print("\nPer-module coverage floor breached:", file=sys.stderr)
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print("\nAll per-module floors satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "coverage.json"))


### PR DESCRIPTION
## Summary

- \`pytest --cov\` now spans the 9 backend modules (was \`actions.py\` only).
- \`--cov-fail-under=80\` kept on the **aggregate** total (currently 83%, ~3 pts headroom).
- New script \`app/tests/check_coverage_floors.py\` enforces a **per-module floor** ≈3 pts under the value at the time the floor was set. Catches drift on a single module that the aggregate would mask.
- Floor changes are explicit constants in the script — raising is encouraged, lowering is a reviewable diff.
- Documented the reference command in \`app/CLAUDE.md\`.

## Current floors (vs measured)

| Module | Floor | Measured |
|---|---:|---:|
| actions.py | 80% | 84.3% |
| alerts.py | 90% | 95.7% |
| collect.py | 90% | 94.7% |
| db.py | 85% | 91.7% |
| expire.py | 88% | 92.5% |
| manage.py | 75% | 78.3% |
| servers.py | 88% | 93.1% |
| ssh.py | 65% | 70.2% |
| web.py | 85% | 88.1% |
| **Total** | **80%** | **83.4%** |

## Test plan

- [x] Run full pytest + floor check locally → 665 tests OK, all floors satisfied
- [x] Negative check: artificially raise \`ssh.py\` floor to 75 → script exits 1 with clear message. Restored.
- [ ] CI green

Closes #407