### PR TITLE
fix(expire): never expire the collector key

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -682,6 +682,11 @@ def set_key_expiry(
     """
     if unix_user == "root":
         raise UserError("Cannot set an expiry on root's SSH key — this would revoke root access automatically")
+    if unix_user == ssh.SSH_USER:
+        raise UserError(
+            f"Cannot set an expiry on the {ssh.SSH_USER} collector key — "
+            "expiring it would revoke SAM's own access to the server"
+        )
     _check_fingerprint(fingerprint)
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (fingerprint,))
     if not key:
@@ -699,8 +704,9 @@ def set_key_expiry(
     else:
         db.execute(
             "UPDATE key_authorizations SET expires_at = %s"
-            " WHERE key_id = %s AND status = 'ACTIVE' AND unix_user != 'root'",
-            (expires_at, key["id"]),
+            " WHERE key_id = %s AND status = 'ACTIVE'"
+            " AND unix_user != 'root' AND unix_user != %s",
+            (expires_at, key["id"], ssh.SSH_USER),
         )
 
 

--- a/app/expire.py
+++ b/app/expire.py
@@ -71,8 +71,9 @@ def expire_keys() -> int:
           AND ka.expires_at IS NOT NULL
           AND ka.expires_at <= now()
           AND ka.unix_user != 'root'
+          AND ka.unix_user != %s
         """,
-        (),
+        (ssh.SSH_USER,),
     )
     expired = 0
     for row in rows:

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -9,6 +9,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import actions
+import ssh
 from actions import UserError
 
 
@@ -387,6 +388,13 @@ def test_actions_assign_key_raises_if_key_not_found():
 def test_actions_set_key_expiry_root_raises():
     with pytest.raises(UserError, match="Cannot set an expiry on root"):
         actions.set_key_expiry("SHA256:abc", datetime.now(), unix_user="root", hostname="server")
+
+
+def test_actions_set_key_expiry_collector_raises():
+    with pytest.raises(UserError, match="collector key"):
+        actions.set_key_expiry(
+            "SHA256:abc", datetime.now(), unix_user=ssh.SSH_USER, hostname="server"
+        )
 
 
 def test_actions_set_key_expiry_updates_active_auths(sample_key):

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -195,6 +195,19 @@ def test_expire_expire_keys_excludes_root_unix_user():
         assert "unix_user != 'root'" in sql
 
 
+def test_expire_expire_keys_excludes_collector_unix_user():
+    """Expiring the collector key would revoke SAM's own access to the server."""
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_ssh.SSH_USER = "audit-collector"
+        mock_db.query.return_value = []
+        expire.expire_keys()
+        sql, params = mock_db.query.call_args[0]
+        assert "unix_user != %s" in sql
+        assert params == ("audit-collector",)
+
+
 def test_expire_expire_keys_returns_zero_when_no_expired_keys():
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \


### PR DESCRIPTION
`expire_keys()` excluded `root` but not `audit-collector`. Reproduced on a live install: as soon as a collector authorization carries an expiry, the cron job revokes SAM's own key from the target, and everything after that fails.

```
INFO Connected (version 2.0, client OpenSSH_10.0p2)
INFO Authentication (publickey) successful!          <- collector key revoked here
INFO Connected (version 2.0, client OpenSSH_10.0p2)
INFO Authentication (publickey) failed.              <- next key, locked out
INFO [CRITICAL] Expired key revocation failed on becane
expire.py: 0 warnings sent, 1 keys expired, 0 audit entries purged
```

The server is then unreachable for scan, revoke and deploy, with no recovery short of re-provisioning — and the user key that was supposed to expire stays active.

The collector account is already protected in `revoke_key`, `lock_user` and `unlock_user`. This extends the same rule to the expiry path: `set_key_expiry` refuses it up front (targeted and bulk), and `expire_keys` skips it as a last-resort guard for rows that already carry an expiry.

Covered by `test_expire_expire_keys_excludes_collector_unix_user` and `test_actions_set_key_expiry_collector_raises`.