### PR TITLE
fix(security): close four privilege escalation paths

### DIFF
--- a/app/actions.py
+++ b/app/actions.py
@@ -861,6 +861,10 @@ def deploy_key(
     """
     if unix_user == "root":
         raise UserError("Cannot deploy a key for the root account")
+    if unix_user == ssh.SSH_USER:
+        # The collector account carries NOPASSWD sudo on sam-add and the rest
+        # of the sam-* helpers: a key deployed there is root on that host.
+        raise UserError(f"Cannot deploy a key for the {ssh.SSH_USER} collector account")
     if not _UNIX_USER_RE.match(unix_user):
         raise UserError(
             f"Invalid Unix username: '{unix_user}' "
@@ -1146,20 +1150,37 @@ def revoke_request(request_id: str, admin_id: str) -> None:
     if not req:
         raise NotFoundError(f"Request not found or not APPROVED: {request_id}")
 
+    # Scoped to the account the request was approved for. A global revoke here
+    # would strip the key from every account on the host, root and the
+    # collector included — the same accounts revoke_key refuses to touch.
+    unix_user = _resolve_authorization_user(req["key_id"], req["server_id"])
+    if unix_user == "root":
+        raise UserError(
+            "Cannot revoke the root account's SSH key — this would cause permanent loss of server access"
+        )
+    if unix_user == ssh.SSH_USER:
+        raise UserError(
+            f"Cannot revoke the {ssh.SSH_USER} collector key directly — "
+            "use the Rotate Collector Key button on the server detail page"
+        )
+
     key = db.query_one("SELECT fingerprint FROM ssh_keys WHERE id = %s", (req["key_id"],))
     if key:
         server = db.query_one("SELECT id, hostname, ip_address, ssh_port FROM servers WHERE id = %s", (req["server_id"],))
         if server:
             key_path = _get_key_path(server["id"])
-            ssh.revoke_on_server(server["hostname"], key["fingerprint"], ip=server["ip_address"], port=server["ssh_port"], key_path=key_path)
+            ssh.revoke_on_server(
+                server["hostname"], key["fingerprint"], ip=server["ip_address"],
+                unix_user=unix_user, port=server["ssh_port"], key_path=key_path,
+            )
 
     db.execute(
         """
         UPDATE key_authorizations
         SET status = 'REVOKED', revoked_at = now(), revoked_by = %s, revoked_automatically = false
-        WHERE key_id = %s AND server_id = %s
+        WHERE key_id = %s AND server_id = %s AND unix_user = %s
         """,
-        (admin_id, req["key_id"], req["server_id"]),
+        (admin_id, req["key_id"], req["server_id"], unix_user),
     )
     db.execute(
         "UPDATE access_requests SET status = 'EXPIRED' WHERE id = %s",

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -178,6 +178,16 @@ if [ -z "$TARGET_USER" ] || [ -z "$PUBKEY" ]; then
     exit 1
 fi
 
+# Same allowlist as sam-grant-group. Without it, the collector account,
+# which holds NOPASSWD sudo on this script, could add any user to any group
+# on the host, wheel included, straight out of SAM's group model.
+if [ -n "$TARGET_GROUP" ]; then
+    case "$TARGET_GROUP" in
+        sam-operator|sam-pkg|sam-root) ;;
+        *) echo "Error: group must be sam-operator, sam-pkg or sam-root" >&2; exit 1 ;;
+    esac
+fi
+
 TMPPASS=""
 if ! id "$TARGET_USER" >/dev/null 2>&1; then
     useradd -m -s /bin/bash "$TARGET_USER"

--- a/app/tests/test_actions.py
+++ b/app/tests/test_actions.py
@@ -659,6 +659,8 @@ def test_actions_reject_request_raises_if_not_pending():
 def test_actions_revoke_request_calls_sam_revoke():
     req = {"key_id": KEY_ID, "server_id": SERVER_ID}
     with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.SSH_USER = "audit-collector"
+        mock_db.query.return_value = [{"unix_user": "alice"}]
         mock_db.query_one.side_effect = [
             req,
             {"fingerprint": "SHA256:abc"},
@@ -666,8 +668,39 @@ def test_actions_revoke_request_calls_sam_revoke():
         ]
         actions.revoke_request(REQUEST_ID, ADMIN_ID)
         mock_ssh.revoke_on_server.assert_called_once_with(
-            "server-test-01", "SHA256:abc", ip="192.168.1.10", port=22
-        , key_path=ANY)
+            "server-test-01", "SHA256:abc", ip="192.168.1.10",
+            unix_user="alice", port=22, key_path=ANY,
+        )
+
+
+def test_actions_revoke_request_scopes_the_update_to_the_account():
+    """A global revoke would strip the key from root and the collector too."""
+    req = {"key_id": KEY_ID, "server_id": SERVER_ID}
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.SSH_USER = "audit-collector"
+        mock_db.query.return_value = [{"unix_user": "alice"}]
+        mock_db.query_one.side_effect = [
+            req,
+            {"fingerprint": "SHA256:abc"},
+            {"id": SERVER_ID, "hostname": "server-test-01", "ip_address": "192.168.1.10", "ssh_port": 22},
+        ]
+        actions.revoke_request(REQUEST_ID, ADMIN_ID)
+        update = [c for c in mock_db.execute.call_args_list
+                  if "SET status = 'REVOKED'" in c[0][0]][0]
+        assert "unix_user = %s" in update[0][0]
+        assert "alice" in update[0][1]
+
+
+@pytest.mark.parametrize("account", ["root", "audit-collector"])
+def test_actions_revoke_request_refuses_protected_accounts(account):
+    req = {"key_id": KEY_ID, "server_id": SERVER_ID}
+    with patch("actions.db") as mock_db, patch("actions.ssh") as mock_ssh:
+        mock_ssh.SSH_USER = "audit-collector"
+        mock_db.query.return_value = [{"unix_user": account}]
+        mock_db.query_one.return_value = req
+        with pytest.raises(UserError):
+            actions.revoke_request(REQUEST_ID, ADMIN_ID)
+        mock_ssh.revoke_on_server.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1089,6 +1122,21 @@ def test_actions_deploy_key_success(sample_server, sample_key):
         assert result["hostname"] == sample_server["hostname"]
         assert result["expires_at"] is None
         mock_ssh.add_key_on_server.assert_called_once()
+
+
+def test_actions_deploy_key_refuses_the_collector_account(sample_server, sample_key):
+    """The collector holds NOPASSWD sudo on sam-add: a key there is root."""
+    with patch("actions.db"), patch("actions.ssh") as mock_ssh:
+        mock_ssh.SSH_USER = "audit-collector"
+        with pytest.raises(UserError, match="collector account"):
+            actions.deploy_key(
+                public_key=sample_key["public_key"],
+                unix_user="audit-collector",
+                hostname=sample_server["hostname"],
+                expires_at=None,
+                justification="escalation attempt",
+                admin_id=ADMIN_ID,
+            )
 
 
 def test_actions_deploy_key_invalid_key_type(sample_server):

--- a/app/tests/test_web.py
+++ b/app/tests/test_web.py
@@ -2492,6 +2492,39 @@ def test_web_grant_group_operator_cannot_assign_sam_root(client):
         assert resp.status_code == 403
 
 
+def test_web_deploy_operator_cannot_assign_sam_root(client):
+    """deploy took the same route to sam-root that grant-group already gated."""
+    operator_id = str(uuid.uuid4())
+    with client.session_transaction() as sess:
+        sess["admin_id"] = operator_id
+        sess["admin_username"] = "operator"
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = {"id": operator_id, "username": "operator", "role": "operator"}
+        resp = client.post("/api/access/deploy", json={
+            "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting",
+            "unix_user": "alice", "hostname": "server-01",
+            "justification": "escalation attempt", "sam_group": "sam-root",
+        })
+        assert resp.status_code == 403
+        mock_actions.deploy_key.assert_not_called()
+
+
+def test_web_deploy_sysadmin_may_assign_sam_root(client):
+    sysadmin_id = str(uuid.uuid4())
+    with client.session_transaction() as sess:
+        sess["admin_id"] = sysadmin_id
+        sess["admin_username"] = "admin"
+    with patch("web.db") as mock_db, patch("web.actions") as mock_actions:
+        mock_db.query_one.return_value = {"id": sysadmin_id, "username": "admin", "role": "sysadmin"}
+        mock_actions.deploy_key.return_value = {"fingerprint": "SHA256:abc"}
+        resp = client.post("/api/access/deploy", json={
+            "public_key": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForTesting",
+            "unix_user": "alice", "hostname": "server-01",
+            "justification": "maintenance", "sam_group": "sam-root",
+        })
+        assert resp.status_code == 201
+
+
 def test_web_grant_group_viewer_forbidden(client):
     viewer_id = str(uuid.uuid4())
     with client.session_transaction() as sess:

--- a/app/web.py
+++ b/app/web.py
@@ -852,6 +852,11 @@ def api_deploy_key():
 
     if not all([public_key, unix_user, hostname, justification]):
         return jsonify({"error": "public_key, unix_user, hostname, justification required"}), 400
+    # Same gate as grant-group and change-group: sam-root maps to
+    # "%sam-root ALL=(ALL) ALL" on the target, so deploying into it is a way
+    # for an operator to hand themselves full root on any managed host.
+    if sam_group == "sam-root" and g.admin_role != "sysadmin":
+        return jsonify({"error": "Only sysadmin can assign sam-root"}), 403
 
     hours = data.get("hours")
     date_str = data.get("expires_at")


### PR DESCRIPTION
Four paths let an `operator` reach root on any managed host, or let SAM cut its own access. All four are inconsistencies: the same guard exists elsewhere in the codebase and was missing here.

**`sam-root` ungated on deploy** (`web.py:851`). `grant-group` and `change-group` both refuse `sam-root` to non-sysadmins. `/api/access/deploy` accepted it, and `sam-root` maps to `%sam-root ALL=(ALL) ALL` in the sudoers file. An operator deployed a key for themselves with that group and became root on the target.

**The collector account was a valid deploy target** (`actions.py:862`). `deploy_key` refused `root` but not `audit-collector`, which holds NOPASSWD sudo on `sam-add`, `sam-revoke`, `sam-grant-group` and the rest. A key pushed there is root on that host.

**`sam-add` had no group allowlist** (`ssh.py:192`). `sam-grant-group` validates `sam-operator|sam-pkg|sam-root`; `sam-add` passed its third argument straight to `gpasswd -a`. From the collector account, `sudo sam-add user key wheel` left SAM's group model entirely.

**`revoke_request` revoked globally** (`actions.py:1154`). No `unix_user`, so `sam-revoke` stripped the key from every account on the host — root and the collector included, the two accounts `revoke_key` explicitly refuses to touch. It now resolves the account the request was approved for, refuses those two, and scopes both the remote revoke and the status update to it.

715 tests pass, seven new ones cover each path.