### PR TITLE
docs: link to the NS8 module and fix the workflow count

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -5,6 +5,8 @@ Outil d'audit et de gestion des accès SSH dans un container Alpine Linux unique
 **Stack** : Python 3.12 · Flask · PostgreSQL 18 · Nginx · Vue.js 3 · vue-i18n · Supervisord · Alpine 3.23.4
 
 > 🇬🇧 An English version of this document is available in [README.md](README.md).
+>
+> 📦 Sur NethServer 8, cette application est empaquetée par le module [ns8-ssh-access-manager](https://github.com/stephdl/ns8-ssh-access-manager) : installez-le avec `add-module` plutôt que de suivre les instructions container ci-dessous.
 
 ---
 
@@ -136,7 +138,7 @@ Les durées sont des constantes dans `web.py` — pas de redémarrage nécessair
 
 SAM génère **une paire de clés SSH ed25519 distincte par serveur** (stockée dans `/data/keys/per-server/<uuid>.key{,.pub}`, chmod 600, propriétaire `nobody`, fichier anonyme — pas de commentaire SSH). La compromission d'une clé n'expose qu'un seul hôte, jamais l'ensemble du parc. Le mapping serveur ↔ clé est implicite via le nom de fichier (UUID v4 random) — **pas de fingerprint stocké en base**, pour qu'un vol de la BDD seule ne révèle aucune information cryptographique exploitable.
 
-Cinq workflows d'ajout, du plus simple au plus scriptable :
+Six workflows d'ajout, du plus simple au plus scriptable :
 
 ### A. UI, un serveur, avec mot de passe (le plus simple)
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ SSH access auditing and management, in a single Alpine Linux container.
 **Stack**: Python 3.12 · Flask · PostgreSQL 18 · Nginx · Vue.js 3 · vue-i18n · Supervisord · Alpine 3.24.1
 
 > 🇫🇷 Une version française de ce document est disponible dans [README.fr.md](README.fr.md).
+>
+> 📦 On NethServer 8, this application is packaged as the [ns8-ssh-access-manager](https://github.com/stephdl/ns8-ssh-access-manager) module: install it with `add-module` rather than following the container instructions below.
 
 ---
 
@@ -136,7 +138,7 @@ The durations are constants in `web.py` — no restart is needed to change them 
 
 SAM generates **a distinct ed25519 SSH key pair per server** (stored in `/data/keys/per-server/<uuid>.key{,.pub}`, chmod 600, owned by `nobody`, with no SSH comment). A compromised key exposes one host, never the whole estate. The server ↔ key mapping is implicit in the file name (random UUID v4) — **no fingerprint is stored in the database**, so stealing the database alone reveals nothing cryptographically useful.
 
-Five ways to add a server, from the simplest to the most scriptable:
+Six ways to add a server, from the simplest to the most scriptable:
 
 ### A. UI, one server, with a password (simplest)
 


### PR DESCRIPTION
Carries the second commit of #462, which was squash-merged while only its first commit was on the branch — the translation landed, this did not.

**The relationship was documented in one direction only.** The module README links here twice (the repository and `DESIGN.md`); this repository never mentioned `ns8-ssh-access-manager`. The word "NS8" appears in the README solely to name the `runagent` and `api-cli` binaries in the sudo rules. A reader landing here had no way to learn the module exists, and would follow the container instructions when a single `add-module` is enough. A note in the header now points at it, in both languages.

**Miscount in the add-a-server section.** It announced five workflows for six lettered subsections, A to F. The error predates the translation — it was already in the French — and I carried it over faithfully before spotting it. Corrected in both files.