### PR TITLE
fix(provision): support root SSH login on hosts without sudo

### DIFF
--- a/app/ssh.py
+++ b/app/ssh.py
@@ -1494,14 +1494,23 @@ def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 
         sftp.chmod("/tmp/sam-provision.sh", 0o700)
         sftp.close()
 
-        # Step 5 - execute via sudo -S (password on stdin)
-        cmd = (
-            f"sudo -S bash /tmp/sam-provision.sh "
-            f"{shlex.quote(pubkey)} {shlex.quote(SSH_USER)}"
-        )
+        # Step 5 - execute the script, escalating only when needed.
+        # Minimal images (Debian netinst, Alpine) often ship no sudo at all;
+        # wrapping in sudo there fails with exit 127 even though the SSH user
+        # is already root and needs no escalation.
+        _, id_out, _ = client.exec_command("id -u", timeout=15)
+        is_root = id_out.read().decode(errors="replace").strip() == "0"
+
+        script_args = f"{shlex.quote(pubkey)} {shlex.quote(SSH_USER)}"
+        if is_root:
+            cmd = f"bash /tmp/sam-provision.sh {script_args}"
+        else:
+            cmd = f"sudo -S bash /tmp/sam-provision.sh {script_args}"
+
         stdin, stdout, stderr = client.exec_command(cmd, timeout=60)
-        stdin.write(ssh_password + "\n")
-        stdin.flush()
+        if not is_root:
+            stdin.write(ssh_password + "\n")
+            stdin.flush()
         stdin.channel.shutdown_write()
 
         exit_code = stdout.channel.recv_exit_status()

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -1067,6 +1067,46 @@ def test_ssh_provision_server_success():
         mock_client.close.assert_called_once()
 
 
+def test_ssh_provision_server_root_skips_sudo():
+    """A root SSH user runs the script directly — minimal images ship no sudo."""
+    from unittest.mock import MagicMock, patch, mock_open
+
+    def mock_open_side_effect(filename, *args, **kwargs):
+        if filename == "/app/provision-host.sh":
+            return mock_open(read_data=b"#!/bin/sh\necho provisioned")()
+        return mock_open(read_data="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5...")()
+
+    with patch("ssh._fetch_host_key"), \
+         patch("builtins.open", side_effect=mock_open_side_effect), \
+         patch("ssh.paramiko.SSHClient") as mock_cls, \
+         patch("ssh.paramiko.RejectPolicy"):
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+
+        id_stdout = MagicMock()
+        id_stdout.read.return_value = b"0\n"
+
+        run_stdin, run_stdout, run_stderr = MagicMock(), MagicMock(), MagicMock()
+        run_stdout.channel.recv_exit_status.return_value = 0
+        run_stderr.read.return_value = b""
+
+        def exec_command(cmd, **kwargs):
+            if cmd == "id -u":
+                return (MagicMock(), id_stdout, MagicMock())
+            return (run_stdin, run_stdout, run_stderr)
+
+        mock_client.exec_command.side_effect = exec_command
+        mock_client.open_sftp.return_value = MagicMock()
+
+        ssh.provision_server("192.168.1.10", "root", "password123", 22, pubkey="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting")
+
+        run_cmds = [c.args[0] for c in mock_client.exec_command.call_args_list if c.args[0] != "id -u"]
+        assert any(c.startswith("bash /tmp/sam-provision.sh") for c in run_cmds)
+        assert not any("sudo" in c for c in run_cmds)
+        # No password written to stdin: there is nothing to escalate to.
+        assert not run_stdin.write.called
+
+
 def test_ssh_provision_server_uses_paramiko_for_host_key():
     """provision_server calls _fetch_host_key instead of subprocess ssh-keyscan."""
     from unittest.mock import MagicMock, patch, mock_open

--- a/provision-host.sh
+++ b/provision-host.sh
@@ -12,6 +12,20 @@ if [ -z "${COLLECTOR_PUBKEY}" ]; then
     exit 1
 fi
 
+# 0. sudo is a hard requirement: every collector operation (sam-collect,
+# sam-revoke, sam-add, …) runs through `sudo` from the unprivileged
+# COLLECTOR_USER account. Without it the host can be provisioned but never
+# scanned, so refuse now with an actionable message instead of failing later.
+if ! command -v sudo >/dev/null 2>&1; then
+    printf "ERROR: 'sudo' is not installed on this host.\n" >&2
+    printf "%s needs sudo to run the sam-* helper scripts as root.\n" "${COLLECTOR_USER}" >&2
+    printf "Install it, then re-run SAM provisioning:\n" >&2
+    printf "    apt install sudo    # Debian/Ubuntu\n" >&2
+    printf "    dnf install sudo    # RHEL/Rocky/Fedora\n" >&2
+    printf "    apk add sudo        # Alpine\n" >&2
+    exit 1
+fi
+
 # 1. Create system user (without interactive shell)
 if ! id "${COLLECTOR_USER}" >/dev/null 2>&1; then
     useradd -r -m -s /bin/bash "${COLLECTOR_USER}"


### PR DESCRIPTION
Provisioning a Debian 13 minimal host as `root` fails:

```
Provisioning script failed (exit 127): bash: line 1: sudo: command not found
```

Two independent problems, one commit each.

**1. sudo used even when the SSH user is root.** `provision_server` always wrapped the script in `sudo -S`. On a root login there is nothing to escalate to, and minimal images often ship no sudo at all. Now it probes `id -u` and runs `bash /tmp/sam-provision.sh` directly when the user is already root — no password written to stdin either.

**2. Missing sudo was detected too late.** `sam-collect`, `sam-revoke`, `sam-add` and the rest all run through sudo from the unprivileged collector account. Without sudo the host provisions cleanly and then fails on every scan. `provision-host.sh` now refuses up front with the install command for Debian, RHEL and Alpine.

Covered by `test_ssh_provision_server_root_skips_sudo`. Found while running 1.0.0 on an NS8 node against a Debian 13 target.