### PR TITLE
chore(ci): analyze main on push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,11 @@ name: CodeQL
 
 on:
   pull_request:
+  # Without this, alerts fixed by a merge stay open until the Monday scan:
+  # analysis is per-ref, and PR runs never update the main ref.
+  push:
+    branches:
+      - main
   schedule:
     - cron: '0 6 * * 1'
 


### PR DESCRIPTION
CodeQL stores results per ref. The workflow runs on `pull_request` and a Monday schedule, so nothing ever re-analyzes `main` right after a merge.

Consequence: #454 fixed alerts 67, 68, 71 and 72, they passed on the PR ref, and all four stayed open on `main` afterwards — they would have cleared on their own next Monday.

Adding `push: main` closes them at merge time and keeps the security tab honest from then on.