### PR TITLE
fix(ssh): three ways to lose access to a managed host

### DIFF
--- a/app/expire.py
+++ b/app/expire.py
@@ -63,7 +63,8 @@ def expire_keys() -> int:
     """
     rows = db.query(
         """
-        SELECT DISTINCT ka.key_id, ka.server_id, sk.fingerprint, s.id AS server_id, s.hostname, s.ip_address, s.ssh_port
+        SELECT DISTINCT ka.key_id, ka.server_id, ka.unix_user, sk.fingerprint,
+               s.hostname, s.ip_address, s.ssh_port
         FROM key_authorizations ka
         JOIN ssh_keys sk ON sk.id = ka.key_id
         JOIN servers s ON s.id = ka.server_id
@@ -79,7 +80,13 @@ def expire_keys() -> int:
     for row in rows:
         try:
             key_path = ssh._resolve_key_path(row["server_id"])
-            ssh.revoke_on_server(row["hostname"], row["fingerprint"], ip=row["ip_address"], port=row["ssh_port"], key_path=key_path)
+            # Scoped to the account whose authorization expired. A global
+            # revoke also strips the key from root and from the collector,
+            # the two accounts this query deliberately never selects.
+            ssh.revoke_on_server(
+                row["hostname"], row["fingerprint"], ip=row["ip_address"],
+                unix_user=row["unix_user"], port=row["ssh_port"], key_path=key_path,
+            )
         except Exception as exc:
             alerts.send_alert(
                 "CRITICAL",
@@ -96,9 +103,9 @@ def expire_keys() -> int:
                 revoked_by = NULL,
                 revoked_automatically = true,
                 revocation_justification = 'Scheduled expiration reached'
-            WHERE key_id = %s AND server_id = %s AND status = 'ACTIVE'
+            WHERE key_id = %s AND server_id = %s AND unix_user = %s AND status = 'ACTIVE'
             """,
-            (row["key_id"], row["server_id"]),
+            (row["key_id"], row["server_id"], row["unix_user"]),
         )
         db.execute(
             """

--- a/app/ssh.py
+++ b/app/ssh.py
@@ -935,6 +935,9 @@ def rotate_per_server_key(hostname: str, ip: str, port: int, server_id: str) -> 
     new_fingerprint = None
     client_old = None
     client_new = None
+    # True once authorized_keys holds the new key alone: past that point the
+    # old key is dead and the .new files are the only way back into the host.
+    remote_switched = False
 
     try:
         # Step 4: connect with current key
@@ -961,27 +964,34 @@ def rotate_per_server_key(hostname: str, ip: str, port: int, server_id: str) -> 
         # accumulated from previous (partial) rotations or from manual
         # operator additions would otherwise survive forever.
         _replace_authorized_keys_remote(client_new, new_pubkey)
+        remote_switched = True
         client_new.close()
         client_new = None
 
-        # Step 8: atomic file rotation
-        old_backup_path = current_key_path + ".old"
-        old_backup_pub_path = current_pubkey_path + ".old"
-
-        os.rename(current_key_path, old_backup_path)
-        os.rename(current_pubkey_path, old_backup_pub_path)
-        os.rename(new_key_path, current_key_path)
-        os.rename(new_pubkey_path, current_pubkey_path)
-
-        # Cleanup old backup
-        os.remove(old_backup_path)
-        os.remove(old_backup_pub_path)
+        # Step 8: move the new key onto the canonical path.
+        # os.replace overwrites atomically, so the canonical path is never
+        # missing and there is no backup left to clean up. The previous
+        # rename-to-.old dance had a window where a failure deleted the new
+        # private key while the old one was renamed away — with the host
+        # already accepting only the new key, that locked SAM out for good.
+        os.replace(new_key_path, current_key_path)
+        os.replace(new_pubkey_path, current_pubkey_path)
 
         # Step 9: compute and return new fingerprint
         new_fingerprint = _compute_pubkey_fingerprint(new_pubkey)
         return new_fingerprint
 
     except Exception as exc:
+        if remote_switched:
+            # authorized_keys already holds the new key alone. Removing it or
+            # deleting the .new files would leave no usable key at all, so
+            # everything stays where it is and the operator is told where.
+            raise SSHError(
+                f"Key rotation failed after {hostname} was switched to the new key: {exc}. "
+                f"The new key pair is kept at {new_key_path} and must not be deleted — "
+                f"move it to {current_key_path} to restore access."
+            )
+
         # Rollback: try to remove new pubkey from authorized_keys
         try:
             if client_new is None and os.path.isfile(current_key_path):
@@ -1429,8 +1439,24 @@ def _fetch_host_key(ip: str, port: int, known_hosts_path: str | None = None) -> 
             t.close()
     host = f"[{ip}]:{port}" if port != 22 else ip
     path = known_hosts_path if known_hosts_path is not None else KNOWN_HOSTS
-    with open(path, "a") as fh:
-        fh.write(f"{host} {key.get_name()} {key.get_base64()}\n")
+    entry = f"{host} {key.get_name()} {key.get_base64()}\n"
+
+    # Replace the entries for this host instead of appending. Appending left
+    # the previous key valid alongside the new one, so a host key that changed
+    # between two provisionings was silently accepted under either — which is
+    # exactly what the pinning is meant to catch.
+    prefix = f"{host} "
+    try:
+        with open(path, "r") as fh:
+            kept = [line for line in fh if not line.startswith(prefix)]
+    except FileNotFoundError:
+        kept = []
+
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w") as fh:
+        fh.writelines(kept)
+        fh.write(entry)
+    os.replace(tmp_path, path)
 
 
 def provision_server(ip: str, ssh_user: str, ssh_password: str, ssh_port: int = 22, pubkey: str = None) -> None:

--- a/app/tests/test_expire.py
+++ b/app/tests/test_expire.py
@@ -109,7 +109,7 @@ def test_expire_warn_expiring_keys_no_email_when_all_antispammed():
 
 def test_expire_expire_keys_scenario4_calls_sam_revoke():
     row = {
-        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice",
         "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
@@ -127,7 +127,7 @@ def test_expire_expire_keys_scenario4_calls_sam_revoke():
 
 def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():
     row = {
-        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice",
         "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
@@ -143,7 +143,7 @@ def test_expire_expire_keys_scenario4_sets_expired_revoked_automatically():
 
 def test_expire_expire_keys_scenario4_logs_key_expired():
     row = {
-        "key_id": KEY_ID, "server_id": SERVER_ID,
+        "key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice",
         "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
     }
     with patch("expire.db") as mock_db, \
@@ -155,10 +155,28 @@ def test_expire_expire_keys_scenario4_logs_key_expired():
         assert "KEY_EXPIRED" in audit_sql
 
 
+def test_expire_expire_keys_scopes_the_revoke_to_the_account():
+    """A global sam-revoke also strips the key from root's authorized_keys."""
+    row = {
+        "key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice",
+        "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22,
+    }
+    with patch("expire.db") as mock_db, \
+         patch("expire.ssh") as mock_ssh, \
+         patch("expire.alerts"):
+        mock_db.query.return_value = [row]
+        expire.expire_keys()
+        assert mock_ssh.revoke_on_server.call_args.kwargs["unix_user"] == "alice"
+        update = [c for c in mock_db.execute.call_args_list
+                  if "SET status = 'EXPIRED'" in c[0][0]][0]
+        assert "unix_user = %s" in update[0][0]
+        assert "alice" in update[0][1]
+
+
 def test_expire_expire_keys_scenario4_returns_count():
     rows = [
-        {"key_id": KEY_ID, "server_id": SERVER_ID, "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
-        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "fingerprint": "SHA256:other", "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
+        {"key_id": KEY_ID, "server_id": SERVER_ID, "unix_user": "alice", "fingerprint": FINGERPRINT, "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
+        {"key_id": str(uuid.uuid4()), "server_id": SERVER_ID, "unix_user": "bob", "fingerprint": "SHA256:other", "hostname": HOSTNAME, "ip_address": "192.168.1.10", "ssh_port": 22},
     ]
     with patch("expire.db") as mock_db, \
          patch("expire.ssh") as mock_ssh, \

--- a/app/tests/test_ssh.py
+++ b/app/tests/test_ssh.py
@@ -944,6 +944,35 @@ def test_ssh_fetch_host_key_single_connection():
         os.unlink(path)
 
 
+def test_ssh_fetch_host_key_replaces_a_changed_key():
+    """Appending left the old key valid, defeating the pinning it protects."""
+    import tempfile
+    from unittest.mock import MagicMock, patch
+
+    mock_key = MagicMock()
+    mock_key.get_name.return_value = "ssh-ed25519"
+    mock_key.get_base64.return_value = "NEWKEYBASE64"
+
+    mock_transport = MagicMock()
+    mock_transport.get_remote_server_key.return_value = mock_key
+
+    with tempfile.NamedTemporaryFile("w", suffix="known_hosts", delete=False) as f:
+        f.write("192.168.1.10 ssh-ed25519 OLDKEYBASE64\n")
+        f.write("192.168.1.99 ssh-ed25519 OTHERHOSTKEY\n")
+        path = f.name
+    try:
+        with patch("ssh.paramiko.Transport", return_value=mock_transport):
+            ssh._fetch_host_key("192.168.1.10", 22, known_hosts_path=path)
+        with open(path) as f:
+            content = f.read()
+        assert "OLDKEYBASE64" not in content
+        assert "NEWKEYBASE64" in content
+        # Other hosts keep their entry
+        assert "OTHERHOSTKEY" in content
+    finally:
+        os.unlink(path)
+
+
 def test_ssh_fetch_host_key_non_standard_port_brackets():
     """_fetch_host_key uses [ip]:port bracket format for non-22 ports."""
     import tempfile


### PR DESCRIPTION
Three independent paths where SAM loses its own access, or silently loses the guarantee it advertises.

**Rotation could delete the only usable key** (`ssh.py:971`). Step 7 replaces `authorized_keys` with the new key alone; step 8 then renames the current key to `.old`, moves `.new` into place and removes the backup. Any failure in that window lands in the `except` block, which deletes the `.new` files — while the old key has already been renamed away and the host no longer accepts it. Nothing can reach that server again.

The backup dance is gone: `os.replace` moves the new key onto the canonical path atomically, so the path is never missing and there is nothing to clean up. A failure after the remote switch now keeps the key pair and tells the operator where it is instead of deleting it.

**Expiry revoked globally** (`expire.py:82`). `sam-revoke` without `unix_user` strips the fingerprint from *every* account on the host, and the `UPDATE` had no `unix_user` predicate either. Expiring one user's key therefore also removed it from root's `authorized_keys` and flipped root's row to `EXPIRED` — the two accounts the selection deliberately excludes. Both are scoped to the row being expired. The duplicate `server_id` column in that `SELECT` goes away at the same time.

**Host key pinning accepted the old key forever** (`ssh.py:1432`). `_fetch_host_key` appended, so after a reprovisioning that changed the host key both entries were valid and `RejectPolicy` accepted either. Entries for that host are now replaced; other hosts are untouched.

711 tests pass, two new ones cover the scoped revoke and the host key replacement.