### PR TITLE
test(smoke): tier 1 security posture — 7 runtime checks + nginx hardening headers

### DIFF
--- a/.github/workflows/smoke-container.yml
+++ b/.github/workflows/smoke-container.yml
@@ -63,6 +63,86 @@ jobs:
       - name: Run smoke HTTP assertions (first boot)
         run: bash tests/smoke/run.sh http://127.0.0.1:8080 admin smoke-admin-pw
 
+      - name: Assert no secret leaks into container logs
+        # docker compose logs aggregates supervisord + every service. A
+        # debug print(os.environ) or logging.info(config) would dump
+        # POSTGRES_PASSWORD or FLASK_SECRET_KEY here — the kind of
+        # leakage an ANSSI audit would never forgive. The .env values
+        # used by the job are unique fixed strings so grep is reliable.
+        run: |
+          logs=$(docker compose logs --no-color 2>&1)
+          for secret in smoke-postgres-pw smoke-flask-secret-key-not-for-prod smoke-admin-pw; do
+            if printf '%s' "$logs" | grep -qF "$secret"; then
+              echo "::error::secret value leaked into container logs: $secret"
+              printf '%s' "$logs" | grep -nF "$secret" | head -5
+              exit 1
+            fi
+          done
+          echo "No secret value detected in container logs."
+
+      - name: Assert Postgres port 5432 is NOT reachable from the host
+        # A regression on docker-compose.yml (e.g. `ports: "5432:5432"`)
+        # would expose the database to the public network. Only the Nginx
+        # port should answer on the host.
+        run: |
+          if nc -z -w 2 127.0.0.1 5432 2>/dev/null; then
+            echo "::error::Postgres is reachable on 127.0.0.1:5432 — port should NOT be published"
+            exit 1
+          fi
+          if ! nc -z -w 2 127.0.0.1 8080 2>/dev/null; then
+            echo "::error::Nginx is NOT reachable on 127.0.0.1:8080 (sanity check failed)"
+            exit 1
+          fi
+          echo "Postgres 5432 closed, Nginx 8080 open — port surface correct."
+
+      - name: Assert /data permissions match CLAUDE.md spec
+        # /data/pg                    chmod 700 postgres:postgres   PGDATA, must not be world-readable
+        # /data/keys/per-server       chmod 700 nobody:nobody       contains private SSH keys (one per server)
+        # /data/keys/known_hosts      chmod 644 nobody:*            public host-key fingerprints
+        run: |
+          ex() { docker compose exec -T sam-server "$@"; }
+          check() {
+              local path="$1" exp_mode="$2" exp_user="$3"
+              local mode user
+              mode=$(ex stat -c '%a' "$path" 2>/dev/null)
+              user=$(ex stat -c '%U' "$path" 2>/dev/null)
+              if [ "$mode" != "$exp_mode" ] || [ "$user" != "$exp_user" ]; then
+                  echo "::error::${path}: expected ${exp_mode} ${exp_user}, got ${mode} ${user}"
+                  return 1
+              fi
+              echo "  OK ${path}: ${mode} ${user}"
+          }
+          set -e
+          check /data/pg 700 postgres
+          check /data/keys/per-server 700 nobody
+          check /data/keys/known_hosts 644 nobody
+
+      - name: Assert process users (Flask=nobody, postgres=postgres, never root)
+        # supervisord.conf declares user=nobody for the flask program and
+        # user=postgres for postgresql. A regression removing those lines
+        # would make Flask run as root — full container takeover on any
+        # RCE. nginx legitimately runs its master as root + workers as
+        # nginx/nobody; that's fine.
+        run: |
+          # Alpine ships BusyBox ps which doesn't support --no-headers; strip
+          # the first line ourselves. Column layout under `-o user,comm` is
+          # USER followed by the binary name, whitespace-separated.
+          ps_lines=$(docker compose exec -T sam-server ps -eo user,comm | tail -n +2)
+          echo "$ps_lines"
+          # Flask: python3 web.py — must be nobody
+          flask_users=$(printf '%s\n' "$ps_lines" | awk '/python3/ {print $1}' | sort -u)
+          [ "$flask_users" = "nobody" ] || {
+              echo "::error::Flask running as '$flask_users' — expected 'nobody'"
+              exit 1
+          }
+          # postgres: the main postmaster process must run as postgres
+          pg_users=$(printf '%s\n' "$ps_lines" | awk '$2=="postgres" {print $1}' | sort -u)
+          [ "$pg_users" = "postgres" ] || {
+              echo "::error::postgres running as '$pg_users' — expected 'postgres'"
+              exit 1
+          }
+          echo "Process users OK: flask=nobody, postgres=postgres."
+
       - name: Assert supervisord shows all 4 services RUNNING
         # postgresql, flask, nginx and crond are all declared in
         # supervisord.conf. Any STARTING/EXITED/FATAL line means the

--- a/nginx.conf.http.template
+++ b/nginx.conf.http.template
@@ -16,6 +16,18 @@ http {
         listen {{NGINX_PORT}};
         server_name _;
 
+        # Hardening response headers (applied to every response, including 4xx/5xx).
+        # X-Frame-Options DENY      → anti-clickjacking (legacy browsers; CSP frame-ancestors covers modern ones).
+        # X-Content-Type-Options    → forbids MIME-sniffing on responses (defence-in-depth).
+        # Referrer-Policy           → never send full URL on cross-origin navigations.
+        # Content-Security-Policy   → SPA needs 'self' for scripts/img/style; 'unsafe-inline' on style is
+        #                             unavoidable with Vue scoped styles. frame-ancestors 'none' is the
+        #                             modern equivalent of X-Frame-Options DENY.
+        add_header X-Frame-Options          "DENY" always;
+        add_header X-Content-Type-Options   "nosniff" always;
+        add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy  "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+
         # Flask API — proxy to 127.0.0.1:5000
         location /api/ {
             proxy_pass         http://127.0.0.1:5000;

--- a/nginx.conf.https.template
+++ b/nginx.conf.https.template
@@ -33,6 +33,12 @@ http {
         ssl_session_tickets  off;
         add_header           Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
+        # Hardening response headers — see nginx.conf.http.template for rationale.
+        add_header X-Frame-Options          "DENY" always;
+        add_header X-Content-Type-Options   "nosniff" always;
+        add_header Referrer-Policy          "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy  "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+
         # Flask API — proxy to 127.0.0.1:5000
         location /api/ {
             proxy_pass         http://127.0.0.1:5000;

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -243,6 +243,73 @@ sweep PUT    /api/system/config '{}'
 sweep POST   /api/system/test-smtp '{}'
 
 # ---------------------------------------------------------------------------
+section "Step 5b — security headers (cookie flags + JSON Content-Type + nginx hardening)"
+# ---------------------------------------------------------------------------
+# These three sub-checks are inexpensive (one curl each) and cover the most
+# dangerous silent regressions a Vue SPA / Flask container can ship with.
+
+# --- Cookie flags on the session cookie ---
+# HttpOnly is set unconditionally; SameSite=Lax is always set; Secure is set
+# only when the container was started with NGINX_TLS_* (the smoke detects this
+# from BASE_URL).
+COOKIE_HEADER=$(curl $CURL_FLAGS -D - -o /dev/null \
+    -H 'Content-Type: application/json' -X POST \
+    -d "$login_body" "${BASE_URL}/api/auth/login" | grep -i '^set-cookie:' || true)
+echo "  Set-Cookie line: $(printf '%s' "$COOKIE_HEADER" | head -c 200)"
+
+case "$COOKIE_HEADER" in
+    *HttpOnly*) pass "session cookie has HttpOnly" ;;
+    *)          fail "session cookie missing HttpOnly — XSS could exfiltrate it" ;;
+esac
+case "$COOKIE_HEADER" in
+    *SameSite=Lax*|*SameSite=Strict*) pass "session cookie has SameSite Lax/Strict" ;;
+    *)                                fail "session cookie missing SameSite" ;;
+esac
+case "$BASE_URL" in
+    https://*)
+        case "$COOKIE_HEADER" in
+            *Secure*) pass "session cookie has Secure (HTTPS mode)" ;;
+            *)        fail "session cookie missing Secure under HTTPS — downgrade attack possible" ;;
+        esac
+        ;;
+    *)
+        # HTTP mode: Secure must NOT be set (the browser would drop the cookie).
+        case "$COOKIE_HEADER" in
+            *Secure*) fail "session cookie has Secure under HTTP — browser will drop it" ;;
+            *)        pass "session cookie does not have Secure under HTTP (expected)" ;;
+        esac
+        ;;
+esac
+
+# --- Content-Type: application/json on the API surface ---
+# A regression where an endpoint returns text/html (debug print, leaked
+# traceback page) would be invisible to a JSON-only frontend until the user
+# hits a parse error.
+for api_path in /api/auth/me /api/servers /api/keys /api/audit /api/system/status; do
+    ctype=$(curl $CURL_FLAGS -D - -o /dev/null -b "$COOKIE_JAR" "${BASE_URL}${api_path}" \
+        | grep -i '^content-type:' | head -1)
+    case "$ctype" in
+        *application/json*) pass "Content-Type on ${api_path}: application/json" ;;
+        *)                  fail "Content-Type on ${api_path} is not JSON — got: $ctype" ;;
+    esac
+done
+
+# --- Nginx hardening response headers on / (covers /api too because they're
+# declared at server level in both nginx templates) ---
+HEADERS=$(curl $CURL_FLAGS -D - -o /dev/null "${BASE_URL}/")
+for header in \
+    "X-Frame-Options: DENY" \
+    "X-Content-Type-Options: nosniff" \
+    "Referrer-Policy:" \
+    "Content-Security-Policy:"; do
+    if printf '%s' "$HEADERS" | grep -qi "^${header}"; then
+        pass "nginx serves header '${header}'"
+    else
+        fail "nginx is NOT serving '${header}' — hardening regression in the template"
+    fi
+done
+
+# ---------------------------------------------------------------------------
 section "Step 6 — RBAC roundtrip (sysadmin / operator / viewer enforced at runtime)"
 # ---------------------------------------------------------------------------
 # Pytest covers `require_role` with mocks. This step proves the wiring


### PR DESCRIPTION
## Summary

Seven security-posture checks the smoke test couldn't see before. Each one catches a class of silent regression that mocked pytest cannot reach.

### tests/smoke/run.sh — new Step 5b

| Check | What |
|---|---|
| A | Session cookie has \`HttpOnly\` + \`SameSite\` always; \`Secure\` only on HTTPS, must be absent on HTTP |
| B | 5 representative \`/api/\` routes return \`Content-Type: application/json\` |
| C | Nginx serves \`X-Frame-Options: DENY\`, \`X-Content-Type-Options: nosniff\`, \`Referrer-Policy\`, \`Content-Security-Policy\` |

### .github/workflows/smoke-container.yml — four new steps

| Check | What |
|---|---|
| D | \`docker compose logs\` contains none of \`POSTGRES_PASSWORD\`, \`FLASK_SECRET_KEY\`, \`ADMIN_PASSWORD\` |
| E | Postgres 5432 not reachable from host; Nginx 8080 reachable |
| F | \`/data/pg\` 700 postgres, \`/data/keys/per-server\` 700 nobody, \`/data/keys/known_hosts\` 644 nobody |
| G | Flask runs as \`nobody\`, postgres as \`postgres\` (never root) |

### Bonus fix uncovered by Check C

Both nginx templates were missing the four hardening headers. Added \`add_header … always\` for each in the server block — applies to 4xx/5xx too. CSP intentionally permissive for Vue scoped styles (\`style-src 'unsafe-inline'\`).

## Test plan

- [x] Local podman HTTP run: cookie excludes Secure (expected), 5 Content-Type JSON OK, 4 nginx headers served, 0 leaks, 5432 closed / 8080 open, perms exact, flask=nobody / postgres=postgres
- [ ] CI green on both smoke and smoke-https jobs

Closes #424