### PR TITLE
feat(provision): detect sshd AllowGroups/AllowUsers and refuse with clear error

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,56 @@ La sortie doit inclure les commandes SAM (`/usr/local/bin/sam-*`) sans demande d
 
 `provision-host.sh` installe également les règles sudoers dédiées aux groupes SAM (`sam-operator`, `sam-pkg`, `sam-root`) — voir section [SAM sudo groups](#workflow--sam-sudo-groups). Toutes ces règles sont validées par `visudo -c` avant installation et exigent `PASSWD:` (jamais NOPASSWD pour les utilisateurs SAM). Le bloc sshd `Match Group sam-users` est aussi posé pour interdire l'authentification par mot de passe aux utilisateurs créés via `sam-add`.
 
+### 4. Known limitations — sshd AllowGroups/AllowUsers
+
+Si l'hôte distant a configuré les directives `AllowGroups` ou `AllowUsers` dans `/etc/ssh/sshd_config` (ou dans `/etc/ssh/sshd_config.d/*.conf`), le provisionnement de SAM échouera **si `audit-collector` n'est pas autorisé**.
+
+#### Contexte technique
+
+Ces directives OpenSSH sont **globales uniquement** et **non overridables via Match blocks**. SAM ne peut donc pas les contourner avec une configuration sshd dédiée. Le script `provision-host.sh` détecte cette limitation automatiquement (#438) et refusera de terminer le provisionnement.
+
+#### Symptômes
+
+Dans les logs sshd de l'hôte distant (via `journalctl -u sshd` ou `/var/log/auth.log`) :
+
+```
+User audit-collector from <SAM-IP> not allowed because none of user's groups are listed in AllowGroups
+input_userauth_request: invalid user audit-collector [preauth]
+```
+
+Côté SAM : le provisionnement initial peut réussir (l'utilisateur est créé), mais **chaque scan échouera immédiatement à l'authentification SSH**. Le serveur est marqué comme `UNREACHABLE` après 3 échecs consécutifs.
+
+#### Solution
+
+**Avant de provisionner** (ou lors du re-provisionnement), un administrateur doit manuellement autoriser `audit-collector` :
+
+**Option 1 — AllowGroups** : ajouter `audit-collector` à l'un des groupes autorisés
+
+```bash
+# Sur l'hôte distant (en root)
+usermod -aG <allowed-group> audit-collector
+```
+
+**Option 2 — AllowUsers** : ajouter `audit-collector` à la liste dans `/etc/ssh/sshd_config`
+
+```bash
+# Éditer /etc/ssh/sshd_config
+AllowUsers existing-user1 existing-user2 audit-collector
+
+# Recharger sshd
+systemctl reload sshd
+```
+
+Après modification, relancer le provisionnement SAM (le script détectera que la contrainte est levée et continuera normalement).
+
+#### Détection automatique
+
+Depuis #438, `provision-host.sh` :
+1. Parse `/etc/ssh/sshd_config` et tous les `sshd_config.d/*.conf` (avec fallback gracieux si absents)
+2. Extrait les directives `AllowGroups` et `AllowUsers` (insensible à la casse, supporte multiple directives)
+3. Vérifie que `audit-collector` passe les contraintes (groupe OU utilisateur — les deux sont en AND logique côté OpenSSH)
+4. **Exit 1** avec un message clair si la contrainte n'est pas satisfaite (le message remonte via SSH stderr → API → modal UI)
+
 ---
 
 ## Workflow — Traitement des clés PENDING_REVIEW

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -326,6 +326,8 @@ Actions : crée l'utilisateur collector, déploie la clé publique, crée sudoer
 
 **Strict cleanup d'authorized_keys (#429)** — `provision-host.sh` **réécrit** `~${COLLECTOR_USER}/.ssh/authorized_keys` avec exactement la pubkey passée en argument (printf > tmp + chmod 600 + chown + `mv -f`), au lieu d'append. Le compte audit-collector est dédié SAM (pas de shell humain), donc toute clé pré-existante est soit une résidue d'une install précédente, soit un ajout manuel non géré — dans les deux cas à nettoyer. La rotation `ssh.rotate_per_server_key` applique la même sémantique via `_replace_authorized_keys_remote`.
 
+**AllowGroups/AllowUsers detection (#438)** — `provision-host.sh` parse `/etc/ssh/sshd_config` + `sshd_config.d/*.conf`, extrait directives `AllowGroups` et `AllowUsers` (insensibles à la casse, supporte multiple). Vérifie que `audit-collector` passe les contraintes (intersection groupes pour AllowGroups, exact match pour AllowUsers). Si échec, exit 1 avec message clair indiquant l'action manuelle requise (usermod -aG ou édition sshd_config). Wildcards AllowGroups (ex: `*admin`) traités comme non-match (false positive accepté — admin voit le message et adapte).
+
 Permissions appliquées (#260) :
 - `chmod 700 /home/${COLLECTOR_USER}` — home non listable par les autres utilisateurs
 - Scripts SAM déployés avec `-m 750` (root:root) — non lisibles/exécutables par les non-root

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -77,4 +77,82 @@ printf "${COLLECTOR_USER} ALL=(root) NOPASSWD: /usr/local/bin/sam-self-update *\
 chmod 440 "${SUDOERS_FILE}"
 echo "[provision] Sudoers configured in ${SUDOERS_FILE}."
 
+# 5. Check sshd AllowGroups/AllowUsers directives
+# OpenSSH AllowGroups/AllowUsers are global-only directives (not overridable via Match blocks).
+# If present, they restrict which users can authenticate via SSH. Detect and fail early.
+SSHD_CONFIG="/etc/ssh/sshd_config"
+SSHD_CONFIG_DIR="/etc/ssh/sshd_config.d"
+
+# Parse all sshd config files (main + includes), strip comments and blank lines
+SSHD_ALL_LINES=""
+if [ -f "${SSHD_CONFIG}" ]; then
+    SSHD_ALL_LINES="$(grep -vE '^\s*(#|$)' "${SSHD_CONFIG}" 2>/dev/null || true)"
+fi
+if [ -d "${SSHD_CONFIG_DIR}" ]; then
+    for conf_file in "${SSHD_CONFIG_DIR}"/*.conf; do
+        [ -f "${conf_file}" ] || continue
+        SSHD_ALL_LINES="${SSHD_ALL_LINES}
+$(grep -vE '^\s*(#|$)' "${conf_file}" 2>/dev/null || true)"
+    done
+fi
+
+# Extract AllowGroups directives (case-insensitive, can appear multiple times)
+ALLOW_GROUPS=$(echo "${SSHD_ALL_LINES}" | grep -iE '^\s*AllowGroups\s+' | sed -E 's/^\s*AllowGroups\s+//i' || true)
+
+# Extract AllowUsers directives (case-insensitive, can appear multiple times)
+ALLOW_USERS=$(echo "${SSHD_ALL_LINES}" | grep -iE '^\s*AllowUsers\s+' | sed -E 's/^\s*AllowUsers\s+//i' || true)
+
+# Check AllowGroups constraint
+if [ -n "${ALLOW_GROUPS}" ]; then
+    # Get all groups of the collector user
+    COLLECTOR_GROUPS=$(id -Gn "${COLLECTOR_USER}" 2>/dev/null || echo "")
+
+    # Build union of all allowed groups (multiple directives → union)
+    ALL_ALLOWED_GROUPS=$(echo "${ALLOW_GROUPS}" | tr '\n' ' ')
+
+    # Check if any collector group is in the allowed list
+    MATCH_FOUND=false
+    for user_group in ${COLLECTOR_GROUPS}; do
+        for allowed_group in ${ALL_ALLOWED_GROUPS}; do
+            # Exact match only (wildcards like *admin are not expanded)
+            if [ "${user_group}" = "${allowed_group}" ]; then
+                MATCH_FOUND=true
+                break 2
+            fi
+        done
+    done
+
+    if [ "${MATCH_FOUND}" = "false" ]; then
+        printf "ERROR: sshd is configured with 'AllowGroups %s' which restricts SSH access.\n" "${ALL_ALLOWED_GROUPS}" >&2
+        printf "%s is in groups: %s\n" "${COLLECTOR_USER}" "${COLLECTOR_GROUPS}" >&2
+        printf "Action required: add %s to one of the AllowGroups manually, e.g.:\n" "${COLLECTOR_USER}" >&2
+        printf "    usermod -aG <allowed-group> %s\n" "${COLLECTOR_USER}" >&2
+        printf "Then re-run SAM provisioning for this server.\n" >&2
+        exit 1
+    fi
+fi
+
+# Check AllowUsers constraint
+if [ -n "${ALLOW_USERS}" ]; then
+    # Build union of all allowed users
+    ALL_ALLOWED_USERS=$(echo "${ALLOW_USERS}" | tr '\n' ' ')
+
+    # Check if collector user is in the allowed list (exact match)
+    USER_MATCH_FOUND=false
+    for allowed_user in ${ALL_ALLOWED_USERS}; do
+        if [ "${COLLECTOR_USER}" = "${allowed_user}" ]; then
+            USER_MATCH_FOUND=true
+            break
+        fi
+    done
+
+    if [ "${USER_MATCH_FOUND}" = "false" ]; then
+        printf "ERROR: sshd is configured with 'AllowUsers %s' which restricts SSH access.\n" "${ALL_ALLOWED_USERS}" >&2
+        printf "Action required: add %s to AllowUsers in %s:\n" "${COLLECTOR_USER}" "${SSHD_CONFIG}" >&2
+        printf "    AllowUsers %s %s\n" "${ALL_ALLOWED_USERS}" "${COLLECTOR_USER}" >&2
+        printf "Then reload sshd and re-run SAM provisioning.\n" >&2
+        exit 1
+    fi
+fi
+
 echo "[provision] Host ready for SSH collection by ${COLLECTOR_USER}."

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -467,34 +467,36 @@ fi
 # so SAM has no way to bypass them — the admin must edit sshd_config manually.
 section "Phase 8 — sshd AllowGroups / AllowUsers detection"
 
-SSHD_MAIN="/etc/ssh/sshd_config"
-SSHD_BACKUP="/tmp/sam-it/sshd_config.before-phase8"
-cp "$SSHD_MAIN" "$SSHD_BACKUP"
+# Use a drop-in file rather than mutating the main sshd_config — provision-host.sh
+# reads both, and some distros (openSUSE Leap 16+) ship without /etc/ssh/sshd_config
+# at the root and rely entirely on /etc/ssh/sshd_config.d/ drop-ins.
+mkdir -p /etc/ssh/sshd_config.d
+SSHD_DROPIN="/etc/ssh/sshd_config.d/99-phase8-test.conf"
 
-restore_sshd() {
-    cp "$SSHD_BACKUP" "$SSHD_MAIN"
+cleanup_dropin() {
+    rm -f "$SSHD_DROPIN"
 }
 
 # --- 8a. AllowGroups that excludes audit-collector -----------------------
 # audit-collector belongs only to its own primary group at this point;
 # 'wheel' is unrelated, so detection must trip.
-printf '\nAllowGroups wheel\n' >> "$SSHD_MAIN"
+printf 'AllowGroups wheel\n' > "$SSHD_DROPIN"
 phase8a_out=$(bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER" 2>&1 1>/dev/null) && phase8a_rc=0 || phase8a_rc=$?
 if [ "$phase8a_rc" -ne 0 ]; then
     _pass "AllowGroups exclusion → provision-host.sh exited $phase8a_rc (non-zero, as expected)"
 else
-    restore_sshd
+    cleanup_dropin
     _fail "AllowGroups exclusion → provision-host.sh unexpectedly exited 0"
 fi
 case "$phase8a_out" in
     *"AllowGroups"*"restricts SSH access"*) _pass "stderr mentions AllowGroups restriction" ;;
-    *) restore_sshd; _fail "stderr did not include the expected AllowGroups error message: $phase8a_out" ;;
+    *) cleanup_dropin; _fail "stderr did not include the expected AllowGroups error message: $phase8a_out" ;;
 esac
 case "$phase8a_out" in
     *"usermod -aG"*) _pass "stderr suggests usermod -aG remediation" ;;
-    *) restore_sshd; _fail "stderr did not include usermod -aG remediation hint" ;;
+    *) cleanup_dropin; _fail "stderr did not include usermod -aG remediation hint" ;;
 esac
-restore_sshd
+cleanup_dropin
 
 # --- 8b. AllowGroups that includes a collector group ---------------------
 # Add audit-collector to 'wheel' (creating the group first on distros that
@@ -503,30 +505,30 @@ if ! getent group wheel >/dev/null 2>&1; then
     groupadd wheel
 fi
 usermod -aG wheel "$COLLECTOR_USER"
-printf '\nAllowGroups wheel\n' >> "$SSHD_MAIN"
+printf 'AllowGroups wheel\n' > "$SSHD_DROPIN"
 assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"
 gpasswd -d "$COLLECTOR_USER" wheel >/dev/null 2>&1 || true
-restore_sshd
+cleanup_dropin
 
 # --- 8c. AllowUsers that excludes audit-collector ------------------------
-printf '\nAllowUsers root someoneelse\n' >> "$SSHD_MAIN"
+printf 'AllowUsers root someoneelse\n' > "$SSHD_DROPIN"
 phase8c_out=$(bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER" 2>&1 1>/dev/null) && phase8c_rc=0 || phase8c_rc=$?
 if [ "$phase8c_rc" -ne 0 ]; then
     _pass "AllowUsers exclusion → provision-host.sh exited $phase8c_rc (non-zero, as expected)"
 else
-    restore_sshd
+    cleanup_dropin
     _fail "AllowUsers exclusion → provision-host.sh unexpectedly exited 0"
 fi
 case "$phase8c_out" in
     *"AllowUsers"*"restricts SSH access"*) _pass "stderr mentions AllowUsers restriction" ;;
-    *) restore_sshd; _fail "stderr did not include the expected AllowUsers error message: $phase8c_out" ;;
+    *) cleanup_dropin; _fail "stderr did not include the expected AllowUsers error message: $phase8c_out" ;;
 esac
-restore_sshd
+cleanup_dropin
 
 # --- 8d. AllowUsers that includes audit-collector ------------------------
-printf '\nAllowUsers root %s\n' "$COLLECTOR_USER" >> "$SSHD_MAIN"
+printf 'AllowUsers root %s\n' "$COLLECTOR_USER" > "$SSHD_DROPIN"
 assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"
-restore_sshd
+cleanup_dropin
 
 # --- 8e. No restriction directives — baseline still passes ---------------
 assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -458,4 +458,77 @@ else
     _pass "/etc/sam-provision-version not updated (rollback respected)"
 fi
 
+# ---------------------------------------------------------------------------
+# Phase 8 — sshd AllowGroups / AllowUsers detection (#438)
+# ---------------------------------------------------------------------------
+# provision-host.sh must refuse to provision when sshd is configured with
+# AllowGroups or AllowUsers directives that exclude the collector user.
+# These OpenSSH directives are global-only (not overridable in Match blocks),
+# so SAM has no way to bypass them — the admin must edit sshd_config manually.
+section "Phase 8 — sshd AllowGroups / AllowUsers detection"
+
+SSHD_MAIN="/etc/ssh/sshd_config"
+SSHD_BACKUP="/tmp/sam-it/sshd_config.before-phase8"
+cp "$SSHD_MAIN" "$SSHD_BACKUP"
+
+restore_sshd() {
+    cp "$SSHD_BACKUP" "$SSHD_MAIN"
+}
+
+# --- 8a. AllowGroups that excludes audit-collector -----------------------
+# audit-collector belongs only to its own primary group at this point;
+# 'wheel' is unrelated, so detection must trip.
+printf '\nAllowGroups wheel\n' >> "$SSHD_MAIN"
+phase8a_out=$(bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER" 2>&1 1>/dev/null) && phase8a_rc=0 || phase8a_rc=$?
+if [ "$phase8a_rc" -ne 0 ]; then
+    _pass "AllowGroups exclusion → provision-host.sh exited $phase8a_rc (non-zero, as expected)"
+else
+    restore_sshd
+    _fail "AllowGroups exclusion → provision-host.sh unexpectedly exited 0"
+fi
+case "$phase8a_out" in
+    *"AllowGroups"*"restricts SSH access"*) _pass "stderr mentions AllowGroups restriction" ;;
+    *) restore_sshd; _fail "stderr did not include the expected AllowGroups error message: $phase8a_out" ;;
+esac
+case "$phase8a_out" in
+    *"usermod -aG"*) _pass "stderr suggests usermod -aG remediation" ;;
+    *) restore_sshd; _fail "stderr did not include usermod -aG remediation hint" ;;
+esac
+restore_sshd
+
+# --- 8b. AllowGroups that includes a collector group ---------------------
+# Add audit-collector to 'wheel' (creating the group first on distros that
+# do not ship it), then declare 'AllowGroups wheel' — provision must pass.
+if ! getent group wheel >/dev/null 2>&1; then
+    groupadd wheel
+fi
+usermod -aG wheel "$COLLECTOR_USER"
+printf '\nAllowGroups wheel\n' >> "$SSHD_MAIN"
+assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"
+gpasswd -d "$COLLECTOR_USER" wheel >/dev/null 2>&1 || true
+restore_sshd
+
+# --- 8c. AllowUsers that excludes audit-collector ------------------------
+printf '\nAllowUsers root someoneelse\n' >> "$SSHD_MAIN"
+phase8c_out=$(bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER" 2>&1 1>/dev/null) && phase8c_rc=0 || phase8c_rc=$?
+if [ "$phase8c_rc" -ne 0 ]; then
+    _pass "AllowUsers exclusion → provision-host.sh exited $phase8c_rc (non-zero, as expected)"
+else
+    restore_sshd
+    _fail "AllowUsers exclusion → provision-host.sh unexpectedly exited 0"
+fi
+case "$phase8c_out" in
+    *"AllowUsers"*"restricts SSH access"*) _pass "stderr mentions AllowUsers restriction" ;;
+    *) restore_sshd; _fail "stderr did not include the expected AllowUsers error message: $phase8c_out" ;;
+esac
+restore_sshd
+
+# --- 8d. AllowUsers that includes audit-collector ------------------------
+printf '\nAllowUsers root %s\n' "$COLLECTOR_USER" >> "$SSHD_MAIN"
+assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"
+restore_sshd
+
+# --- 8e. No restriction directives — baseline still passes ---------------
+assert_exit_zero bash provision-host.sh "$PUBKEY" "$COLLECTOR_USER"
+
 section "All integration assertions passed on $ID $VERSION_ID"


### PR DESCRIPTION
## Summary
- \`provision-host.sh\` parses \`/etc/ssh/sshd_config\` + drop-ins for \`AllowGroups\` / \`AllowUsers\` directives
- If \`AllowGroups\` excludes audit-collector (no group intersection) → exits 1 with actionable message (\`usermod -aG <group> audit-collector\`)
- If \`AllowUsers\` excludes audit-collector → exits 1 with actionable message (edit AllowUsers in sshd_config)
- Message stderr → SSHScriptError → 422 \`details\` → modal UI (existing #433 plumbing)
- README "Known limitations" section explains the manual remediation

## Production trigger
Host \`ns7\` had \`AllowGroups\` set; SAM provisioned successfully but every subsequent scan failed with paramiko \`AuthenticationException\` (\`User audit-collector ... not allowed because none of user's groups are listed in AllowGroups\`). With this change, the failure is caught at provision time with a clear message instead of being silently broken.

## Test plan
- [x] Manual: AllowGroups restricts → fails with message
- [x] Manual: AllowGroups allows (user in group) → passes
- [x] Manual: AllowUsers restricts → fails with message
- [x] Manual: AllowUsers allows → passes
- [x] Manual: union across main config + drop-ins → respected
- [x] Manual: neither directive set → passes (no regression)

## Pairs with
- #437 (PR #439): once that lands, the auth failure on already-provisioned hosts surfaces as a clean 422 in the UI

Closes #438