### PR TITLE
fix(api): stop returning chained exception text in responses

### DIFF
--- a/app/collect.py
+++ b/app/collect.py
@@ -76,6 +76,17 @@ def _parse_key_line(line: str) -> dict | None:
     }
 
 
+def _client_error(exc: Exception) -> str:
+    """Message safe to hand back through the API.
+
+    Scan results are returned verbatim by /api/servers/<h>/scan, so they must
+    carry the exception's own message and not str(exc), which chains the
+    underlying cause and exposes internals. The audit log keeps the full text.
+    """
+    message = exc.args[0] if exc.args else getattr(exc, "error_code", "SCAN_FAILED")
+    return str(message)[:500]
+
+
 def scan_server(server: dict, admin_id: str | None = None) -> dict:
     """
     Scan one server: ensure scripts, collect keys, reconcile with DB.
@@ -93,7 +104,7 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
         key_path = ssh._resolve_key_path(server_id)
     except KeyError as exc:
         # No per-server key — admin must re-add this server
-        result["error"] = str(exc)
+        result["error"] = _client_error(exc)
         db.execute(
             """
             INSERT INTO audit_log (action, target_server, details)
@@ -158,7 +169,7 @@ def scan_server(server: dict, admin_id: str | None = None) -> dict:
 
         raw_lines = ssh.collect_keys(hostname, ip=ip, port=ssh_port, key_path=key_path)
     except Exception as exc:
-        result["error"] = str(exc)
+        result["error"] = _client_error(exc)
         db.execute(
             """
             INSERT INTO audit_log (action, target_server, details)

--- a/app/web.py
+++ b/app/web.py
@@ -385,7 +385,7 @@ def add_server():
         return jsonify({
             "error": "SSH operation failed",
             "error_code": e.error_code,
-            "details": str(e)[:500],
+            "details": (e.args[0] if e.args else e.error_code)[:500],
         }), 422
 
 
@@ -410,7 +410,7 @@ def provision_server_route(hostname):
         return jsonify({
             "error": "SSH operation failed",
             "error_code": exc.error_code,
-            "details": str(exc)[:500],
+            "details": (exc.args[0] if exc.args else exc.error_code)[:500],
         }), 422
 
 


### PR DESCRIPTION
Closes the four open CodeQL `py/stack-trace-exposure` alerts (67, 68, 71, 72).

`str(exc)` renders the whole exception chain, so an API response could carry the underlying cause. The exception's own message is what actually helps the operator — the remote stderr of a failed provisioning, for instance — and it is enough.

`update_provision` already handled this with `exc.args[0] if exc.args else exc.error_code`. This applies the same pattern to `add_server` (alert 67) and `provision` (alert 68), and adds a `_client_error` helper in `collect.py` for scan results, which `/api/servers/<hostname>/scan` (alert 71) and `/api/system/scan` (alert 72) return verbatim.

Audit log rows keep the full `str(exc)` — they stay server-side.

No behaviour change for the operator: the message shown in the UI is the same one the app authored, e.g. `Provisioning script failed (exit 1): ERROR: 'sudo' is not installed on this host.`

704 tests pass.