### PR TITLE
fix(servers): purge keys left without authorization on delete

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -1417,6 +1417,20 @@ def delete_server(hostname: str, admin_id: str | None = None) -> None:
     db.execute("DELETE FROM key_authorizations WHERE server_id = %s", (sid,))
     db.execute("DELETE FROM servers WHERE id = %s", (sid,))
 
+    # Keys known only through this server (its collector key, and any key that
+    # was never seen anywhere else) keep no authorization once the rows above
+    # are gone. Left behind they surface as rows with a null server, user and
+    # status. Keys still authorized on another server are untouched.
+    db.execute(
+        """
+        DELETE FROM ssh_keys sk
+        WHERE NOT EXISTS (
+            SELECT 1 FROM key_authorizations ka WHERE ka.key_id = sk.id
+        )
+        """,
+        (),
+    )
+
     # Cleanup per-server keypair files
     for ext in (".key", ".key.pub"):
         try:

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -871,6 +871,17 @@ def test_actions_delete_server_removes_authorizations_and_requests():
         assert any("access_requests" in c for c in delete_calls)
 
 
+def test_actions_delete_server_purges_keys_left_without_authorization():
+    """Keys known only through the deleted server must not survive it."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.return_value = {"id": SERVER_ID}
+        actions.delete_server("server-test-01", ADMIN_ID)
+        delete_calls = [c[0][0] for c in mock_db.execute.call_args_list]
+        purge = [c for c in delete_calls if "DELETE FROM ssh_keys" in c]
+        assert purge, "orphan keys are never purged"
+        assert "NOT EXISTS" in purge[0]
+
+
 def test_actions_delete_server_raises_if_not_found():
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = None

--- a/app/web.py
+++ b/app/web.py
@@ -653,7 +653,7 @@ def list_keys():
                ka.revoked_automatically, ka.revoked_by, ka.revoked_at,
                ka.revocation_justification, s.hostname AS server_hostname
         FROM ssh_keys sk
-        LEFT JOIN key_authorizations ka ON ka.key_id = sk.id
+        JOIN key_authorizations ka ON ka.key_id = sk.id
         LEFT JOIN servers s ON s.id = ka.server_id
         WHERE 1=1
     """


### PR DESCRIPTION
Deleting a server drops its `key_authorizations` but leaves the `ssh_keys` rows behind — starting with the per-server collector key, which by definition is known through that server only.

`/api/keys` LEFT JOINs authorizations, so those keys come back fully null on the relationship columns and render as blank rows in the keys table:

```json
{"fingerprint":"SHA256:r7CP6f+MQgttqk…","server_hostname":null,"unix_user":null,"status":null}
```

Two of them accumulated on a live install after two delete/re-add cycles.

`delete_server` now purges keys that have no authorization left; a key still authorized on another server keeps its row. The listing inner joins as well, so orphans already sitting in existing databases stop showing up without needing a migration.

Covered by `test_actions_delete_server_purges_keys_left_without_authorization`.