### PR TITLE
feat(cli): let access grant target a Unix account

### DIFF
--- a/app/manage.py
+++ b/app/manage.py
@@ -367,8 +367,11 @@ def access_show(request_id):
 @click.option("--server", "hostname", required=True, help="Target server")
 @click.option("--hours", default=None, type=int, help="Duration in hours")
 @click.option("--date", "date_str", default=None, help="Expiration date YYYY-MM-DD HH:MM")
+@click.option("--user", "unix_user", default=None,
+              help="Unix account to grant on. Inferred when the key is authorized "
+                   "for exactly one account on that server, required otherwise.")
 @click.option("--reason", required=True, help="Justification")
-def access_grant(key_fp, hostname, hours, date_str, reason):
+def access_grant(key_fp, hostname, hours, date_str, unix_user, reason):
     """Grant temporary access."""
     if hours and date_str:
         raise click.UsageError("Use --hours OR --date, not both.")
@@ -380,7 +383,8 @@ def access_grant(key_fp, hostname, hours, date_str, reason):
         raise click.UsageError("--hours or --date required.")
     admin_id = _require_admin()
     try:
-        actions.grant_access(key_fp, hostname, expires_at, reason, admin_id)
+        actions.grant_access(key_fp, hostname, expires_at, reason, admin_id,
+                             unix_user=unix_user)
         click.echo(f"Access granted until {expires_at.isoformat()}.")
     except (ValueError, UserError, NotFoundError) as e:
         raise click.ClickException(str(e))

--- a/app/tests/test_manage.py
+++ b/app/tests/test_manage.py
@@ -205,6 +205,24 @@ def test_manage_access_grant_hours(runner):
         ])
         assert result.exit_code == 0
         mock_actions.grant_access.assert_called_once()
+        assert mock_actions.grant_access.call_args.kwargs["unix_user"] is None
+
+
+def test_manage_access_grant_passes_the_explicit_account(runner):
+    """Without --user the CLI could not act on a key held by several accounts."""
+    with patch("manage.db") as mock_db, patch("manage.actions") as mock_actions:
+        mock_db.query_one.return_value = _admin()
+        mock_actions.grant_access.return_value = {
+            "key_id": KEY_ID, "server_id": SERVER_ID,
+            "expires_at": datetime.now(tz=timezone.utc),
+        }
+        result = runner.invoke(manage.cli, [
+            "access", "grant",
+            "--key", FINGERPRINT, "--server", HOSTNAME,
+            "--hours", "8", "--user", "bob", "--reason", "maintenance",
+        ])
+        assert result.exit_code == 0
+        assert mock_actions.grant_access.call_args.kwargs["unix_user"] == "bob"
 
 
 def test_manage_access_approve(runner):


### PR DESCRIPTION
Follow-up to #456. `grant_access` resolves the Unix account from the authorizations already recorded for that key on that server, and refuses when several match:

```
unix_user is required: this key is authorized for several accounts (alice, bob)
```

The API accepts `unix_user` in the payload to resolve that. `manage.py access grant` exposed `--key`, `--server`, `--hours`, `--date` and `--reason` but nothing for the account, so the CLI had no way out of the ambiguous case.

`--user` is optional: the single-account case keeps inferring, as before.

The web UI is unaffected — it never calls `/api/access/grant`; `grant`, `request` and `approve` are an API and CLI surface only.

710 tests pass, one new one; the existing grant test now also pins that the account stays `None` when the flag is omitted.