### PR TITLE
test(smoke): supervisor + SPA fallback + DB roundtrip + 56-route sweep + persistence

### DIFF
--- a/.github/workflows/smoke-container.yml
+++ b/.github/workflows/smoke-container.yml
@@ -42,8 +42,65 @@ jobs:
       - name: Start the container
         run: docker compose up -d
 
-      - name: Run smoke assertions
+      - name: Run smoke HTTP assertions (first boot)
         run: bash tests/smoke/run.sh http://127.0.0.1:8080 admin smoke-admin-pw
+
+      - name: Assert supervisord shows all 4 services RUNNING
+        # postgresql, flask, nginx and crond are all declared in
+        # supervisord.conf. Any STARTING/EXITED/FATAL line means the
+        # service crash-loops or never came up — exactly the silent
+        # failure mode this job is designed to catch.
+        run: |
+          out=$(docker compose exec -T sam-server supervisorctl status)
+          echo "$out"
+          for svc in postgresql flask nginx crond; do
+            if ! echo "$out" | grep -E "^${svc}[[:space:]]+RUNNING" >/dev/null; then
+              echo "::error::supervisord shows ${svc} not RUNNING"
+              exit 1
+            fi
+          done
+          echo "All 4 supervised services are RUNNING."
+
+      - name: Capture first-boot logs for the idempotence check
+        # bootstrap.sh logs "First startup detected." on the very first
+        # boot, then "Normal startup (existing data)." on every reboot
+        # that finds /data/pg/PG_VERSION already there. The presence of
+        # the first line on boot #1 + the second line on boot #2 is the
+        # proof that bootstrap.sh is correctly idempotent.
+        run: |
+          docker compose logs --no-color sam-server > /tmp/first-boot.log
+          grep -q "\[bootstrap\] First startup detected" /tmp/first-boot.log \
+              || (echo "::error::expected 'First startup detected' in first-boot logs"; \
+                  tail -50 /tmp/first-boot.log; exit 1)
+          if grep -q "\[bootstrap\] Normal startup" /tmp/first-boot.log; then
+              echo "::error::Normal startup logged on first boot — bootstrap thinks the DB already exists"
+              exit 1
+          fi
+          echo "First-boot log shape OK."
+
+      - name: Restart the container (volume preserved — proves persistence)
+        # `docker compose down` (no -v) preserves the named volume, so
+        # /data/pg/ survives. `up` again must reuse the existing PGDATA,
+        # the admin row, the schema and all settings.
+        run: |
+          docker compose down
+          docker compose up -d
+
+      - name: Wait for the container to come back up + re-run HTTP smoke
+        # Same admin credentials must still log in. If bootstrap.sh
+        # re-runs initdb / re-applies schema / re-seeds the admin, the
+        # smoke either fails (admin password reset to ENV default) or
+        # the existing data is wiped — both are catastrophic in prod
+        # upgrade flows and entirely invisible to pytest.
+        run: bash tests/smoke/run.sh http://127.0.0.1:8080 admin smoke-admin-pw
+
+      - name: Assert second boot took the "Normal startup" branch
+        run: |
+          docker compose logs --no-color sam-server > /tmp/second-boot.log
+          grep -q "\[bootstrap\] Normal startup (existing data)" /tmp/second-boot.log \
+              || (echo "::error::expected 'Normal startup (existing data)' on reboot — bootstrap may have reinitialised the DB"; \
+                  tail -80 /tmp/second-boot.log; exit 1)
+          echo "Second-boot log confirms bootstrap took the idempotent path."
 
       - name: Dump container logs on failure
         if: failure()

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -4,6 +4,19 @@ logfile=/dev/stdout
 logfile_maxbytes=0
 user=root
 
+# RPC socket so `supervisorctl status` works from inside the container.
+# Used by tests/smoke + by operators troubleshooting a live container.
+# Restricted to root (chmod 0700) — no exposure on TCP.
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
 [program:postgresql]
 command=postgres -D /data/pg
 user=postgres

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -1,17 +1,30 @@
 #!/usr/bin/env bash
 # Smoke test — assert the SAM container is bootable end-to-end.
 #
-# Designed to be invoked by .github/workflows/smoke-container.yml after a
-# `docker compose up -d` against a freshly-built image. Validates:
-#   - Flask is alive behind Nginx (/api/auth/me returns 401 unauthenticated)
-#   - Postgres is initialised, schema applied, admin row inserted from ENV
-#   - POST /api/auth/login succeeds with the admin credentials from .env
-#   - GET /api/auth/me with the session cookie returns the expected payload
+# Invoked by .github/workflows/smoke-container.yml after `docker compose up -d`
+# against a freshly-built image. The workflow handles container lifecycle
+# (supervisorctl, restart, persistence) while this script focuses on what
+# can be observed from outside via HTTP.
 #
-# Designed to fail fast and dump compose logs on assertion failure so the
-# CI log is self-contained.
+# Assertions performed:
+#   1. Flask is alive behind Nginx and require_auth wired (GET /api/auth/me → 401)
+#   2. Postgres init + schema + werkzeug hash + session cookie all work
+#      (POST /api/auth/login → 200)
+#   3. /api/auth/me with cookie returns the seeded admin profile
+#   4. /api/servers (authenticated) returns an empty JSON array — proves
+#      Flask ↔ Postgres roundtrip on a clean schema
+#   5. SPA fallback in nginx: GET / and GET /servers/xyz both return the
+#      same HTML (vue-router history mode)
+#   6. Route sweep: every documented /api/ route returns <500 when hit
+#      with the admin cookie. 4xx are expected for routes that need real
+#      data; only 5xx fails the suite (catches SQL typos, serializer
+#      crashes, KeyError in handlers — none of which pytest mocks see)
+#   7. Logout flow: POST /api/auth/logout → 200, then GET /api/auth/me → 401
 #
 # Usage:  bash tests/smoke/run.sh [BASE_URL] [ADMIN_USER] [ADMIN_PASSWORD]
+#
+# Exits non-zero on the first failed assertion. On failure the workflow
+# dumps `docker compose logs` so the CI log is self-contained.
 
 set -eu
 
@@ -19,7 +32,8 @@ BASE_URL="${1:-http://127.0.0.1:8080}"
 ADMIN_USER="${2:-admin}"
 ADMIN_PASSWORD="${3:-admin}"
 COOKIE_JAR="$(mktemp /tmp/sam-smoke-cookies.XXXXXX)"
-trap 'rm -f "$COOKIE_JAR"' EXIT
+RESP_BODY=/tmp/sam-smoke-resp.json
+trap 'rm -f "$COOKIE_JAR" "$RESP_BODY"' EXIT
 
 if [ -t 1 ]; then
     GREEN=$'\033[32m'; RED=$'\033[31m'; RST=$'\033[0m'
@@ -28,14 +42,12 @@ else
 fi
 pass() { printf '  %sOK%s   %s\n' "$GREEN" "$RST" "$1"; }
 fail() { printf '  %sFAIL%s %s\n' "$RED" "$RST" "$1" >&2; exit 1; }
+section() { printf '\n%s== %s ==%s\n' "$GREEN" "$1" "$RST"; }
 
 # ---------------------------------------------------------------------------
-# Wait for /api/auth/me to respond. We don't care about the status code yet —
-# we only need to know the HTTP server is up and proxying to Flask. A 401 is
-# the *expected* steady state, but during boot we'll see ConnRefused or 502
-# until Nginx has Flask upstream.
+section "Step 1 — wait for the container to accept HTTP traffic"
 # ---------------------------------------------------------------------------
-echo "Waiting for ${BASE_URL}/api/auth/me to respond (up to 120 s)…"
+echo "Polling ${BASE_URL}/api/auth/me (up to 120 s)…"
 for i in $(seq 1 60); do
     code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "${BASE_URL}/api/auth/me" || true)
     case "$code" in
@@ -48,42 +60,184 @@ for i in $(seq 1 60); do
 done
 
 # ---------------------------------------------------------------------------
-# Unauthenticated /api/auth/me must be 401 (proves require_auth is wired).
+section "Step 2 — auth wiring (unauthenticated /me, login, authenticated /me)"
 # ---------------------------------------------------------------------------
 code=$(curl -s -o /dev/null -w '%{http_code}' "${BASE_URL}/api/auth/me")
 [ "$code" = "401" ] || fail "GET /api/auth/me unauthenticated — expected 401, got $code"
 pass "GET /api/auth/me without session → 401"
 
-# ---------------------------------------------------------------------------
-# Login must succeed with the admin credentials seeded from ENV by
-# bootstrap.sh (this exercises Postgres connection, password hash, session
-# cookie issuance).
-# ---------------------------------------------------------------------------
 login_body=$(printf '{"username":"%s","password":"%s"}' "$ADMIN_USER" "$ADMIN_PASSWORD")
-code=$(curl -s -o /tmp/sam-smoke-login.json -w '%{http_code}' \
+code=$(curl -s -o "$RESP_BODY" -w '%{http_code}' \
     -c "$COOKIE_JAR" \
     -H 'Content-Type: application/json' \
     -X POST -d "$login_body" \
     "${BASE_URL}/api/auth/login")
 if [ "$code" != "200" ]; then
-    echo "Response body:"; cat /tmp/sam-smoke-login.json || true
+    echo "Response body:"; cat "$RESP_BODY" || true; echo
     fail "POST /api/auth/login — expected 200, got $code"
 fi
-pass "POST /api/auth/login → 200 (admin from ENV is usable)"
+pass "POST /api/auth/login → 200"
 
-# ---------------------------------------------------------------------------
-# Authenticated /api/auth/me must echo back the admin profile.
-# ---------------------------------------------------------------------------
 body=$(curl -s -b "$COOKIE_JAR" "${BASE_URL}/api/auth/me")
 echo "  /api/auth/me payload: $body"
 case "$body" in
-    *"\"username\""*"\"$ADMIN_USER\""*) pass "GET /api/auth/me with cookie returns username=$ADMIN_USER" ;;
-    *) fail "GET /api/auth/me payload does not contain username=$ADMIN_USER" ;;
+    *"\"username\""*"\"$ADMIN_USER\""*"\"role\""*"\"sysadmin\""*|*"\"role\""*"\"sysadmin\""*"\"username\""*"\"$ADMIN_USER\""*)
+        pass "GET /api/auth/me with cookie returns username=$ADMIN_USER + role=sysadmin" ;;
+    *) fail "GET /api/auth/me payload missing username=$ADMIN_USER and/or role=sysadmin" ;;
 esac
+
+# ---------------------------------------------------------------------------
+section "Step 3 — Flask ↔ Postgres roundtrip (GET /api/servers → [])"
+# ---------------------------------------------------------------------------
+# Proves: schema applied, FK resolvable, JSON serializer compatible with
+# Postgres types, no extension missing (gen_random_uuid…). A 500 here
+# means the DB is unreachable from Flask or the query refers to a column
+# that does not exist.
+code=$(curl -s -o "$RESP_BODY" -w '%{http_code}' -b "$COOKIE_JAR" "${BASE_URL}/api/servers")
+[ "$code" = "200" ] || { cat "$RESP_BODY"; echo; fail "GET /api/servers — expected 200, got $code"; }
+body=$(cat "$RESP_BODY")
 case "$body" in
-    *"\"role\""*"\"sysadmin\""*) pass "admin from ENV was seeded with role=sysadmin" ;;
-    *) fail "admin role is not sysadmin in /api/auth/me payload" ;;
+    "[]"|"[ ]") pass "GET /api/servers → 200 [] (DB is reachable, schema applied, serializer OK)" ;;
+    *) fail "GET /api/servers — expected empty array, got: $body" ;;
 esac
+
+# ---------------------------------------------------------------------------
+section "Step 4 — nginx SPA fallback (/, /servers/xyz both return index.html)"
+# ---------------------------------------------------------------------------
+# Vue-router runs in history mode. Without `try_files $uri $uri/ /index.html`
+# in nginx, a hard-refresh on /servers/server-01 returns 404. This check
+# catches that.
+root_html=$(curl -s "${BASE_URL}/")
+[ -n "$root_html" ] || fail "GET / returned empty body"
+case "$root_html" in
+    *"<html"*|*"<!DOCTYPE"*|*"<!doctype"*) pass "GET / returns HTML (SPA entry point served)" ;;
+    *) fail "GET / does not look like HTML: $(printf '%s' "$root_html" | head -c 100)" ;;
+esac
+
+deep_html=$(curl -s "${BASE_URL}/servers/some-future-host")
+if [ "$root_html" = "$deep_html" ]; then
+    pass "GET /servers/some-future-host returns the same HTML (nginx try_files OK)"
+else
+    fail "GET /servers/some-future-host differs from / — vue-router history mode will 404 on hard refresh"
+fi
+
+# ---------------------------------------------------------------------------
+section "Step 5 — route sweep (no /api/ endpoint may return 5xx)"
+# ---------------------------------------------------------------------------
+# Strategy: as sysadmin, hit every documented route. Sentinel values for
+# path parameters (does-not-exist / SHA256:nonexistent / nil UUID) so the
+# server has nothing to act on — 4xx is the right answer, 5xx is a bug.
+#
+# This catches what mocked pytest cannot:
+#   - SQL typos that mocks don't see (substring assertions accept them)
+#   - JSON serializer crashes on Postgres types (UUID, INET, TIMESTAMPTZ)
+#   - KeyError / TypeError in handlers when input is incomplete
+#   - Missing pg_extension (gen_random_uuid, etc.)
+#
+# Route inventory mirrors app/web.py at HEAD. Keep alphabetical by path
+# inside each group.
+
+NIL_UUID="00000000-0000-0000-0000-000000000000"
+NIL_HOST="does-not-exist"
+NIL_FP="SHA256:nonexistent"
+
+sweep() {
+    local method="$1" path="$2" body="${3:-}"
+    local code
+    if [ -n "$body" ]; then
+        code=$(curl -s -o "$RESP_BODY" -w '%{http_code}' -b "$COOKIE_JAR" \
+            -H 'Content-Type: application/json' -X "$method" -d "$body" \
+            "${BASE_URL}${path}")
+    else
+        code=$(curl -s -o "$RESP_BODY" -w '%{http_code}' -b "$COOKIE_JAR" \
+            -X "$method" "${BASE_URL}${path}")
+    fi
+    if [ "$code" -ge 500 ]; then
+        echo "  Response body (first 500 bytes):"
+        head -c 500 "$RESP_BODY"; echo
+        fail "$method $path → ${code} (server-side crash)"
+    fi
+    pass "$method $path → $code"
+}
+
+# Auth/me variant
+sweep GET    /api/admins/me
+
+# Servers
+sweep GET    /api/servers
+sweep GET    "/api/servers/${NIL_HOST}"
+sweep GET    "/api/servers/${NIL_HOST}/collector-key"
+sweep GET    "/api/servers/${NIL_HOST}/sessions"
+sweep GET    "/api/servers/${NIL_HOST}/sessions/history"
+sweep GET    "/api/servers/${NIL_HOST}/sshd-audit"
+sweep POST   /api/servers '{}'
+sweep POST   "/api/servers/${NIL_HOST}/provision" '{"ssh_user":"root"}'
+sweep PUT    "/api/servers/${NIL_HOST}" '{}'
+sweep PUT    "/api/servers/${NIL_HOST}/disable"
+sweep PUT    "/api/servers/${NIL_HOST}/enable"
+sweep DELETE "/api/servers/${NIL_HOST}"
+sweep POST   "/api/servers/${NIL_HOST}/scan"
+sweep POST   "/api/servers/${NIL_HOST}/rotate-key"
+sweep POST   "/api/servers/${NIL_HOST}/sync"
+sweep POST   "/api/servers/${NIL_HOST}/sessions/refresh"
+
+# Keys
+sweep GET    /api/keys
+sweep GET    "/api/keys/search?q=x"
+sweep GET    "/api/keys/get/${NIL_FP}"
+sweep POST   "/api/keys/validate/${NIL_FP}" '{}'
+sweep POST   "/api/keys/revoke/${NIL_FP}"   '{"reason":"smoke"}'
+sweep POST   "/api/keys/assign/${NIL_FP}"   '{"owner":"smoke"}'
+sweep POST   "/api/keys/set-expiry/${NIL_FP}"   '{"hours":24}'
+sweep POST   "/api/keys/remove-expiry/${NIL_FP}" '{}'
+sweep POST   /api/keys/bulk-validate '{"fingerprints":[]}'
+sweep POST   /api/keys/bulk-revoke   '{"fingerprints":[],"reason":"smoke"}'
+
+# Access
+sweep GET    /api/access
+sweep GET    "/api/access/${NIL_UUID}"
+sweep GET    /api/access/deployed-users
+sweep POST   /api/access/grant         '{}'
+sweep POST   /api/access/deploy        '{}'
+sweep POST   /api/access/grant-group   '{}'
+sweep POST   /api/access/revoke-group  '{}'
+sweep PUT    /api/access/change-group  '{}'
+sweep POST   /api/access/lock-user     '{}'
+sweep POST   /api/access/unlock-user   '{}'
+sweep POST   /api/access/request       '{}'
+sweep POST   "/api/access/${NIL_UUID}/approve" '{}'
+sweep POST   "/api/access/${NIL_UUID}/reject"  '{}'
+sweep POST   "/api/access/${NIL_UUID}/revoke"  '{}'
+
+# Admins
+sweep GET    /api/admins
+sweep POST   /api/admins '{}'
+sweep PUT    "/api/admins/${NIL_HOST}"          '{}'
+sweep PUT    "/api/admins/${NIL_HOST}/password" '{"password":"x"}'
+sweep PUT    "/api/admins/${NIL_HOST}/disable"
+sweep PUT    "/api/admins/${NIL_HOST}/enable"
+sweep DELETE "/api/admins/${NIL_HOST}"
+sweep PUT    "/api/admins/${NIL_HOST}/alerts"   '{"alerts_enabled":true}'
+
+# Audit + system
+sweep GET    /api/audit
+sweep GET    /api/system/status
+sweep GET    /api/system/config
+sweep POST   /api/system/scan
+sweep PUT    /api/system/config '{}'
+sweep POST   /api/system/test-smtp '{}'
+
+# ---------------------------------------------------------------------------
+section "Step 6 — logout invalidates the session"
+# ---------------------------------------------------------------------------
+code=$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" -c "$COOKIE_JAR" \
+    -X POST "${BASE_URL}/api/auth/logout")
+[ "$code" = "200" ] || fail "POST /api/auth/logout — expected 200, got $code"
+pass "POST /api/auth/logout → 200"
+
+code=$(curl -s -o /dev/null -w '%{http_code}' -b "$COOKIE_JAR" "${BASE_URL}/api/auth/me")
+[ "$code" = "401" ] || fail "GET /api/auth/me after logout — expected 401, got $code (session not invalidated)"
+pass "GET /api/auth/me after logout → 401 (server-side session cleared)"
 
 echo ""
 echo "${GREEN}All smoke assertions passed.${RST}"


### PR DESCRIPTION
## Summary

Re-opening of #416 — GitHub auto-closed it when the base branch \`test/smoke-container-boot\` was deleted on the merge of #412. Same head branch, same commits, rebased on main.

Grows the smoke test from PR #412's 3 HTTP calls into a real container-level acceptance gate:

| Step | Check | Catches |
|---|---|---|
| 2 | unauth /me → 401, login → 200, auth /me payload | (unchanged) |
| 3 | \`GET /api/servers\` → 200 \`[]\` | Schema not applied, missing pg_extension, JSON serializer crash |
| 4 | SPA fallback: \`/\` and \`/servers/xyz\` return same HTML | \`try_files\` missing in nginx |
| 5 | **56-route sweep** without 5xx | SQL typos, KeyError, serializer crashes on Postgres types |
| 6 | logout → 200, then /me → 401 | Server-side session destruction broken |
| workflow | supervisorctl status shows all 4 services RUNNING | Service crash-loop |
| workflow | first-boot logs contain \`First startup detected\` | Bootstrap detection broken |
| workflow | down (no -v) + up + re-login admin | **bootstrap.sh re-running initdb** on second boot |
| workflow | second-boot logs contain \`Normal startup (existing data)\` | Bootstrap took idempotent path |

Bonus: \`supervisorctl status\` now works at all (added \`[unix_http_server]\` / \`[rpcinterface]\` / \`[supervisorctl]\` sections — was missing).

Closes #415