### PR TITLE
fix(access): grant and approve target the right Unix account

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -749,12 +749,41 @@ def remove_key_expiry(
 # Temporary access
 # ---------------------------------------------------------------------------
 
+def _resolve_authorization_user(
+    key_id: str, server_id: str, unix_user: str | None = None
+) -> str:
+    """Pick which authorization row a grant or an approval applies to.
+
+    key_authorizations is keyed by (key_id, server_id, unix_user): one key can
+    be authorized for several accounts on the same server. Neither the grant
+    payload nor access_requests carries the account, so it is resolved from the
+    authorizations already recorded for that key on that server.
+    """
+    if unix_user:
+        return unix_user
+    rows = db.query(
+        "SELECT unix_user FROM key_authorizations WHERE key_id = %s AND server_id = %s",
+        (key_id, server_id),
+    )
+    if len(rows) == 1:
+        return rows[0]["unix_user"]
+    if not rows:
+        raise UserError(
+            "unix_user is required: this key is not authorized on this server yet"
+        )
+    users = ", ".join(sorted(r["unix_user"] for r in rows))
+    raise UserError(
+        f"unix_user is required: this key is authorized for several accounts ({users})"
+    )
+
+
 def grant_access(
     key_fp: str,
     hostname: str,
     expires_at: datetime,
     justification: str,
     admin_id: str,
+    unix_user: str | None = None,
 ) -> dict:
     """Create or update a key_authorization as ACTIVE for a given server."""
     key = db.query_one("SELECT id FROM ssh_keys WHERE fingerprint = %s", (key_fp,))
@@ -766,17 +795,19 @@ def grant_access(
     if not server:
         raise NotFoundError(f"Server not found: {hostname}")
 
+    unix_user = _resolve_authorization_user(key["id"], server["id"], unix_user)
+
     db.execute(
         """
-        INSERT INTO key_authorizations (key_id, server_id, authorized_by, status, expires_at)
-        VALUES (%s, %s, %s, 'ACTIVE', %s)
-        ON CONFLICT (key_id, server_id) DO UPDATE SET
+        INSERT INTO key_authorizations (key_id, server_id, unix_user, authorized_by, status, expires_at)
+        VALUES (%s, %s, %s, %s, 'ACTIVE', %s)
+        ON CONFLICT (key_id, server_id, unix_user) DO UPDATE SET
             status = 'ACTIVE',
             authorized_by = EXCLUDED.authorized_by,
             authorized_at = now(),
             expires_at = EXCLUDED.expires_at
         """,
-        (key["id"], server["id"], admin_id, expires_at),
+        (key["id"], server["id"], unix_user, admin_id, expires_at),
     )
     db.execute(
         """
@@ -1058,17 +1089,19 @@ def approve_request(request_id: str, admin_id: str) -> None:
         """,
         (admin_id, expires_at, request_id),
     )
+    unix_user = _resolve_authorization_user(req["key_id"], req["server_id"])
+
     db.execute(
         """
-        INSERT INTO key_authorizations (key_id, server_id, authorized_by, status, expires_at)
-        VALUES (%s, %s, %s, 'ACTIVE', %s)
-        ON CONFLICT (key_id, server_id) DO UPDATE SET
+        INSERT INTO key_authorizations (key_id, server_id, unix_user, authorized_by, status, expires_at)
+        VALUES (%s, %s, %s, %s, 'ACTIVE', %s)
+        ON CONFLICT (key_id, server_id, unix_user) DO UPDATE SET
             status = 'ACTIVE',
             authorized_by = EXCLUDED.authorized_by,
             authorized_at = now(),
             expires_at = EXCLUDED.expires_at
         """,
-        (req["key_id"], req["server_id"], admin_id, expires_at),
+        (req["key_id"], req["server_id"], unix_user, admin_id, expires_at),
     )
     db.execute(
         """

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -531,12 +531,63 @@ def test_actions_grant_access_returns_ids(sample_key, sample_server):
             {"id": KEY_ID},
             {"id": SERVER_ID},
         ]
+        mock_db.query.return_value = [{"unix_user": "alice"}]
         result = actions.grant_access(
             sample_key["fingerprint"], sample_server["hostname"],
             expires_at, "maintenance", ADMIN_ID,
         )
         assert result["key_id"] == KEY_ID
         assert result["server_id"] == SERVER_ID
+
+
+def test_actions_grant_access_infers_the_only_authorized_account(sample_key, sample_server):
+    """key_authorizations is keyed by account, and the payload carries none."""
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, {"id": SERVER_ID}]
+        mock_db.query.return_value = [{"unix_user": "alice"}]
+        actions.grant_access(
+            sample_key["fingerprint"], sample_server["hostname"],
+            _future(), "maintenance", ADMIN_ID,
+        )
+        insert = [c for c in mock_db.execute.call_args_list
+                  if "INSERT INTO key_authorizations" in c[0][0]][0]
+        assert "ON CONFLICT (key_id, server_id, unix_user)" in insert[0][0]
+        assert "alice" in insert[0][1]
+
+
+def test_actions_grant_access_needs_an_account_when_ambiguous(sample_key, sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, {"id": SERVER_ID}]
+        mock_db.query.return_value = [{"unix_user": "alice"}, {"unix_user": "bob"}]
+        with pytest.raises(UserError, match="alice, bob"):
+            actions.grant_access(
+                sample_key["fingerprint"], sample_server["hostname"],
+                _future(), "maintenance", ADMIN_ID,
+            )
+
+
+def test_actions_grant_access_needs_an_account_when_key_unknown(sample_key, sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, {"id": SERVER_ID}]
+        mock_db.query.return_value = []
+        with pytest.raises(UserError, match="not authorized on this server"):
+            actions.grant_access(
+                sample_key["fingerprint"], sample_server["hostname"],
+                _future(), "maintenance", ADMIN_ID,
+            )
+
+
+def test_actions_grant_access_uses_the_explicit_account(sample_key, sample_server):
+    with patch("actions.db") as mock_db:
+        mock_db.query_one.side_effect = [{"id": KEY_ID}, {"id": SERVER_ID}]
+        mock_db.query.return_value = [{"unix_user": "alice"}, {"unix_user": "bob"}]
+        actions.grant_access(
+            sample_key["fingerprint"], sample_server["hostname"],
+            _future(), "maintenance", ADMIN_ID, unix_user="bob",
+        )
+        insert = [c for c in mock_db.execute.call_args_list
+                  if "INSERT INTO key_authorizations" in c[0][0]][0]
+        assert "bob" in insert[0][1]
 
 
 def test_actions_grant_access_raises_if_server_not_found(sample_key):
@@ -557,10 +608,16 @@ def test_actions_approve_request_sets_approved_and_creates_auth():
     }
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = req
+        mock_db.query.return_value = [{"unix_user": "alice"}]
         actions.approve_request(REQUEST_ID, ADMIN_ID)
         calls = [c[0][0] for c in mock_db.execute.call_args_list]
         assert any("APPROVED" in c for c in calls)
         assert any("REQUEST_APPROVED" in c for c in calls)
+        insert = [c for c in mock_db.execute.call_args_list
+                  if "INSERT INTO key_authorizations" in c[0][0]][0]
+        # access_requests carries no account, so it comes from the authorizations
+        assert "ON CONFLICT (key_id, server_id, unix_user)" in insert[0][0]
+        assert "alice" in insert[0][1]
 
 
 def test_actions_approve_request_raises_if_not_pending():
@@ -577,6 +634,7 @@ def test_actions_approve_request_computes_expires_at_from_duration():
     }
     with patch("actions.db") as mock_db:
         mock_db.query_one.return_value = req
+        mock_db.query.return_value = [{"unix_user": "alice"}]
         actions.approve_request(REQUEST_ID, ADMIN_ID)
         update_params = mock_db.execute.call_args_list[0][0][1]
         assert update_params[1] is not None  # expires_at computed

--- a/app/web.py
+++ b/app/web.py
@@ -829,6 +829,7 @@ def grant_access():
         result = actions.grant_access(
             data["key_fp"], data["hostname"], expires_at,
             data.get("justification", ""), g.admin_id,
+            unix_user=(data.get("unix_user") or "").strip() or None,
         )
         result["expires_at"] = result["expires_at"].isoformat()
         return jsonify(result), 201


### PR DESCRIPTION
`/api/access/grant` and `/api/access/<id>/approve` return 500 on every call:

```
psycopg2.errors.InvalidColumnReference: there is no unique or exclusion
constraint matching the ON CONFLICT specification
```

`key_authorizations` is keyed by `(key_id, server_id, unix_user)` — one key can be authorized for several accounts on the same server — but both `grant_access` and `approve_request` insert without the account and specify `ON CONFLICT (key_id, server_id)`. Postgres rejects the statement at planning time, so the temporary-grant path and the whole request/approval workflow are dead. Reproduced on a live install: the request is created, the approval 500s.

Neither the grant payload nor the `access_requests` table carries an account, so it is resolved from the authorizations already recorded for that key on that server — one match is used, none or several ask the caller for an explicit `unix_user`, which the grant endpoint now accepts.

`/api/access/deploy` was unaffected: it passes the account explicitly.

709 tests pass, five new ones cover inference, ambiguity, the unknown key and the explicit account.